### PR TITLE
Gradle build cleanup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,19 +61,19 @@ android {
       dimension 'track'
       applicationIdSuffix ".qa"
       versionNameSuffix "-qa"
-      buildConfigField "String", "API_ENDPOINT", "\"" + System.getenv("QA_API_ENDPOINT") + "\""
+      buildConfigField "String", "API_ENDPOINT", "\"" + qaApiEndpoint + "\""
     }
 
     staging {
       dimension 'track'
       applicationIdSuffix ".staging"
       versionNameSuffix "-staging"
-      buildConfigField "String", "API_ENDPOINT", "\"" + System.getenv("STAGING_API_ENDPOINT") + "\""
+      buildConfigField "String", "API_ENDPOINT", "\"" + stagingApiEndpoint + "\""
     }
 
     production {
       dimension 'track'
-      buildConfigField "String", "API_ENDPOINT", "\"" + System.getenv("PRODUCTION_API_ENDPOINT") + "\""
+      buildConfigField "String", "API_ENDPOINT", "\"" + productionApiEndpoint + "\""
     }
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,11 @@ org.gradle.jvmargs=-Xmx1536m
 android.enableD8=true
 # We want the ability to turn off Proguard at will.
 runProguard=false
+
+# Add endpoints in gradle properties so that we can change at will
+# Used for local development
+qaApiEndpoint=https://api-qa.simple.org/api/
+
+# Change them on CI environments or local builds, do not check any actual staging or production endpoints in
+stagingApiEndpoint=do_not_change_here
+productionApiEndpoint=do_not_change_here


### PR DESCRIPTION
## Notes
- Read endpoints from `gradle.properties` instead of system environment variables
- QA endpoint is hardcoded so that local development is a lot faster
- Staging and Production endpoints have placeholder values, that are meant to be overriden on the build server