### PR TITLE
Fix: entering an empty systolic or diastolic value crashes BP entry

### DIFF
--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
@@ -136,4 +136,14 @@ class BloodPressureEntrySheet : BottomSheetActivity() {
     errorTextView.text = getString(R.string.bloodpressureentry_error_diastolic_180)
     errorTextView.visibility = View.VISIBLE
   }
+
+  fun showSystolicEmptyError() {
+    errorTextView.text = getString(R.string.bloodpressureentry_error_systolic_empty)
+    errorTextView.visibility = View.VISIBLE
+  }
+
+  fun showDiastolicEmptyError() {
+    errorTextView.text = getString(R.string.bloodpressureentry_error_diastolic_empty)
+    errorTextView.visibility = View.VISIBLE
+  }
 }

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
@@ -7,8 +7,10 @@ import io.reactivex.rxkotlin.ofType
 import io.reactivex.rxkotlin.withLatestFrom
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.bp.BloodPressureRepository
+import org.simple.clinic.bp.entry.BloodPressureEntrySheetController.Validation.ERROR_DIASTOLIC_EMPTY
 import org.simple.clinic.bp.entry.BloodPressureEntrySheetController.Validation.ERROR_DIASTOLIC_TOO_HIGH
 import org.simple.clinic.bp.entry.BloodPressureEntrySheetController.Validation.ERROR_DIASTOLIC_TOO_LOW
+import org.simple.clinic.bp.entry.BloodPressureEntrySheetController.Validation.ERROR_SYSTOLIC_EMPTY
 import org.simple.clinic.bp.entry.BloodPressureEntrySheetController.Validation.ERROR_SYSTOLIC_LESS_THAN_DIASTOLIC
 import org.simple.clinic.bp.entry.BloodPressureEntrySheetController.Validation.ERROR_SYSTOLIC_TOO_HIGH
 import org.simple.clinic.bp.entry.BloodPressureEntrySheetController.Validation.ERROR_SYSTOLIC_TOO_LOW
@@ -84,7 +86,10 @@ class BloodPressureEntrySheetController @Inject constructor(
               ERROR_SYSTOLIC_TOO_LOW -> ui.showSystolicLowError()
               ERROR_DIASTOLIC_TOO_HIGH -> ui.showDiastolicHighError()
               ERROR_DIASTOLIC_TOO_LOW -> ui.showDiastolicLowError()
-              SUCCESS -> { // Nothing to do here, SUCCESS handled below separately!
+              ERROR_SYSTOLIC_EMPTY -> ui.showSystolicEmptyError()
+              ERROR_DIASTOLIC_EMPTY -> ui.showDiastolicEmptyError()
+              SUCCESS -> {
+                // Nothing to do here, SUCCESS handled below separately!
               }
             }.exhaustive()
           }
