### PR TITLE
Avoid ignoring months when calculating fuzzy age bounds

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/TestClinicApp.kt
+++ b/app/src/androidTest/java/org/simple/clinic/TestClinicApp.kt
@@ -15,6 +15,7 @@ import org.simple.clinic.di.TestAppComponent
 import org.simple.clinic.login.LoginModule
 import org.simple.clinic.login.LoginOtpSmsListener
 import org.simple.clinic.patient.fuzzy.AbsoluteFuzzer
+import org.simple.clinic.patient.fuzzy.AgeFuzzer
 import org.simple.clinic.patient.fuzzy.AgeFuzzerModule
 import org.simple.clinic.storage.StorageModule
 import org.simple.clinic.sync.SyncConfig
@@ -71,7 +72,10 @@ class TestClinicApp : ClinicApp() {
           }
         })
         .ageFuzzerModule(object : AgeFuzzerModule() {
-          override fun provideAgeFuzzer() = AbsoluteFuzzer(5)
+          override fun provideAgeFuzzer(clock: Clock): AgeFuzzer {
+            val numberOfYearsToFuzzBy = 5
+            return AbsoluteFuzzer(clock, numberOfYearsToFuzzBy)
+          }
         })
         .crashReporterModule(object : CrashReporterModule() {
           override fun crashReporter() = NoOpCrashReporter()

--- a/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
@@ -70,10 +70,9 @@ class PatientRepository @Inject constructor(
   }
 
   fun search(name: String, assumedAge: Int, includeFuzzyNameSearch: Boolean = true): Observable<List<PatientSearchResult>> {
-    val (ageLowerBound, ageUpperBound) = ageFuzzer.bounded(assumedAge)
-
-    val dateOfBirthUpperBound = LocalDate.now(clock).minusYears(ageUpperBound.toLong()).toString()
-    val dateOfBirthLowerBound = LocalDate.now(clock).minusYears(ageLowerBound.toLong()).toString()
+    val ageBounds = ageFuzzer.bounded(assumedAge)
+    val dateOfBirthLowerBound = ageBounds.upper.toString()
+    val dateOfBirthUpperBound = ageBounds.lower.toString()
 
     val searchableName = nameToSearchableForm(name)
 

--- a/app/src/main/java/org/simple/clinic/patient/fuzzy/AbsoluteFuzzer.kt
+++ b/app/src/main/java/org/simple/clinic/patient/fuzzy/AbsoluteFuzzer.kt
@@ -1,9 +1,12 @@
 package org.simple.clinic.patient.fuzzy
 
+import org.threeten.bp.Clock
+import org.threeten.bp.LocalDate
+
 /**
  * This fuzzes age by a fixed ± value from the passed in age.
  **/
-class AbsoluteFuzzer(private val fuzziness: Int) : AgeFuzzer {
+class AbsoluteFuzzer(private val clock: Clock, private val fuzziness: Int): AgeFuzzer {
 
   init {
     if (fuzziness < 0) {
@@ -15,6 +18,11 @@ class AbsoluteFuzzer(private val fuzziness: Int) : AgeFuzzer {
     if (age < 0) {
       throw AssertionError("Age cannot be negative")
     }
-    return BoundedAge((age - fuzziness).coerceAtLeast(0), age + fuzziness)
+    val today = LocalDate.now(clock)
+
+    val dateLowerBound = today.minusYears((age + fuzziness).toLong())
+    val dateUpperBound = today.minusYears((age - fuzziness).toLong())
+
+    return BoundedAge(lower = dateLowerBound, upper = dateUpperBound)
   }
 }

--- a/app/src/main/java/org/simple/clinic/patient/fuzzy/AgeFuzzer.kt
+++ b/app/src/main/java/org/simple/clinic/patient/fuzzy/AgeFuzzer.kt
@@ -1,8 +1,6 @@
 package org.simple.clinic.patient.fuzzy
 
-
 interface AgeFuzzer {
 
   fun bounded(age: Int): BoundedAge
 }
-

--- a/app/src/main/java/org/simple/clinic/patient/fuzzy/AgeFuzzerModule.kt
+++ b/app/src/main/java/org/simple/clinic/patient/fuzzy/AgeFuzzerModule.kt
@@ -2,10 +2,14 @@ package org.simple.clinic.patient.fuzzy
 
 import dagger.Module
 import dagger.Provides
+import org.threeten.bp.Clock
 
 @Module
 open class AgeFuzzerModule {
 
   @Provides
-  open fun provideAgeFuzzer(): AgeFuzzer = PercentageFuzzer(0.1F)
+  open fun provideAgeFuzzer(clock: Clock): AgeFuzzer {
+    val fuzzinessFactor = 0.1F
+    return PercentageFuzzer(clock, fuzzinessFactor)
+  }
 }

--- a/app/src/main/java/org/simple/clinic/patient/fuzzy/BoundedAge.kt
+++ b/app/src/main/java/org/simple/clinic/patient/fuzzy/BoundedAge.kt
@@ -1,6 +1,9 @@
 package org.simple.clinic.patient.fuzzy
 
-data class BoundedAge(val lower: Int, val upper: Int) {
+import org.threeten.bp.LocalDate
+
+data class BoundedAge(val lower: LocalDate, val upper: LocalDate) {
+
   init {
     if (upper < lower) {
       throw AssertionError("Upper bound [$upper] should be >= lower bound [$lower]")

--- a/app/src/main/java/org/simple/clinic/patient/fuzzy/PercentageFuzzer.kt
+++ b/app/src/main/java/org/simple/clinic/patient/fuzzy/PercentageFuzzer.kt
@@ -1,24 +1,38 @@
 package org.simple.clinic.patient.fuzzy
 
+import org.threeten.bp.Clock
+import org.threeten.bp.LocalDate
+import kotlin.math.floor
+
 /**
  * This fuzzes age by a percentage of the passed in age.
  **/
-class PercentageFuzzer(private val fuzziness: Float) : AgeFuzzer {
+class PercentageFuzzer(private val clock: Clock, private val fuzziness: Float) : AgeFuzzer {
 
   init {
-    if (fuzziness < 0) {
+    if (fuzziness < 0F) {
       throw AssertionError("Fuzziness cannot be negative!")
     }
-    if (fuzziness > 1.0F) {
+    if (fuzziness > 1F) {
       throw AssertionError("Fuzziness must be between 0.0 and 1.0")
     }
   }
 
+  private val oneYearAsDays = 365.25F
+
   override fun bounded(age: Int): BoundedAge {
-    if (age < 0) {
-      throw AssertionError("Age cannot be negative")
+    if (age <= 0) {
+      throw AssertionError("Age cannot be negative or zero")
     }
+    val dateToFuzz = LocalDate.now(clock).minusYears(age.toLong())
+
     val ageDelta = age * fuzziness
-    return BoundedAge((age - ageDelta).toInt(), (age + ageDelta).toInt())
+
+    val daysDelta = floor(ageDelta * oneYearAsDays).toLong()
+
+    val dateLowerBound = dateToFuzz.minusDays(daysDelta)
+    val dateUpperBound = dateToFuzz.plusDays(daysDelta)
+
+    return BoundedAge(dateLowerBound, dateUpperBound)
   }
 }

--- a/app/src/test/java/org/simple/clinic/patient/PatientRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/patient/PatientRepositoryTest.kt
@@ -25,6 +25,7 @@ import org.simple.clinic.patient.sync.PatientPhoneNumberPayload
 import org.simple.clinic.registration.phone.PhoneNumberValidator
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.TestClock
+import org.threeten.bp.LocalDate
 import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
@@ -48,7 +49,7 @@ class PatientRepositoryTest {
   @Before
   fun setUp() {
     ageFuzzer = mock()
-    whenever(ageFuzzer.bounded(any())).thenReturn(BoundedAge(0, 0))
+    whenever(ageFuzzer.bounded(any())).thenReturn(BoundedAge(LocalDate.now(clock), LocalDate.now(clock)))
     repository = PatientRepository(database, dobValidator, facilityRepository, userSession, numberValidator, clock, ageFuzzer)
 
     val user = PatientMocker.loggedInUser()

--- a/app/src/test/java/org/simple/clinic/patient/fuzzy/AbsoluteFuzzerTest.kt
+++ b/app/src/test/java/org/simple/clinic/patient/fuzzy/AbsoluteFuzzerTest.kt
@@ -3,49 +3,55 @@ package org.simple.clinic.patient.fuzzy
 import com.google.common.truth.Truth.assertThat
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.simple.clinic.util.TestClock
+import org.threeten.bp.LocalDate
+import java.lang.AssertionError
 
 @RunWith(JUnitParamsRunner::class)
 class AbsoluteFuzzerTest {
 
-  @Parameters(value = [
-    "0|3|0|3",
-    "1|3|0|4",
-    "3|3|0|6",
-    "4|3|1|7",
-    "0|5|0|5",
-    "1|5|0|6",
-    "12|5|7|17",
-    "15|0|15|15"
-  ])
-  @Test
-  fun `it should properly generate upper and lower age bounds`(
-      age: Int,
-      fuzziness: Int,
-      expectedLower: Int,
-      expectedUpper: Int
-  ) {
-    val fuzzer = AbsoluteFuzzer(fuzziness)
+  private val clock = TestClock()
 
-    val (lower, upper) = fuzzer.bounded(age)
-
-    assertThat(age).isIn(lower..upper)
-    assertThat(lower).isEqualTo(expectedLower)
-    assertThat(upper).isEqualTo(expectedUpper)
+  @Before
+  fun setUp() {
+    clock.setYear(2000)
   }
 
+  @Test
   @Parameters(value = [
-    "-1|3",
-    "1|-3",
-    "-1|-3"
+    "0|3|1997-01-01|2003-01-01",
+    "30|3|1967-01-01|1973-01-01",
+    "30|5|1965-01-01|1975-01-01"
   ])
+  fun `it should properly generate upper and lower date bounds`(
+      age: Int,
+      fuzziness: Int,
+      expectedLower: String,
+      expectedUpper: String
+  ) {
+    val (expectedLowerDate, expectedUpperDate) = BoundedAge(lower = LocalDate.parse(expectedLower), upper = LocalDate.parse(expectedUpper))
+
+    val fuzzer = AbsoluteFuzzer(clock, fuzziness)
+    val (lowerDate, upperDate) = fuzzer.bounded(age)
+
+    assertThat(lowerDate).isEqualTo(expectedLowerDate)
+    assertThat(upperDate).isEqualTo(expectedUpperDate)
+  }
+
   @Test(expected = AssertionError::class)
+  @Parameters(value = [
+  "-1|3",
+  "1|-3",
+  "-1|-3"
+  ])
   fun `it should fail on invalid input`(
       age: Int,
       fuzziness: Int
   ) {
-    val fuzzer = AbsoluteFuzzer(fuzziness)
+    val fuzzer = AbsoluteFuzzer(clock, fuzziness)
     fuzzer.bounded(age)
   }
 }

--- a/app/src/test/java/org/simple/clinic/patient/fuzzy/BoundedAgeTest.kt
+++ b/app/src/test/java/org/simple/clinic/patient/fuzzy/BoundedAgeTest.kt
@@ -1,0 +1,39 @@
+package org.simple.clinic.patient.fuzzy
+
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.threeten.bp.LocalDate
+import java.lang.AssertionError
+
+@RunWith(JUnitParamsRunner::class)
+class BoundedAgeTest {
+
+  @Test(expected = AssertionError::class)
+  @Parameters(value = [
+  "1991-01-30|1990-01-30",
+  "1991-02-28|1991-01-30",
+  "1991-01-30|1991-01-28"
+  ])
+  fun `it should fail if the upper bound is earlier than the lower bound`(
+      lower: String,
+      upper: String
+  ) {
+    BoundedAge(lower = LocalDate.parse(lower), upper = LocalDate.parse(upper))
+  }
+
+  @Test
+  @Parameters(value = [
+    "1990-01-30|1991-01-30",
+    "1991-01-30|1991-02-28",
+    "1991-01-28|1991-01-30",
+    "1991-01-28|1991-01-28"
+  ])
+  fun `it should not fail if the upper bound is after or the same as the lower bound`(
+      lower: String,
+      upper: String
+  ) {
+    BoundedAge(lower = LocalDate.parse(lower), upper = LocalDate.parse(upper))
+  }
+}

--- a/app/src/test/java/org/simple/clinic/patient/fuzzy/PercentageFuzzerTest.kt
+++ b/app/src/test/java/org/simple/clinic/patient/fuzzy/PercentageFuzzerTest.kt
@@ -3,44 +3,50 @@ package org.simple.clinic.patient.fuzzy
 import com.google.common.truth.Truth.assertThat
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.simple.clinic.util.TestClock
+import org.threeten.bp.LocalDate
 
 @RunWith(JUnitParamsRunner::class)
 class PercentageFuzzerTest {
 
-  @Parameters(value = [
-    "0|0.1|0|0",
-    "5|0.1|4|5",
-    "5|0.5|2|7",
-    "5|0.8|1|9",
-    "5|1.0|0|10",
-    "25|0.1|22|27",
-    "25|0.5|12|37",
-    "25|0.8|5|45",
-    "25|1.0|0|50",
-    "43|0.1|38|47",
-    "43|0.5|21|64",
-    "43|0.8|8|77",
-    "43|1.0|0|86"
-  ])
+  private val clock = TestClock()
+
+  @Before
+  fun setUp() {
+    clock.setYear(2000)
+  }
+
   @Test
-  fun `it should properly generate upper and lower bounds`(
+  @Parameters(
+      value = [
+        "30|0.1|1967-01-02|1972-12-31",
+        "30|0.3|1961-01-01|1979-01-01",
+        "30|0.7|1949-01-01|1991-01-01",
+        "43|0.1|1952-09-14|1961-04-20",
+        "43|0.3|1944-02-08|1969-11-25",
+        "43|0.7|1926-11-26|1987-02-07"
+      ]
+  )
+  fun `it should generate upper and lower date bounds`(
       age: Int,
       fuzziness: Float,
-      expectedLower: Int,
-      expectedUpper: Int
+      expectedLower: String,
+      expectedUpper: String
   ) {
-    val fuzzer = PercentageFuzzer(fuzziness)
+    val (expectedLowerDate, expectedUpperDate) = BoundedAge(lower = LocalDate.parse(expectedLower), upper = LocalDate.parse(expectedUpper))
 
-    val (lower, upper) = fuzzer.bounded(age)
+    val fuzzer = PercentageFuzzer(clock, fuzziness)
+    val (lowerDate, upperDate) = fuzzer.bounded(age)
 
-    assertThat(age).isIn(lower..upper)
-    assertThat(lower).isEqualTo(expectedLower)
-    assertThat(upper).isEqualTo(expectedUpper)
+    assertThat(lowerDate).isEqualTo(expectedLowerDate)
+    assertThat(upperDate).isEqualTo(expectedUpperDate)
   }
 
   @Parameters(value = [
+    "0|0.1",
     "-1|0.1",
     "1|-0.1",
     "-1|-0.1",
@@ -52,7 +58,7 @@ class PercentageFuzzerTest {
       age: Int,
       fuzziness: Float
   ) {
-    val fuzzer = PercentageFuzzer(fuzziness)
+    val fuzzer = PercentageFuzzer(clock, fuzziness)
 
     fuzzer.bounded(age)
   }


### PR DESCRIPTION
The percentage based fuzzer was ignoring the precision lost when rounding down the fuzziness factor. However, since this is multiplied by years instead of days, our fuzziness search could be inaccurate by months.

This commit fixes the problem by changing Age fuzziness to compute the dates internally, and to convert the fuzziness into a factor of days instead of years.

#### How to test this
This is a little tricky to test since the calculation is done taking the current date into account.

Create patients with the following DOBs:
1. 26/11/1998
2. 26/08/1994

On master, only the 26th november patient will be visible but on the current branch, both will be (as is expected.)