### PR TITLE
Fix: Crash on 1000+ results in patient search

### DIFF
--- a/app/src/main/java/org/simple/clinic/patient/PatientFuzzySearch.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientFuzzySearch.kt
@@ -45,7 +45,7 @@ class PatientFuzzySearch {
         val searchQuery = SimpleSQLiteQuery("""
           SELECT "Patient"."uuid", editdist3('$query', "Patient"."searchableName") "score"
           FROM "Patient" WHERE "score" < 750
-          ORDER BY "score"
+          ORDER BY "score" LIMIT 100
         """.trimIndent())
 
         sqLiteOpenHelper.readableDatabase.query(searchQuery)


### PR DESCRIPTION
SQLite has a hard limit of 999 for the number of parameters in a parameterized query. Since it is unlikely the nurse will scroll through 999 patients, this fixes the problem by limiting the number of results from fuzzy search to 100.