### PR TITLE
25 July 2018 - Fuzzy Lookup v1

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/bp/sync/BloodPressureSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/bp/sync/BloodPressureSyncAndroidTest.kt
@@ -103,6 +103,7 @@ class BloodPressureSyncAndroidTest {
             patientUuid,
             addressUuid,
             faker.name.name(),
+            faker.name.name(),
             Gender.FEMALE,
             LocalDate.parse("1947-08-15"),
             null,

--- a/app/src/androidTest/java/org/simple/clinic/drugs/PrescriptionRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/drugs/PrescriptionRepositoryAndroidTest.kt
@@ -86,6 +86,7 @@ class PrescriptionRepositoryAndroidTest {
             patientUuid,
             addressUuid,
             faker.name.name(),
+            faker.name.name(),
             Gender.FEMALE,
             LocalDate.parse("1947-08-15"),
             null,

--- a/app/src/androidTest/java/org/simple/clinic/drugs/sync/PrescriptionSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/drugs/sync/PrescriptionSyncAndroidTest.kt
@@ -103,6 +103,7 @@ class PrescriptionSyncAndroidTest {
             patientUuid,
             addressUuid,
             faker.name.name(),
+            faker.name.name(),
             Gender.FEMALE,
             LocalDate.parse("1947-08-15"),
             null,

--- a/app/src/main/java/org/simple/clinic/AppDatabase.kt
+++ b/app/src/main/java/org/simple/clinic/AppDatabase.kt
@@ -26,7 +26,7 @@ import org.simple.clinic.util.UuidRoomTypeConverter
       BloodPressureMeasurement::class,
       PrescribedDrug::class,
       Facility::class],
-    version = 2,
+    version = 3,
     exportSchema = false)
 @TypeConverters(
     Gender.RoomTypeConverter::class,

--- a/app/src/main/java/org/simple/clinic/patient/Patient.kt
+++ b/app/src/main/java/org/simple/clinic/patient/Patient.kt
@@ -34,6 +34,8 @@ data class Patient constructor(
 
     val fullName: String,
 
+    val searchableName: String,
+
     val gender: Gender,
 
     val dateOfBirth: LocalDate?,

--- a/app/src/main/java/org/simple/clinic/patient/Patient.kt
+++ b/app/src/main/java/org/simple/clinic/patient/Patient.kt
@@ -53,9 +53,6 @@ data class Patient constructor(
   @Dao
   interface RoomDao {
 
-    @Query("SELECT * FROM patient WHERE fullName LIKE '%' || :query || '%'")
-    fun search(query: String): Flowable<List<Patient>>
-
     @Query("SELECT * FROM patient")
     fun allPatients(): Flowable<List<Patient>>
 

--- a/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
@@ -65,11 +65,11 @@ data class PatientSearchResult(
     """
     }
 
-    @Query("$mainQuery WHERE P.fullname LIKE '%' || :query || '%' OR PP.number LIKE '%' || :query || '%'")
+    @Query("$mainQuery WHERE P.searchableName LIKE '%' || :query || '%' OR PP.number LIKE '%' || :query || '%'")
     fun search(query: String): Flowable<List<PatientSearchResult>>
 
     @Query("""$mainQuery
-      WHERE (P.fullname LIKE '%' || :query || '%' OR PP.number LIKE '%' || :query || '%')
+      WHERE (P.searchableName LIKE '%' || :query || '%' OR PP.number LIKE '%' || :query || '%')
       AND ((P.dateOfBirth BETWEEN :dobUpperBound AND :dobLowerBound) OR (P.age_computedDateOfBirth BETWEEN :dobUpperBound AND :dobLowerBound))
       """)
     fun search(query: String, dobUpperBound: String, dobLowerBound: String): Flowable<List<PatientSearchResult>>

--- a/app/src/main/java/org/simple/clinic/patient/sync/PatientPayload.kt
+++ b/app/src/main/java/org/simple/clinic/patient/sync/PatientPayload.kt
@@ -57,6 +57,7 @@ data class PatientPayload(
     return Patient(
         uuid = uuid,
         addressUuid = address.uuid,
+        searchableName = "",
         fullName = fullName,
         gender = gender,
         dateOfBirth = dateOfBirth,

--- a/app/src/main/java/org/simple/clinic/patient/sync/PatientPayload.kt
+++ b/app/src/main/java/org/simple/clinic/patient/sync/PatientPayload.kt
@@ -53,11 +53,11 @@ data class PatientPayload(
     val phoneNumbers: List<PatientPhoneNumberPayload>?
 ) {
 
-  fun toDatabaseModel(newStatus: SyncStatus): Patient {
+  fun toDatabaseModel(newStatus: SyncStatus, convertToSearchable: (String) -> String): Patient {
     return Patient(
         uuid = uuid,
         addressUuid = address.uuid,
-        searchableName = "",
+        searchableName = convertToSearchable(fullName),
         fullName = fullName,
         gender = gender,
         dateOfBirth = dateOfBirth,

--- a/app/src/test/java/org/simple/clinic/patient/PatientMocker.kt
+++ b/app/src/test/java/org/simple/clinic/patient/PatientMocker.kt
@@ -23,6 +23,7 @@ object PatientMocker {
         uuid = uuid,
         addressUuid = addressUuid,
         fullName = fullName,
+        searchableName = fullName,
         gender = mock(),
         dateOfBirth = mock(),
         age = mock(),


### PR DESCRIPTION
### Changes

- Adds a new field `searchableName` to the `Patient` table that saves a stripped down version of the Patient name without whitespaces and punctuation
- Changed `PatientRepository` to strip search queries of white spaces and punctuation when searching for names
- Changed `PatientRepository` to updated the `searchableName` when merging remote patient records as well as adding new patients
- Changed `PatientSearchResult.RoomDao` to use the `searchableName` instead of the `fullName` when doing search queries