### PR TITLE
Update Indian PhoneNumberObfuscator with new specs.

### DIFF
--- a/app/src/main/java/org/simple/clinic/search/results/PhoneNumberObfuscator.kt
+++ b/app/src/main/java/org/simple/clinic/search/results/PhoneNumberObfuscator.kt
@@ -1,5 +1,7 @@
 package org.simple.clinic.search.results
 
+import org.simple.clinic.util.Unicode.bullet
+import org.simple.clinic.util.Unicode.hairSpace
 import javax.inject.Inject
 
 interface PhoneNumberObfuscator {
@@ -7,14 +9,23 @@ interface PhoneNumberObfuscator {
 }
 
 class IndianPhoneNumberObfuscator @Inject constructor() : PhoneNumberObfuscator {
-  override fun obfuscate(number: String): String {
-    if (number.length < 10) {
-      return "• ".repeat(number.length)
-    }
 
-    val first2Digits = number.substring(0, 2)
-    val last3Digits = number.substring(number.length - 3, number.length)
-    val obfuscatedDigits = "• ".repeat(number.length - 5)
-    return "$first2Digits $obfuscatedDigits$last3Digits"
+  private val mask = "$bullet$hairSpace"
+
+  override fun obfuscate(number: String): String {
+    val lastThree = (number.lastIndex - 2)..number.lastIndex
+    val fiveBeforeLastThree = (lastThree.first - 5)..(lastThree.first - 1)
+    val beforeFirstMasked = fiveBeforeLastThree.start - 1
+
+    return number
+        .mapIndexed { index, char ->
+          when (index) {
+            in lastThree -> char.toString()
+            in fiveBeforeLastThree -> mask
+            beforeFirstMasked -> "$char$hairSpace"
+            else -> char.toString()
+          }
+        }
+        .joinToString(separator = "")
   }
 }

--- a/app/src/main/java/org/simple/clinic/util/Unicode.kt
+++ b/app/src/main/java/org/simple/clinic/util/Unicode.kt
@@ -1,0 +1,6 @@
+package org.simple.clinic.util
+
+object Unicode {
+  const val hairSpace = "\u200A"
+  const val bullet = "\u2022"
+}

--- a/app/src/test/java/org/simple/clinic/search/results/IndianPhoneNumberObfuscatorTest.kt
+++ b/app/src/test/java/org/simple/clinic/search/results/IndianPhoneNumberObfuscatorTest.kt
@@ -1,21 +1,38 @@
 package org.simple.clinic.search.results
 
 import com.google.common.truth.Truth.assertThat
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.simple.clinic.util.Unicode.hairSpace
+import org.simple.clinic.util.Unicode.bullet
 
+private const val mask = "$bullet$hairSpace"
+
+@RunWith(JUnitParamsRunner::class)
 class IndianPhoneNumberObfuscatorTest {
 
+  private val obfuscator = IndianPhoneNumberObfuscator()
+
   @Test
-  fun `should obfuscate correctly`() {
-    val obfuscator = IndianPhoneNumberObfuscator()
-
-    val validNumber = "9811111365"
-    assertThat(obfuscator.obfuscate(validNumber)).isEqualTo("98 • • • • • 365")
-
-    val incompleteNumber = validNumber.substring(1)
-    assertThat(obfuscator.obfuscate(incompleteNumber)).isEqualTo("• • • • • • • • • ")
-
-    val extraNumbers = validNumber.repeat(2)
-    assertThat(obfuscator.obfuscate(extraNumbers)).isEqualTo("98 • • • • • • • • • • • • • • • 365")
+  @Parameters(value = [
+    "|",
+    "4|4",
+    "45|45",
+    "365|365",
+    "12345|$mask${mask}345",
+    "112345|$mask$mask${mask}345",
+    "1112345|$mask$mask$mask${mask}345",
+    "11112345|$mask$mask$mask$mask${mask}345",
+    "811111365|8$hairSpace$mask$mask$mask$mask${mask}365",
+    "9811111365|98$hairSpace$mask$mask$mask$mask${mask}365",
+    "98111113659811111365|981111136598$hairSpace$mask$mask$mask$mask${mask}365"
+  ])
+  fun `should obfuscate correctly`(
+      inputNumber: String,
+      expected: String
+  ) {
+    assertThat(obfuscator.obfuscate(inputNumber)).isEqualTo(expected)
   }
 }


### PR DESCRIPTION
1. Last three digits are always visible.
2. Five digits before the last three are masked.
3. All preceding digits are also visible.