### PR TITLE
Open create new PIN screen if user has not completed raising a PIN request

### DIFF
--- a/app/src/main/java/org/simple/clinic/activity/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/activity/TheActivity.kt
@@ -25,10 +25,9 @@ import org.simple.clinic.router.screen.FullScreenKey
 import org.simple.clinic.router.screen.FullScreenKeyChanger
 import org.simple.clinic.router.screen.NestedKeyChanger
 import org.simple.clinic.router.screen.ScreenRouter
-import org.simple.clinic.user.User.LoggedInStatus.LOGGED_IN
-import org.simple.clinic.user.User.LoggedInStatus.NOT_LOGGED_IN
-import org.simple.clinic.user.User.LoggedInStatus.OTP_REQUESTED
-import org.simple.clinic.user.User.LoggedInStatus.VERIFYING_OTP
+import org.simple.clinic.user.User
+import org.simple.clinic.user.User.*
+import org.simple.clinic.user.User.LoggedInStatus.*
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.widgets.TheActivityLifecycle
 import javax.inject.Inject
@@ -98,9 +97,10 @@ class TheActivity : AppCompatActivity() {
   private fun initialScreenKey(): FullScreenKey {
     val localUser = userSession.loggedInUser().blockingFirst().toNullable()
 
+    // TODO: Figure out how to handle the new PIN reset status
     val canMoveToHomeScreen = when (localUser?.loggedInStatus) {
-      NOT_LOGGED_IN -> false
-      LOGGED_IN, OTP_REQUESTED, VERIFYING_OTP -> true
+      NOT_LOGGED_IN, RESETTING_PIN -> false
+      LOGGED_IN, OTP_REQUESTED, RESET_PIN_REQUESTED  -> true
       null -> false
     }
 

--- a/app/src/main/java/org/simple/clinic/analytics/UpdateAnalyticsUserId.kt
+++ b/app/src/main/java/org/simple/clinic/analytics/UpdateAnalyticsUserId.kt
@@ -2,6 +2,9 @@ package org.simple.clinic.analytics
 
 import io.reactivex.Scheduler
 import org.simple.clinic.user.User
+import org.simple.clinic.user.User.LoggedInStatus.LOGGED_IN
+import org.simple.clinic.user.User.LoggedInStatus.RESETTING_PIN
+import org.simple.clinic.user.User.LoggedInStatus.RESET_PIN_REQUESTED
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.Just
 import timber.log.Timber
@@ -9,12 +12,16 @@ import javax.inject.Inject
 
 class UpdateAnalyticsUserId @Inject constructor(private val userSession: UserSession) {
 
+  private val statesToSetUserIdFor = setOf(
+      LOGGED_IN, RESETTING_PIN, RESET_PIN_REQUESTED
+  )
+
   fun listen(scheduler: Scheduler) {
     userSession.loggedInUser()
         .subscribeOn(scheduler)
         .filter { it is Just<User> }
         .map { (user) -> user!! }
-        .filter { it.loggedInStatus == User.LoggedInStatus.LOGGED_IN }
+        .filter { it.loggedInStatus in statesToSetUserIdFor }
         .subscribe({
           Analytics.setUserId(it.uuid)
         }, {

--- a/app/src/main/java/org/simple/clinic/forgotpin/createnewpin/ForgotPinCreateNewPinScreen.kt
+++ b/app/src/main/java/org/simple/clinic/forgotpin/createnewpin/ForgotPinCreateNewPinScreen.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import android.view.inputmethod.EditorInfo
-import android.widget.EditText
 import android.widget.RelativeLayout
 import android.widget.TextView
 import android.widget.Toast
@@ -21,7 +20,6 @@ import org.simple.clinic.widgets.StaggeredEditText
 import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.hideKeyboard
 import org.simple.clinic.widgets.showKeyboard
-import timber.log.Timber
 import javax.inject.Inject
 
 class ForgotPinCreateNewPinScreen(context: Context, attributeSet: AttributeSet?) : RelativeLayout(context, attributeSet) {
@@ -60,9 +58,9 @@ class ForgotPinCreateNewPinScreen(context: Context, attributeSet: AttributeSet?)
   }
 
   private fun pinSubmitClicked(): Observable<UiEvent> {
-   return RxTextView.editorActions(pinEntryEditText)
-       .filter { it == EditorInfo.IME_ACTION_DONE }
-       .map { ForgotPinCreateNewPinSubmitClicked }
+    return RxTextView.editorActions(pinEntryEditText)
+        .filter { it == EditorInfo.IME_ACTION_DONE }
+        .map { ForgotPinCreateNewPinSubmitClicked }
   }
 
   fun showUserName(name: String) {

--- a/app/src/main/java/org/simple/clinic/home/patients/PatientsScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/home/patients/PatientsScreenController.kt
@@ -16,7 +16,6 @@ import org.simple.clinic.user.User
 import org.simple.clinic.user.User.LoggedInStatus.LOGGED_IN
 import org.simple.clinic.user.User.LoggedInStatus.NOT_LOGGED_IN
 import org.simple.clinic.user.User.LoggedInStatus.OTP_REQUESTED
-import org.simple.clinic.user.User.LoggedInStatus.VERIFYING_OTP
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.user.UserStatus.APPROVED_FOR_SYNCING
 import org.simple.clinic.user.UserStatus.DISAPPROVED_FOR_SYNCING
@@ -109,7 +108,7 @@ class PatientsScreenController @Inject constructor(
 
           val setVerificationStatusMessageVisible = { loggedInStatus: User.LoggedInStatus, ui: Ui ->
             when (loggedInStatus) {
-              NOT_LOGGED_IN, OTP_REQUESTED, VERIFYING_OTP -> ui.showUserStatusAsPendingVerification()
+              NOT_LOGGED_IN, OTP_REQUESTED -> ui.showUserStatusAsPendingVerification()
               LOGGED_IN -> ui.hideUserAccountStatus()
             }
           }

--- a/app/src/main/java/org/simple/clinic/login/applock/ConfirmResetPinDialog.kt
+++ b/app/src/main/java/org/simple/clinic/login/applock/ConfirmResetPinDialog.kt
@@ -45,7 +45,6 @@ class ConfirmResetPinDialog : AppCompatDialogFragment() {
     TheActivity.component.inject(this)
   }
 
-
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
     return AlertDialog.Builder(context!!)
         .setTitle(R.string.applock_reset_pin_alert_title)

--- a/app/src/main/java/org/simple/clinic/user/User.kt
+++ b/app/src/main/java/org/simple/clinic/user/User.kt
@@ -52,16 +52,22 @@ data class User(
     OTP_REQUESTED,
 
     /**
-     * Login OTP was received, and a call to validate
-     * the OTP with the server has been scheduled.
-     */
-    VERIFYING_OTP,
-
-    /**
      * Login OTP has been validated with the server
      * and the user is verified.
      */
-    LOGGED_IN;
+    LOGGED_IN,
+
+    /**
+     * User has begun the reset PIN flow, but hasn't yet
+     * submitted the PIN reset request to the server
+     **/
+    RESETTING_PIN,
+
+    /**
+     * User has raised a PIN reset request with the
+     * server, but it has not yet been approved
+     **/
+    RESET_PIN_REQUESTED;
 
     class RoomTypeConverter : RoomEnumTypeConverter<LoggedInStatus>(LoggedInStatus::class.java)
   }

--- a/app/src/main/java/org/simple/clinic/user/UserSession.kt
+++ b/app/src/main/java/org/simple/clinic/user/UserSession.kt
@@ -359,5 +359,10 @@ class UserSession @Inject constructor(
         .retry(syncRetryCount.toLong())
         .onErrorComplete()
         .andThen(patientRepository.clearPatientData())
+        .andThen(requireLoggedInUser().firstOrError().flatMapCompletable { user ->
+          Completable.fromAction {
+            appDatabase.userDao().updateLoggedInStatusForUser(user.uuid, User.LoggedInStatus.RESETTING_PIN)
+          }
+        })
   }
 }

--- a/app/src/main/res/layout/screen_app_lock.xml
+++ b/app/src/main/res/layout/screen_app_lock.xml
@@ -117,6 +117,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/applock_forgotpin" />
+
     </LinearLayout>
   </android.support.v7.widget.CardView>
 </org.simple.clinic.login.applock.AppLockScreen>

--- a/app/src/main/res/layout/screen_forgotpin_createpin.xml
+++ b/app/src/main/res/layout/screen_forgotpin_createpin.xml
@@ -74,9 +74,8 @@
       <org.simple.clinic.widgets.StaggeredEditText
         android:id="@+id/forgotpin_pin"
         style="@style/Clinic.StaggeredEditText.Pin"
-        android:maxLength="4"
         android:imeOptions="actionDone"
-        />
+        android:maxLength="4" />
 
       <TextView
         android:id="@+id/forgotpin_error"

--- a/app/src/test/java/org/simple/clinic/analytics/UpdateAnalyticsUserIdTest.kt
+++ b/app/src/test/java/org/simple/clinic/analytics/UpdateAnalyticsUserIdTest.kt
@@ -44,10 +44,11 @@ class UpdateAnalyticsUserIdTest {
   @Parameters(value = [
     "NOT_LOGGED_IN|false",
     "OTP_REQUESTED|false",
-    "VERIFYING_OTP|false",
+    "RESETTING_PIN|true",
+    "RESET_PIN_REQUESTED|true",
     "LOGGED_IN|true"
   ])
-  fun `the user id must be set only if the local logged in status is LOGGED_IN`(
+  fun `the user id must be set only if the local logged in status is LOGGED_IN, RESETTING_PIN or RESET_PIN_REQUESTED`(
       loggedInStatus: User.LoggedInStatus,
       shouldSetUserId: Boolean
   ) {

--- a/app/src/test/java/org/simple/clinic/forgotpin/createnewpin/ForgotPinCreateNewPinScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/forgotpin/createnewpin/ForgotPinCreateNewPinScreenControllerTest.kt
@@ -79,8 +79,8 @@ class ForgotPinCreateNewPinScreenControllerTest {
 
   @Test
   fun `when the PIN text changes, any error must be hidden`() {
-   uiEvents.onNext(ForgotPinCreateNewPinTextChanged("1"))
-   uiEvents.onNext(ForgotPinCreateNewPinTextChanged("11"))
+    uiEvents.onNext(ForgotPinCreateNewPinTextChanged("1"))
+    uiEvents.onNext(ForgotPinCreateNewPinTextChanged("11"))
 
     verify(screen, times(2)).hideInvalidPinError()
   }


### PR DESCRIPTION
### Changes
1. Removes the `VERIFYING_OTP` logged in status since it was not being used anywhere, and added two more, `RESETTING_PIN` and `RESET_PIN_REQUESTED`.
2. Updated initial screen key in `TheActivity` to load the Create PIN screen if the logged in status is `RESETTING_PIN`.
3. Change the user logged in status to `RESETTING_PIN` once the patient data is cleared.