### PR TITLE
Fix: summary screen crashes if multiple histories are present for the patient

### DIFF
--- a/app/src/main/java/org/simple/clinic/medicalhistory/MedicalHistory.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/MedicalHistory.kt
@@ -55,7 +55,18 @@ data class MedicalHistory(
     @Query("DELETE FROM MedicalHistory")
     fun clear()
 
-    @Query("SELECT * FROM MedicalHistory WHERE patientUuid = :patientUuid")
+    /**
+     * The last updated medical history is returned because it's possible
+     * to have multiple medical histories present for the same patient.
+     * See [MedicalHistoryRepository.historyForPatientOrDefault] to
+     * understand when this will happen.
+     */
+    @Query("""
+      SELECT * FROM MedicalHistory
+      WHERE patientUuid = :patientUuid
+      ORDER BY updatedAt DESC
+      LIMIT 1
+    """)
     fun historyForPatient(patientUuid: PatientUuid): Flowable<List<MedicalHistory>>
   }
 }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreenController.kt
@@ -28,6 +28,7 @@ import org.simple.clinic.summary.PatientSummaryCaller.SEARCH
 import org.simple.clinic.util.Just
 import org.simple.clinic.util.exhaustive
 import org.simple.clinic.widgets.UiEvent
+import org.threeten.bp.Clock
 import javax.inject.Inject
 
 typealias Ui = PatientSummaryScreen
@@ -38,7 +39,8 @@ class PatientSummaryScreenController @Inject constructor(
     private val bpRepository: BloodPressureRepository,
     private val prescriptionRepository: PrescriptionRepository,
     private val medicalHistoryRepository: MedicalHistoryRepository,
-    private val timestampGenerator: RelativeTimestampGenerator
+    private val timestampGenerator: RelativeTimestampGenerator,
+    private val clock: Clock
 ) : ObservableTransformer<UiEvent, UiChange> {
 
   private lateinit var disposable: Disposable

--- a/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreenControllerTest.kt
@@ -43,7 +43,7 @@ class NewMedicalHistoryScreenControllerTest {
   fun setUp() {
     controller = NewMedicalHistoryScreenController(medicalHistoryRepository, patientRepository)
 
-    whenever(medicalHistoryRepository.save(any(), any())).thenReturn(Completable.complete())
+    whenever(medicalHistoryRepository.save(any<UUID>(), any())).thenReturn(Completable.complete())
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.never())
 
     uiEvents.compose(controller).subscribe { uiChange -> uiChange(screen) }


### PR DESCRIPTION
Steps to reproduce:
1. Send patients to the server without any medical history. This can be done by using an HTTP client or running Android tests for syncing patients.
2. Open the patient's summary screen on two phones
3. Answer different medical history questions
4. Exit summary screen
5. Trigger a sync on both phones
6. Open summary screen again for the same patient
7. The app will crash.