@@ -104,8 +109,15 @@ class BloodPressureEntrySheetController @Inject constructor(
   }
 
   private fun validateInput(systolic: String, diastolic: String): Validation {
-    val systolicNumber = systolic.toInt()
-    val diastolicNumber = diastolic.toInt()
+    if (systolic.isBlank()) {
+      return ERROR_SYSTOLIC_EMPTY
+    }
+    if (diastolic.isBlank()) {
+      return ERROR_DIASTOLIC_EMPTY
+    }
+
+    val systolicNumber = systolic.trim().toInt()
+    val diastolicNumber = diastolic.trim().toInt()
 
     return when {
       systolicNumber < 70 -> ERROR_SYSTOLIC_TOO_LOW
@@ -119,6 +131,8 @@ class BloodPressureEntrySheetController @Inject constructor(
 
   enum class Validation {
     SUCCESS,
+    ERROR_SYSTOLIC_EMPTY,
+    ERROR_DIASTOLIC_EMPTY,
     ERROR_SYSTOLIC_TOO_HIGH,
     ERROR_SYSTOLIC_TOO_LOW,
     ERROR_DIASTOLIC_TOO_HIGH,

--- a/app/src/main/java/org/simple/clinic/medicalhistory/MedicalHistoryRepository.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/MedicalHistoryRepository.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.medicalhistory
 import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.Single
+import org.simple.clinic.BuildConfig
 import org.simple.clinic.medicalhistory.sync.MedicalHistoryPayload
 import org.simple.clinic.patient.PatientUuid
 import org.simple.clinic.patient.SyncStatus
@@ -36,7 +37,11 @@ class MedicalHistoryRepository @Inject constructor(
         .toObservable()
         .map { histories ->
           if (histories.size > 1) {
-            throw AssertionError("Multiple histories are present for $patientUuid: $histories")
+            if (BuildConfig.DEBUG) {
+              throw AssertionError("Multiple histories are present for $patientUuid: $histories")
+            } else {
+              throw AssertionError("Multiple histories are present")
+            }
           }
           if (histories.isEmpty()) {
             // This patient's MedicalHistory hasn't synced yet. We're okay with overriding

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,8 @@
   <string name="bloodpressureentry_error_systolic_300">Systolic cannot be more than 300</string>
   <string name="bloodpressureentry_error_diastolic_40">Diastolic cannot be less than 40</string>
   <string name="bloodpressureentry_error_diastolic_180">Diastolic cannot be more than 180</string>
+  <string name="bloodpressureentry_error_systolic_empty">Enter systolic and diastolic pressures</string>
+  <string name="bloodpressureentry_error_diastolic_empty">Enter systolic and diastolic pressures</string>
 
   <!-- Patient summary -->
   <string name="patientsummary_contentdescription_up_button">Go back</string> <!-- TODO: The UP button will probably behave differently for different entry points. Update this CD accordingly. -->

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -111,6 +111,28 @@ class BloodPressureEntrySheetControllerTest {
   }
 
   @Test
+  fun `when systolic is empty, show error`() {
+    uiEvents.onNext(BloodPressureEntrySheetCreated(patientUuid))
+    uiEvents.onNext(BloodPressureSystolicTextChanged(""))
+    uiEvents.onNext(BloodPressureDiastolicTextChanged("190"))
+    uiEvents.onNext(BloodPressureSaveClicked())
+
+    verify(bloodPressureRepository, never()).saveMeasurement(any(), any(), any())
+    verify(sheet).showSystolicEmptyError()
+  }
+
+  @Test
+  fun `when diastolic is empty, show error`() {
+    uiEvents.onNext(BloodPressureEntrySheetCreated(patientUuid))
+    uiEvents.onNext(BloodPressureSystolicTextChanged("120"))
+    uiEvents.onNext(BloodPressureDiastolicTextChanged(""))
+    uiEvents.onNext(BloodPressureSaveClicked())
+
+    verify(bloodPressureRepository, never()).saveMeasurement(any(), any(), any())
+    verify(sheet).showDiastolicEmptyError()
+  }
+
+  @Test
   fun `when systolic or diastolic values change, hide the error message`() {
     uiEvents.onNext(BloodPressureEntrySheetCreated(patientUuid))
     uiEvents.onNext(BloodPressureSystolicTextChanged("12"))
@@ -123,10 +145,17 @@ class BloodPressureEntrySheetControllerTest {
   }
 
   @Test
-  fun `when save is clicked but input is invalid then blood pressure measurement should not be saved`() {
+  @Parameters(value = [
+    ",",
+    "1,1"
+  ])
+  fun `when save is clicked but input is invalid then blood pressure measurement should not be saved`(
+      systolic: String,
+      diastolic: String
+  ) {
     uiEvents.onNext(BloodPressureEntrySheetCreated(patientUuid))
-    uiEvents.onNext(BloodPressureSystolicTextChanged("1"))
-    uiEvents.onNext(BloodPressureDiastolicTextChanged("1"))
+    uiEvents.onNext(BloodPressureSystolicTextChanged(systolic))
+    uiEvents.onNext(BloodPressureDiastolicTextChanged(diastolic))
     uiEvents.onNext(BloodPressureSaveClicked())
 
     verify(bloodPressureRepository, never()).saveMeasurement(any(), any(), any())


### PR DESCRIPTION
Steps to reproduce:
1. Open a patient's summary
2. Tap on 'New BP'
3. Enter empty value for systolic
4. Hit IME-done in keyboard

The same steps will also work for the diastolic field.