### PR TITLE
Convert Instant to LocalDateTime before formatting

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/di/TestAppComponent.kt
+++ b/app/src/androidTest/java/org/simple/clinic/di/TestAppComponent.kt
@@ -17,6 +17,7 @@ import org.simple.clinic.overdue.communication.CommunicationRepositoryAndroidTes
 import org.simple.clinic.overdue.communication.CommunicationSyncAndroidTest
 import org.simple.clinic.patient.PatientRepositoryAndroidTest
 import org.simple.clinic.patient.PatientSyncAndroidTest
+import org.simple.clinic.summary.RelativeTimestampGeneratorAndroidTest
 import org.simple.clinic.user.UserDaoAndroidTest
 import org.simple.clinic.user.UserSessionAndroidTest
 
@@ -41,4 +42,5 @@ interface TestAppComponent : AppComponent {
   fun inject(target: AuthenticationRule)
   fun inject(target: MedicalHistorySyncAndroidTest)
   fun inject(target: MedicalHistoryRepositoryAndroidTest)
+  fun inject(target: RelativeTimestampGeneratorAndroidTest)
 }

--- a/app/src/androidTest/java/org/simple/clinic/summary/RelativeTimestampGeneratorAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/summary/RelativeTimestampGeneratorAndroidTest.kt
@@ -1,0 +1,46 @@
+package org.simple.clinic.summary
+
+import android.app.Application
+import android.support.test.runner.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.simple.clinic.TestClinicApp
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.ZoneOffset
+import javax.inject.Inject
+
+@RunWith(AndroidJUnit4::class)
+class RelativeTimestampGeneratorAndroidTest {
+
+  @Inject
+  lateinit var context: Application
+
+  private val generator = RelativeTimestampGenerator()
+
+  @Before
+  fun setup() {
+    TestClinicApp.appComponent().inject(this)
+  }
+
+  @Test
+  fun it_should_generate_timestamp_strings() {
+    val todayDateTime = LocalDateTime.of(2018, 7, 29, 16, 58)
+
+    val todayTime = LocalDateTime.of(2018, 7, 29, 2, 0, 0).atOffset(ZoneOffset.UTC).toInstant()
+    assertThat(generator.generate(todayDateTime, todayTime).displayText(context)).isNotEmpty()
+
+    val yesterdayButWithin24Hours = LocalDateTime.of(2018, 7, 28, 23, 0, 0).atOffset(ZoneOffset.UTC).toInstant()
+    assertThat(generator.generate(todayDateTime, yesterdayButWithin24Hours).displayText(context)).isNotEmpty()
+
+    val yesterdayButOutside24Hours = LocalDateTime.of(2018, 7, 28, 3, 0, 0).atOffset(ZoneOffset.UTC).toInstant()
+    assertThat(generator.generate(todayDateTime, yesterdayButOutside24Hours).displayText(context)).isNotEmpty()
+
+    val withinSixMonths = LocalDateTime.of(2018, 3, 29, 4, 0, 0).atOffset(ZoneOffset.UTC).toInstant()
+    assertThat(generator.generate(todayDateTime, withinSixMonths).displayText(context)).isNotEmpty()
+
+    val olderThanSixMonths = LocalDateTime.of(2017, 1, 27, 3, 0, 0).atOffset(ZoneOffset.UTC).toInstant()
+    assertThat(generator.generate(todayDateTime, olderThanSixMonths).displayText(context)).isNotEmpty()
+  }
+}

--- a/app/src/main/java/org/simple/clinic/summary/RelativeTimestampGenerator.kt
+++ b/app/src/main/java/org/simple/clinic/summary/RelativeTimestampGenerator.kt
@@ -56,7 +56,7 @@ data class WithinSixMonths(private val daysBetween: Long) : RelativeTimestamp() 
 
 class OlderThanSixMonths(private val time: Instant) : RelativeTimestamp() {
   override fun displayText(context: Context): String {
-    return timestampFormatter.format(time)
+    return timestampFormatter.format(time.atZone(ZoneOffset.UTC).toLocalDateTime())
   }
 
   companion object {


### PR DESCRIPTION
Reason: DateTimeFormatter cannot format patterns with date strings from an Instant.