### PR TITLE
Fix colony not getting prefilled in PatientEntry.

### DIFF
--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreenController.kt
@@ -107,10 +107,11 @@ class PatientEntryScreenController @Inject constructor(
               facilityRepository.currentFacility(userSession).firstOrError())
         }
         .map { (entry, facility) ->
-          entry.copy(address = OngoingPatientEntry.Address(
-              colonyOrVillage = null,
-              district = facility.district,
-              state = facility.state))
+          entry.takeIf { it.address != null }
+              ?: entry.copy(address = OngoingPatientEntry.Address(
+                  colonyOrVillage = null,
+                  district = facility.district,
+                  state = facility.state))
         }
         .map { { ui: Ui -> ui.preFillFields(it) } }
   }

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
@@ -74,6 +74,20 @@ class PatientEntryScreenControllerTest {
   }
 
   @Test
+  fun `when screen is created with an already present address, the already present address must be used for prefilling`() {
+    val address = OngoingPatientEntry.Address(
+        colonyOrVillage = "colony 1",
+        district = "district 2",
+        state = "state 3"
+    )
+    whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingPatientEntry(address = address)))
+
+    uiEvents.onNext(ScreenCreated())
+
+    verify(screen).preFillFields(OngoingPatientEntry(address = address))
+  }
+
+  @Test
   fun `when save button is clicked then a patient record should be created from the form input`() {
     whenever(patientRepository.saveOngoingEntry(any())).thenReturn(Completable.complete())
     whenever(dobValidator.validate(any(), any())).thenReturn(Result.VALID)


### PR DESCRIPTION
On screen creates, a new address was always being created when pre-filling fields. This changes the method to create a new address only if the ongoing patient entry doesn't already have one.