### PR TITLE
Add 'mg' to dosage field only when it's focused for the first time

### DIFF
--- a/app/src/main/java/org/simple/clinic/drugs/selection/entry/CustomPrescriptionEntryController.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/entry/CustomPrescriptionEntryController.kt
@@ -13,6 +13,7 @@ import javax.inject.Inject
 
 private typealias Ui = CustomPrescriptionEntrySheet
 private typealias UiChange = (Ui) -> Unit
+const val DOSAGE_PLACEHOLDER = "mg"
 
 class CustomPrescriptionEntryController @Inject constructor(
     private val prescriptionRepository: PrescriptionRepository
@@ -78,6 +79,7 @@ class CustomPrescriptionEntryController @Inject constructor(
 
     val setPlaceholder = Observables.combineLatest(dosageFocusChanges, dosageTextChanges)
         .filter { (hasFocus, text) -> hasFocus && text.isBlank() }
+        .take(1)
         .map { { ui: Ui -> ui.setDrugDosageText(DOSAGE_PLACEHOLDER) } }
 
     val resetPlaceholder = Observables.combineLatest(dosageFocusChanges, dosageTextChanges)
@@ -89,9 +91,5 @@ class CustomPrescriptionEntryController @Inject constructor(
         .map { { ui: Ui -> ui.moveDrugDosageCursorToBeginning() } }
 
     return Observable.merge(setPlaceholder, resetPlaceholder, moveCursorToStart)
-  }
-
-  companion object {
-    const val DOSAGE_PLACEHOLDER = "mg"
   }
 }

--- a/app/src/test/java/org/simple/clinic/drugs/selection/entry/CustomPrescriptionEntryControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/entry/CustomPrescriptionEntryControllerTest.kt
@@ -14,7 +14,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.drugs.PrescriptionRepository
-import org.simple.clinic.drugs.selection.entry.CustomPrescriptionEntryController.Companion.DOSAGE_PLACEHOLDER
 import org.simple.clinic.util.nullIfBlank
 import org.simple.clinic.widgets.UiEvent
 import java.util.UUID
@@ -79,7 +78,7 @@ class CustomPrescriptionEntryControllerTest {
     uiEvents.onNext(CustomPrescriptionDrugDosageFocusChanged(false))
 
     verify(sheet, times(1)).setDrugDosageText(eq(""))
-    verify(sheet, times(2)).setDrugDosageText(eq(DOSAGE_PLACEHOLDER))
+    verify(sheet, times(1)).setDrugDosageText(eq(DOSAGE_PLACEHOLDER))
   }
 
   @Test


### PR DESCRIPTION
Bug fix for https://www.pivotaltracker.com/story/show/160350133

The placeholder was previously shown everytime the dosage field is empty, making it impossible to clear the field.