### PR TITLE
Disable capturing screenshots and screen recording

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,7 @@ android {
       minifyEnabled false
       useProguard false
       shrinkResources false
+      buildConfigField "boolean", "DISABLE_SCREENSHOT", "false"
     }
 
     release {
@@ -51,6 +52,7 @@ android {
         shrinkResources false
         useProguard false
       }
+      buildConfigField "boolean", "DISABLE_SCREENSHOT", "true"
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/activity/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/activity/TheActivity.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import android.view.WindowManager
 import io.reactivex.rxkotlin.ofType
+import org.simple.clinic.BuildConfig
 import org.simple.clinic.ClinicApp
 import org.simple.clinic.R
 import org.simple.clinic.home.HomeScreen
@@ -50,6 +52,10 @@ class TheActivity : AppCompatActivity() {
 
   override fun onPostCreate(savedInstanceState: Bundle?) {
     super.onPostCreate(savedInstanceState)
+    @Suppress("ConstantConditionIf")
+    if (BuildConfig.DISABLE_SCREENSHOT) {
+      window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
+    }
 
     // getIntent() returns null from attachBaseContext(), so Flow cannot
     // be initialized with the screen key requested by the caller.

--- a/app/src/main/java/org/simple/clinic/widgets/BottomSheetActivity.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/BottomSheetActivity.kt
@@ -6,7 +6,9 @@ import android.support.v7.app.AppCompatActivity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import kotterknife.bindView
+import org.simple.clinic.BuildConfig
 import org.simple.clinic.R
 
 /**
@@ -25,6 +27,10 @@ abstract class BottomSheetActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     overridePendingTransition(0, 0)
     super.onCreate(savedInstanceState)
+    @Suppress("ConstantConditionIf")
+    if (BuildConfig.DISABLE_SCREENSHOT) {
+      window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
+    }
     super.setContentView(R.layout.bottom_sheet)
 
     backgroundView.setOnClickListener {


### PR DESCRIPTION
### Notes
- It has been disabled only in the `release` build type
- Android doesn't let you set individual `View` instances as `SECURE`, (only exception is `SurfaceView`), so we have to set it for `TheActivity`, which disables screenshots for the entire production application