### PR TITLE
Fix a crash when completing registration after selecting facilities 

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/user/UserSessionAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/user/UserSessionAndroidTest.kt
@@ -100,8 +100,8 @@ class UserSessionAndroidTest {
         .blockingFirst()
     assertThat(currentFacility.uuid).isEqualTo(selectedFacilities.first().uuid)
 
-    val postLoginRegistrationEntry = userSession.ongoingRegistrationEntry().blockingGet()
-    assertThat(postLoginRegistrationEntry).isEqualTo(OngoingRegistrationEntry())
+    val isRegistrationEntryPresent = userSession.isOngoingRegistrationEntryPresent().blockingGet()
+    assertThat(isRegistrationEntryPresent).isFalse()
   }
 
   @Test

--- a/app/src/main/java/org/simple/clinic/user/UserSession.kt
+++ b/app/src/main/java/org/simple/clinic/user/UserSession.kt
@@ -238,12 +238,14 @@ class UserSession @Inject constructor(
     }
   }
 
-  fun clearOngoingRegistrationEntry(): Completable {
-    return saveOngoingRegistrationEntry(OngoingRegistrationEntry())
-  }
-
   fun ongoingRegistrationEntry(): Single<OngoingRegistrationEntry> {
     return Single.fromCallable { ongoingRegistrationEntry }
+  }
+
+  fun clearOngoingRegistrationEntry(): Completable {
+    return Completable.fromAction {
+      ongoingRegistrationEntry = null
+    }
   }
 
   fun isOngoingRegistrationEntryPresent(): Single<Boolean> =

--- a/app/src/test/java/org/simple/clinic/user/UserSessionTest.kt
+++ b/app/src/test/java/org/simple/clinic/user/UserSessionTest.kt
@@ -167,6 +167,16 @@ class UserSessionTest {
   }
 
   @Test
+  fun `when ongoing registration entry is cleared then isOngoingRegistrationEntryPresent() should emit false`() {
+    userSession.saveOngoingRegistrationEntry(OngoingRegistrationEntry())
+        .andThen(userSession.clearOngoingRegistrationEntry())
+        .andThen(userSession.isOngoingRegistrationEntryPresent())
+        .test()
+        .await()
+        .assertValue(false)
+  }
+
+  @Test
   fun `when saving the user locally and the facility sync fails, the network error should correctly map results`() {
     whenever(facilitySync.pullWithResult())
         .thenReturn(


### PR DESCRIPTION
RegistrationPhoneScreen wasn't recreating the ongoing registration entry once it was cleared. This was happening because UserSession#clearOngoingRegistrationEntry() and isOngoingRegistrationEntryPresent() were not in sync. 

Steps for reproducing the crash:

1. Open registration screen and enter the phone number of an existing user
2. The login-pin screen should open. Go back to the registration-phone screen
3. Proceed to facility selection and press done to complete registration