### PR TITLE
Upsert records when saving Patient and PatientAddress

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/di/TestAppComponent.kt
+++ b/app/src/androidTest/java/org/simple/clinic/di/TestAppComponent.kt
@@ -19,6 +19,7 @@ import org.simple.clinic.overdue.communication.CommunicationSyncAndroidTest
 import org.simple.clinic.patient.PatientRepositoryAndroidTest
 import org.simple.clinic.patient.PatientSyncAndroidTest
 import org.simple.clinic.security.pin.BruteForceProtectionAndroidTest
+import org.simple.clinic.storage.DaoWithUpsertAndroidTest
 import org.simple.clinic.summary.RelativeTimestampGeneratorAndroidTest
 import org.simple.clinic.user.OngoingLoginEntryRepositoryTest
 import org.simple.clinic.user.UserDaoAndroidTest
@@ -49,4 +50,5 @@ interface TestAppComponent : AppComponent {
   fun inject(target: BloodPressureRepositoryAndroidTest)
   fun inject(target: OngoingLoginEntryRepositoryTest)
   fun inject(target: BruteForceProtectionAndroidTest)
+  fun inject(target: DaoWithUpsertAndroidTest)
 }

--- a/app/src/androidTest/java/org/simple/clinic/drugs/PrescriptionRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/drugs/PrescriptionRepositoryAndroidTest.kt
@@ -117,7 +117,6 @@ class PrescriptionRepositoryAndroidTest {
 
   @Test
   fun soft_delete_prescription_should_update_timestamp_and_sync_status() {
-    val protocolUUID = UUID.randomUUID()
     val patientUUID = UUID.randomUUID()
 
     val drug = ProtocolDrug(name = "Amlodipine", rxNormCode = null, dosages = listOf("5mg", "10mg"))
@@ -136,5 +135,17 @@ class PrescriptionRepositoryAndroidTest {
     assertThat(softDeletedPrescription.updatedAt).isGreaterThan(prescription.updatedAt)
     assertThat(softDeletedPrescription.createdAt).isEqualTo(prescription.createdAt)
     assertThat(softDeletedPrescription.syncStatus).isEqualTo(SyncStatus.PENDING)
+  }
+
+  @Test
+  fun prescriptions_should_be_overridable() {
+    val prescription = testData.prescription(name = "Churro")
+    database.prescriptionDao().save(listOf(prescription))
+
+    val correctedPrescription = prescription.copy(name = "Amlodipine")
+    database.prescriptionDao().save(listOf(correctedPrescription))
+
+    val storedPrescription = database.prescriptionDao().getOne(correctedPrescription.uuid)!!
+    assertThat(storedPrescription.name).isEqualTo(correctedPrescription.name)
   }
 }

--- a/app/src/androidTest/java/org/simple/clinic/storage/DaoWithUpsertAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/storage/DaoWithUpsertAndroidTest.kt
@@ -1,0 +1,112 @@
+package org.simple.clinic.storage
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.simple.clinic.AppDatabase
+import org.simple.clinic.TestClinicApp
+import org.simple.clinic.TestData
+import org.simple.clinic.patient.Gender.FEMALE
+import org.simple.clinic.patient.Gender.MALE
+import org.simple.clinic.patient.Patient
+import org.simple.clinic.patient.PatientAddress
+import java.util.UUID
+import javax.inject.Inject
+
+class DaoWithUpsertAndroidTest {
+
+  @Inject
+  lateinit var database: AppDatabase
+
+  @Inject
+  lateinit var testData: TestData
+
+  @Before
+  fun setUp() {
+    TestClinicApp.appComponent().inject(this)
+  }
+
+  @Test
+  fun when_upserting_a_record_it_should_be_inserted_if_it_doesnt_exist_already() {
+    val patientUuid = UUID.randomUUID()
+    val address = testData.patientAddress(patientUuid)
+    val patient = testData.patient(uuid = patientUuid, addressUuid = address.uuid)
+
+    database.addressDao().save(address)
+    database.patientDao().save(patient)
+
+    val storedPatient = database.patientDao().patient(patientUuid).blockingFirst().first()
+    assertThat(storedPatient.uuid).isEqualTo(patientUuid)
+  }
+
+  @Test
+  fun when_upserting_a_record_it_should_be_updated_if_it_already_exists() {
+    val patientUuid = UUID.randomUUID()
+    val address = testData.patientAddress(patientUuid)
+    val patient = testData.patient(uuid = patientUuid, addressUuid = address.uuid, gender = MALE)
+    val patientNumber = testData.patientPhoneNumber(patientUuid = patientUuid, number = "123")
+
+    database.addressDao().save(address)
+    database.patientDao().save(patient)
+    database.phoneNumberDao().save(listOf(patientNumber))
+
+    val updatedPatient = patient.copy(gender = FEMALE)
+    database.patientDao().save(updatedPatient)
+
+    val storedPatient = database.patientDao().patient(patientUuid).blockingFirst().first()
+    assertThat(storedPatient.uuid).isEqualTo(patientUuid)
+    assertThat(storedPatient.gender).isEqualTo(FEMALE)
+
+    val storedNumbers = database.phoneNumberDao().count()
+    assertThat(storedNumbers).isEqualTo(1)
+  }
+
+  @Test
+  fun upserting_multiple_records_should_work_correctly() {
+    val addresses = mutableListOf<PatientAddress>()
+    val patients = mutableListOf<Patient>()
+
+    val generatePatientAndAddress = {
+      val patientUuid = UUID.randomUUID()
+      val address = testData.patientAddress(patientUuid)
+      val patient = testData.patient(uuid = patientUuid, addressUuid = address.uuid)
+      patient to address
+    }
+
+    (0 until 10).forEach {
+      val (patient, address) = generatePatientAndAddress()
+      addresses += address
+      patients += patient
+    }
+
+    database.addressDao().save(addresses)
+    database.patientDao().save(patients)
+
+    val newAndUpdatedAddresses = mutableListOf<PatientAddress>()
+    newAndUpdatedAddresses.addAll(addresses)
+
+    val newAndUpdatedPatients = mutableListOf<Patient>()
+    newAndUpdatedPatients.addAll(patients)
+
+    (0 until 10).forEach {
+      val (patient, address) = generatePatientAndAddress()
+      newAndUpdatedAddresses += address
+      newAndUpdatedPatients += patient
+    }
+
+    database.addressDao().save(newAndUpdatedAddresses)
+    database.patientDao().save(newAndUpdatedPatients)
+
+    val storedAddressesCount = database.addressDao().count()
+    assertThat(storedAddressesCount).isEqualTo(20)
+
+    val storedPatientsCount = database.patientDao().patientCount().blockingFirst()
+    assertThat(storedPatientsCount).isEqualTo(20)
+  }
+
+  @After
+  fun tearDown() {
+    database.clearAllTables()
+  }
+}

--- a/app/src/main/java/org/simple/clinic/drugs/PrescribedDrug.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/PrescribedDrug.kt
@@ -69,7 +69,7 @@ data class PrescribedDrug(
     @Query("UPDATE prescribeddrug SET syncStatus = :newStatus WHERE uuid IN (:uuids)")
     fun updateSyncStatus(uuids: List<UUID>, newStatus: SyncStatus)
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun save(newDrugs: List<PrescribedDrug>)
 
     /**

--- a/app/src/main/java/org/simple/clinic/facility/Facility.kt
+++ b/app/src/main/java/org/simple/clinic/facility/Facility.kt
@@ -52,7 +52,7 @@ data class Facility(
     @Query("UPDATE facility SET syncStatus = :newStatus WHERE uuid IN (:uuids)")
     fun updateSyncStatus(uuids: List<UUID>, newStatus: SyncStatus)
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun save(newFacilities: List<Facility>)
 
     @Query("SELECT * FROM facility WHERE uuid = :uuid LIMIT 1")

--- a/app/src/main/java/org/simple/clinic/patient/PatientAddress.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientAddress.kt
@@ -2,12 +2,11 @@ package org.simple.clinic.patient
 
 import android.arch.persistence.room.Dao
 import android.arch.persistence.room.Entity
-import android.arch.persistence.room.Insert
-import android.arch.persistence.room.OnConflictStrategy
 import android.arch.persistence.room.PrimaryKey
 import android.arch.persistence.room.Query
 import io.reactivex.Flowable
 import org.simple.clinic.patient.sync.PatientAddressPayload
+import org.simple.clinic.storage.DaoWithUpsert
 import org.threeten.bp.Instant
 import java.util.UUID
 
@@ -43,24 +42,26 @@ data class PatientAddress(
   }
 
   @Dao
-  interface RoomDao {
+  abstract class RoomDao : DaoWithUpsert<PatientAddress>() {
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
-    fun save(address: PatientAddress)
+    fun save(address: PatientAddress) {
+      save(listOf(address))
+    }
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
-    fun save(address: List<PatientAddress>)
+    fun save(addresses: List<PatientAddress>) {
+      upsert(addresses)
+    }
 
     @Query("SELECT * FROM patientaddress WHERE uuid = :uuid")
-    fun getOne(uuid: UUID): PatientAddress?
+    abstract fun getOne(uuid: UUID): PatientAddress?
 
     @Query("SELECT * FROM patientaddress WHERE uuid = :uuid")
-    fun address(uuid: UUID): Flowable<List<PatientAddress>>
+    abstract fun address(uuid: UUID): Flowable<List<PatientAddress>>
 
     @Query("DELETE FROM patientaddress")
-    fun clear()
+    abstract fun clear()
 
     @Query("SELECT COUNT(uuid) FROM PatientAddress")
-    fun count(): Int
+    abstract fun count(): Int
   }
 }

--- a/app/src/main/java/org/simple/clinic/patient/PatientPhoneNumber.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientPhoneNumber.kt
@@ -44,7 +44,7 @@ data class PatientPhoneNumber(
   @Dao
   interface RoomDao {
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun save(phoneNumbers: List<PatientPhoneNumber>)
 
     @Query("SELECT * FROM patientphonenumber WHERE patientUuid = :patientUuid")

--- a/app/src/main/java/org/simple/clinic/storage/DaoWithUpsert.kt
+++ b/app/src/main/java/org/simple/clinic/storage/DaoWithUpsert.kt
@@ -1,0 +1,30 @@
+package org.simple.clinic.storage
+
+import android.arch.persistence.room.Insert
+import android.arch.persistence.room.OnConflictStrategy
+import android.arch.persistence.room.Transaction
+import android.arch.persistence.room.Update
+
+/**
+ * Mimics sqlite's `upsert` conflict strategy because Room's grammar doesn't understand it.
+ */
+abstract class DaoWithUpsert<T> {
+
+  @Insert(onConflict = OnConflictStrategy.IGNORE)
+  abstract fun insert(record: List<T>): List<Long>
+
+  @Update(onConflict = OnConflictStrategy.FAIL)
+  protected abstract fun update(entities: List<T>)
+
+  @Transaction
+  protected open fun upsert(records: List<T>) {
+    val recordsToUpdate = insert(records)
+        .mapIndexed { index, insertedRowId -> index to insertedRowId }
+        .filter { (_, insertedRowId) -> insertedRowId == -1L }
+        .map { (indexToUpdate) -> records[indexToUpdate] }
+
+    if (recordsToUpdate.isNotEmpty()) {
+      update(recordsToUpdate)
+    }
+  }
+}


### PR DESCRIPTION
When records are inserted with `replace` as the conflict strategy, sqlite internally performs a delete+insert. Although they are performed inside the same transaction, sqlite seems to trigger onCascade behavior on foreign keys midway during the transaction. Sqlite recently added support for an `upsert` clause that instead performs insert/update, avoiding any deletion of records. Unfortunately it's only available on newer versions Android and so Room doesn't support it either.

This commit mimics upsert clause by attempting to always insert records and then updating them if insertions fail with conflicts.