### PR TITLE
Report to Sentry if data syncing fails

### DIFF
--- a/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
+++ b/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
@@ -7,8 +7,6 @@ import dagger.Provides
 import io.github.inflationx.viewpump.ViewPump
 import io.reactivex.Single
 import org.simple.clinic.activity.TheActivity
-import org.simple.clinic.analytics.Analytics
-import org.simple.clinic.analytics.DebugAnalyticsReporter
 import org.simple.clinic.crash.CrashReporterModule
 import org.simple.clinic.crash.NoOpCrashReporter
 import org.simple.clinic.di.AppComponent
@@ -44,7 +42,6 @@ class DebugClinicApp : ClinicApp() {
   override fun onCreate() {
     super.onCreate()
     appComponent().inject(this)
-    Analytics.addReporter(DebugAnalyticsReporter())
     keepUserIdUpdatedInAnalytics()
 
     Timber.plant(Timber.DebugTree())

--- a/app/src/main/java/org/simple/clinic/crash/CrashReporter.kt
+++ b/app/src/main/java/org/simple/clinic/crash/CrashReporter.kt
@@ -7,9 +7,13 @@ interface CrashReporter {
   fun init(appContext: Application)
 
   fun dropBreadcrumb(breadcrumb: Breadcrumb)
+
+  fun report(e: Throwable)
 }
 
 class NoOpCrashReporter : CrashReporter {
+
+  override fun report(e: Throwable) {}
 
   override fun init(appContext: Application) {}
 

--- a/app/src/main/java/org/simple/clinic/crash/SentryCrashReporter.kt
+++ b/app/src/main/java/org/simple/clinic/crash/SentryCrashReporter.kt
@@ -38,4 +38,8 @@ class SentryCrashReporter : CrashReporter {
       ERROR, ASSERT -> SentryBreadcrumbLevel.ERROR
     }
   }
+
+  override fun report(e: Throwable) {
+    Sentry.capture(e)
+  }
 }


### PR DESCRIPTION
We swallow errors if data syncing fails, but it'll be nice to see them reported on Sentry along with breadcrumbs (if any).