### PR TITLE
Show transient snackbar in patient screen 

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentRepositoryAndroidTest.kt
@@ -495,16 +495,16 @@ class AppointmentRepositoryAndroidTest {
   @Test
   fun when_fetching_appointment_for_patient_it_should_return_scheduled_appointment_only() {
       val patientId = UUID.randomUUID()
-      val appointmentDate1 = LocalDate.now()
-      val appointmentDate2 = LocalDate.now().plusDays(1)
-      appointmentRepository.schedule(patientId, appointmentDate1).blockingAwait()
-      appointmentRepository.schedule(patientId, appointmentDate2).blockingAwait()
+      val appointmentDateNow = LocalDate.now()
+      val appointmentDateLater = LocalDate.now().plusDays(1)
+      appointmentRepository.schedule(patientId, appointmentDateNow).blockingAwait()
+      appointmentRepository.schedule(patientId, appointmentDateLater).blockingAwait()
 
       val appointment = appointmentRepository.scheduledAppointmentForPatient(patientId).blockingFirst()
       assertThat(appointment).isNotNull()
       assertThat(appointment.patientUuid).isEqualTo(patientId)
       assertThat(appointment.status).isEqualTo(SCHEDULED)
-      assertThat(appointment.scheduledDate).isEqualTo(appointmentDate2)
+      assertThat(appointment.scheduledDate).isEqualTo(appointmentDateLater)
     }
 
     @After

--- a/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentRepositoryAndroidTest.kt
@@ -92,7 +92,7 @@ class AppointmentRepositoryAndroidTest {
     savedAppointment.apply {
       assertThat(this.patientUuid).isEqualTo(patientId)
       assertThat(this.scheduledDate).isEqualTo(appointmentDate)
-      assertThat(this.status).isEqualTo(SCHEDULED)
+      assertThat(this.status).isEqualTo(Appointment.Status.SCHEDULED)
       assertThat(this.cancelReason).isEqualTo(null)
       assertThat(this.syncStatus).isEqualTo(SyncStatus.PENDING)
     }
@@ -114,7 +114,7 @@ class AppointmentRepositoryAndroidTest {
     savedAppointment[0].apply {
       assertThat(this.patientUuid).isEqualTo(patientId)
       assertThat(this.scheduledDate).isEqualTo(date1)
-      assertThat(this.status).isEqualTo(VISITED)
+      assertThat(this.status).isEqualTo(Appointment.Status.VISITED)
       assertThat(this.cancelReason).isEqualTo(null)
       assertThat(this.syncStatus).isEqualTo(SyncStatus.PENDING)
     }
@@ -494,24 +494,24 @@ class AppointmentRepositoryAndroidTest {
 
   @Test
   fun when_fetching_appointment_for_patient_it_should_return_scheduled_appointment_only() {
-    val patientId = UUID.randomUUID()
-    val appointmentDate1 = LocalDate.now()
-    val appointmentDate2 = LocalDate.now().plusDays(1)
-    appointmentRepository.schedule(patientId, appointmentDate1).blockingAwait()
-    appointmentRepository.schedule(patientId, appointmentDate2).blockingAwait()
+      val patientId = UUID.randomUUID()
+      val appointmentDate1 = LocalDate.now()
+      val appointmentDate2 = LocalDate.now().plusDays(1)
+      appointmentRepository.schedule(patientId, appointmentDate1).blockingAwait()
+      appointmentRepository.schedule(patientId, appointmentDate2).blockingAwait()
 
-    val appointment = appointmentRepository.scheduledAppointmentForPatient(patientId).blockingFirst()
-    assertThat(appointment).isNotNull()
-    assertThat(appointment.patientUuid).isEqualTo(patientId)
-    assertThat(appointment.status).isEqualTo(SCHEDULED)
-    assertThat(appointment.scheduledDate).isEqualTo(appointmentDate2)
+      val appointment = appointmentRepository.scheduledAppointmentForPatient(patientId).blockingFirst()
+      assertThat(appointment).isNotNull()
+      assertThat(appointment.patientUuid).isEqualTo(patientId)
+      assertThat(appointment.status).isEqualTo(SCHEDULED)
+      assertThat(appointment.scheduledDate).isEqualTo(appointmentDate2)
+    }
+
+    @After
+    fun tearDown() {
+      database.clearAllTables()
+      testClock.resetToEpoch()
+    }
+
+
   }
-
-  @After
-  fun tearDown() {
-    database.clearAllTables()
-    testClock.resetToEpoch()
-  }
-
-
-}

--- a/app/src/main/java/org/simple/clinic/di/NetworkModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/NetworkModule.kt
@@ -1,12 +1,14 @@
 package org.simple.clinic.di
 
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import dagger.Module
 import dagger.Provides
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.simple.clinic.BuildConfig
 import org.simple.clinic.analytics.NetworkAnalyticsInterceptor
+import org.simple.clinic.patient.PatientSummaryResult
 import org.simple.clinic.user.LoggedInUserHttpInterceptor
 import org.simple.clinic.util.InstantMoshiAdapter
 import org.simple.clinic.util.LocalDateMoshiAdapter
@@ -27,7 +29,14 @@ open class NetworkModule {
         .add(LocalDateMoshiAdapter())
         .add(UuidMoshiAdapter())
         .add(MoshiOptionalAdapterFactory())
+        .add(polymorphic())
         .build()
+  }
+
+  private fun polymorphic(): PolymorphicJsonAdapterFactory<PatientSummaryResult> {
+    return PolymorphicJsonAdapterFactory.of(PatientSummaryResult::class.java, "patient_summary_result")
+        .withSubtype(PatientSummaryResult.Scheduled::class.java, "result_scheduled")
+        .withSubtype(PatientSummaryResult.Saved::class.java, "result_saved")
   }
 
   @Provides

--- a/app/src/main/java/org/simple/clinic/di/NetworkModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/NetworkModule.kt
@@ -29,11 +29,11 @@ open class NetworkModule {
         .add(LocalDateMoshiAdapter())
         .add(UuidMoshiAdapter())
         .add(MoshiOptionalAdapterFactory())
-        .add(polymorphic())
+        .add(patientSummaryResultAdapterFactory())
         .build()
   }
 
-  private fun polymorphic(): PolymorphicJsonAdapterFactory<PatientSummaryResult> {
+  private fun patientSummaryResultAdapterFactory(): PolymorphicJsonAdapterFactory<PatientSummaryResult> {
     return PolymorphicJsonAdapterFactory.of(PatientSummaryResult::class.java, "patient_summary_result")
         .withSubtype(PatientSummaryResult.Scheduled::class.java, "result_scheduled")
         .withSubtype(PatientSummaryResult.Saved::class.java, "result_saved")

--- a/app/src/main/java/org/simple/clinic/home/patients/PatientsScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/patients/PatientsScreen.kt
@@ -54,7 +54,7 @@ open class PatientsScreen(context: Context, attrs: AttributeSet) : RelativeLayou
   private val dateInAppointmentSavedText by bindView<TextView>(R.id.patients_summary_appointment_saved_date)
 
   @IdRes
-  private var currentStatusView: Int = R.id.patients_user_status_hidden
+  private var currentStatusViewId: Int = R.id.patients_user_status_hidden
 
   override fun onFinishInflate() {
     super.onFinishInflate()
@@ -115,7 +115,7 @@ open class PatientsScreen(context: Context, attrs: AttributeSet) : RelativeLayou
 
   private fun showUserAccountStatus(@IdRes statusViewId: Int) {
     showStatus(statusViewId)
-    currentStatusView = approvalStatusViewFlipper.currentView.id
+    currentStatusViewId = approvalStatusViewFlipper.currentView.id
   }
 
   private var disposable = Disposables.empty()
@@ -129,7 +129,7 @@ open class PatientsScreen(context: Context, attrs: AttributeSet) : RelativeLayou
     showStatus(statusViewId)
     disposable = Observable.timer(2500L, TimeUnit.MILLISECONDS, mainThread())
         .subscribe {
-          showUserAccountStatus(currentStatusView)
+          showUserAccountStatus(currentStatusViewId)
         }
   }
 

--- a/app/src/main/java/org/simple/clinic/home/patients/PatientsScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/patients/PatientsScreen.kt
@@ -23,6 +23,7 @@ import org.simple.clinic.search.PatientSearchScreen
 import org.simple.clinic.widgets.ScreenCreated
 import org.simple.clinic.widgets.TheActivityLifecycle
 import org.simple.clinic.widgets.indexOfChildId
+import org.threeten.bp.LocalDate
 import javax.inject.Inject
 
 open class PatientsScreen(context: Context, attrs: AttributeSet) : RelativeLayout(context, attrs) {
@@ -121,10 +122,10 @@ open class PatientsScreen(context: Context, attrs: AttributeSet) : RelativeLayou
     showUserAccountStatus(R.id.patients_user_status_awaitingsmsverification)
   }
 
-  fun showStatusPatientSummarySaved() {
+  fun showStatusPatientSummarySaved(patientName: String){
   }
 
-  fun showStatusPatientAppointmentSaved() {
+  fun showStatusPatientAppointmentSaved(patientName: String, appointmentDate: LocalDate){
   }
 
   fun hideUserAccountStatus() {

--- a/app/src/main/java/org/simple/clinic/home/patients/PatientsScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/patients/PatientsScreen.kt
@@ -19,7 +19,6 @@ import kotterknife.bindView
 import org.simple.clinic.R
 import org.simple.clinic.activity.TheActivity
 import org.simple.clinic.enterotp.EnterOtpScreenKey
-import org.simple.clinic.patient.PatientSummaryResult
 import org.simple.clinic.router.screen.ScreenRouter
 import org.simple.clinic.search.PatientSearchScreen
 import org.simple.clinic.widgets.ScreenCreated
@@ -72,9 +71,7 @@ open class PatientsScreen(context: Context, attrs: AttributeSet) : RelativeLayou
             activityStarts(),
             searchButtonClicks(),
             dismissApprovedStatusClicks(),
-            enterCodeManuallyClicks(),
-            streamSummaryResults()
-        )
+            enterCodeManuallyClicks())
         .observeOn(io())
         .compose(controller)
         .observeOn(mainThread())
@@ -99,11 +96,6 @@ open class PatientsScreen(context: Context, attrs: AttributeSet) : RelativeLayou
   private fun dismissApprovedStatusClicks() = RxView.clicks(dismissApprovedStatusButton).map { UserApprovedStatusDismissed() }
 
   private fun enterCodeManuallyClicks() = RxView.clicks(enterOtpManuallyButton).map { PatientsEnterCodeManuallyClicked() }
-
-  private fun streamSummaryResults() =
-      screenRouter.streamScreenResults()
-          .ofType<PatientSummaryResult>()
-          .map { PatientSummaryResultReceived(it) }
 
   fun openNewPatientScreen() {
     screenRouter.push(PatientSearchScreen.KEY)

--- a/app/src/main/java/org/simple/clinic/home/patients/PatientsScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/patients/PatientsScreen.kt
@@ -55,6 +55,7 @@ open class PatientsScreen(context: Context, attrs: AttributeSet) : RelativeLayou
 
   @IdRes
   private var currentStatusViewId: Int = R.id.patients_user_status_hidden
+  private var disposable = Disposables.empty()
 
   override fun onFinishInflate() {
     super.onFinishInflate()
@@ -117,8 +118,6 @@ open class PatientsScreen(context: Context, attrs: AttributeSet) : RelativeLayou
     showStatus(statusViewId)
     currentStatusViewId = approvalStatusViewFlipper.currentView.id
   }
-
-  private var disposable = Disposables.empty()
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()

--- a/app/src/main/java/org/simple/clinic/home/patients/PatientsScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/home/patients/PatientsScreenController.kt
@@ -188,5 +188,4 @@ class PatientsScreenController @Inject constructor(
 
     return Observable.merge(savedStream, scheduledStream)
   }
-
 }

--- a/app/src/main/java/org/simple/clinic/home/patients/PatientsScreenEvents.kt
+++ b/app/src/main/java/org/simple/clinic/home/patients/PatientsScreenEvents.kt
@@ -1,6 +1,5 @@
 package org.simple.clinic.home.patients
 
-import org.simple.clinic.patient.PatientSummaryResult
 import org.simple.clinic.widgets.UiEvent
 
 object NewPatientClicked : UiEvent {
@@ -14,5 +13,3 @@ class UserApprovedStatusDismissed : UiEvent {
 class PatientsEnterCodeManuallyClicked : UiEvent {
   override val analyticsName = "Patients:Enter Code Manually Clicked"
 }
-
-data class PatientSummaryResultReceived(val result: PatientSummaryResult): UiEvent

--- a/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
@@ -79,7 +79,7 @@ data class Appointment(
     fun save(appointments: List<Appointment>)
 
     @Query("SELECT * FROM Appointment WHERE patientUuid = :patientUuid AND status = :status")
-    fun getAppointmentFromPatientUUID(patientUuid: UUID, status: Status): Flowable<Appointment>
+    fun scheduledAppointmentForPatient(patientUuid: UUID, status: Status): Flowable<Appointment>
 
     @Query("SELECT COUNT(uuid) FROM Appointment")
     fun count(): Flowable<Int>

--- a/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
@@ -78,6 +78,9 @@ data class Appointment(
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun save(appointments: List<Appointment>)
 
+    @Query("SELECT * FROM Appointment WHERE patientUuid = :patientUuid AND status = :status")
+    fun getScheduledFromPatientUUID(patientUuid: UUID, status: Status): Flowable<Appointment>
+
     @Query("SELECT COUNT(uuid) FROM Appointment")
     fun count(): Flowable<Int>
 

--- a/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
@@ -79,7 +79,7 @@ data class Appointment(
     fun save(appointments: List<Appointment>)
 
     @Query("SELECT * FROM Appointment WHERE patientUuid = :patientUuid AND status = :status")
-    fun getScheduledFromPatientUUID(patientUuid: UUID, status: Status): Flowable<Appointment>
+    fun getAppointmentFromPatientUUID(patientUuid: UUID, status: Status): Flowable<Appointment>
 
     @Query("SELECT COUNT(uuid) FROM Appointment")
     fun count(): Flowable<Int>

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
@@ -139,7 +139,7 @@ class AppointmentRepository @Inject constructor(
   }
 
   fun scheduledAppointmentForPatient(patientUuid: UUID): Observable<Appointment> {
-    return appointmentDao.getAppointmentFromPatientUUID(
+    return appointmentDao.scheduledAppointmentForPatient(
         patientUuid = patientUuid,
         status = Appointment.Status.SCHEDULED
     )

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
@@ -139,8 +139,10 @@ class AppointmentRepository @Inject constructor(
   }
 
   fun scheduledAppointmentForPatient(patientUuid: UUID): Observable<Appointment> {
-    return appointmentDao
-        .getScheduledFromPatientUUID(patientUuid, Appointment.Status.SCHEDULED)
+    return appointmentDao.getAppointmentFromPatientUUID(
+        patientUuid = patientUuid,
+        status = Appointment.Status.SCHEDULED
+    )
         .toObservable()
   }
 

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
@@ -138,6 +138,12 @@ class AppointmentRepository @Inject constructor(
         }
   }
 
+  fun scheduledAppointmentForPatient(patientUuid: UUID): Observable<Appointment> {
+    return appointmentDao
+        .getScheduledFromPatientUUID(patientUuid, Appointment.Status.SCHEDULED)
+        .toObservable()
+  }
+
   override fun recordsWithSyncStatus(syncStatus: SyncStatus): Single<List<Appointment>> {
     return appointmentDao.recordsWithSyncStatus(syncStatus).firstOrError()
   }

--- a/app/src/main/java/org/simple/clinic/patient/PatientSummaryResult.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientSummaryResult.kt
@@ -1,13 +1,27 @@
 package org.simple.clinic.patient
 
-import java.io.Serializable
+import com.f2prateek.rx.preferences2.Preference
+import com.squareup.moshi.Moshi
 import java.util.UUID
 
-sealed class PatientSummaryResult : Serializable {
+sealed class PatientSummaryResult {
 
   data class Saved(val patientUuid: UUID) : PatientSummaryResult()
 
   object NotSaved : PatientSummaryResult()
 
   data class Scheduled(val patientUuid: UUID) : PatientSummaryResult()
+
+  class RxPreferencesConverter(moshi: Moshi) : Preference.Converter<PatientSummaryResult> {
+
+    private val adapter by lazy { moshi.adapter(PatientSummaryResult::class.java) }
+
+    override fun deserialize(serialized: String): PatientSummaryResult {
+      return adapter.fromJson(serialized)!!
+    }
+
+    override fun serialize(value: PatientSummaryResult): String {
+      return adapter.toJson(value)
+    }
+  }
 }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryModule.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryModule.kt
@@ -1,9 +1,14 @@
 package org.simple.clinic.summary
 
+import com.f2prateek.rx.preferences2.Preference
+import com.f2prateek.rx.preferences2.RxSharedPreferences
+import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
 import io.reactivex.Single
+import org.simple.clinic.patient.PatientSummaryResult
 import org.threeten.bp.Duration
+import javax.inject.Named
 
 @Module
 open class PatientSummaryModule {
@@ -14,4 +19,11 @@ open class PatientSummaryModule {
       bpEditableFor = Duration.ofDays(1L),
       isPatientEditFeatureEnabled = true
   ))
+
+  @Provides
+  @Named("patient_summary_result")
+  fun patientSummaryResult(rxSharedPreferences: RxSharedPreferences, moshi: Moshi): Preference<PatientSummaryResult> {
+    val typeConverter = PatientSummaryResult.RxPreferencesConverter(moshi)
+    return rxSharedPreferences.getObject("patient_summary_result", PatientSummaryResult.NotSaved, typeConverter)
+  }
 }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryModule.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryModule.kt
@@ -24,6 +24,6 @@ open class PatientSummaryModule {
   @Named("patient_summary_result")
   fun patientSummaryResult(rxSharedPreferences: RxSharedPreferences, moshi: Moshi): Preference<PatientSummaryResult> {
     val typeConverter = PatientSummaryResult.RxPreferencesConverter(moshi)
-    return rxSharedPreferences.getObject("patient_summary_result", PatientSummaryResult.NotSaved, typeConverter)
+    return rxSharedPreferences.getObject("patient_summary_result_v1", PatientSummaryResult.NotSaved, typeConverter)
   }
 }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -35,7 +35,6 @@ import org.simple.clinic.patient.Gender
 import org.simple.clinic.patient.Patient
 import org.simple.clinic.patient.PatientAddress
 import org.simple.clinic.patient.PatientPhoneNumber
-import org.simple.clinic.patient.PatientSummaryResult
 import org.simple.clinic.router.screen.ActivityResult
 import org.simple.clinic.router.screen.BackPressInterceptCallback
 import org.simple.clinic.router.screen.BackPressInterceptor
@@ -296,8 +295,8 @@ class PatientSummaryScreen(context: Context, attrs: AttributeSet) : RelativeLayo
     screenRouter.pop()
   }
 
-  fun goBackToHome(status: PatientSummaryResult) {
-    screenRouter.clearHistoryAndPushWithResult(HomeScreen.KEY, direction = BACKWARD, result = status)
+  fun goBackToHome() {
+    screenRouter.clearHistoryAndPush(HomeScreen.KEY, direction = BACKWARD)
   }
 
   fun disableEditPatientFeature() {

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreenEvents.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreenEvents.kt
@@ -2,7 +2,6 @@ package org.simple.clinic.summary
 
 import org.simple.clinic.bp.BloodPressureMeasurement
 import org.simple.clinic.medicalhistory.MedicalHistoryQuestion
-import org.simple.clinic.patient.PatientSummaryResult
 import org.simple.clinic.widgets.UiEvent
 import org.threeten.bp.Instant
 import java.util.UUID
@@ -44,6 +43,3 @@ data class PatientSummaryRestoredWithBPSaved(val wasBloodPressureSaved: Boolean)
 data class PatientSummaryBpClicked(val bloodPressureMeasurement: BloodPressureMeasurement): UiEvent
 
 data class PatientSummaryItemChanged(val patientSummaryItems: PatientSummaryItems): UiEvent
-
-data class PatientSummaryResultSet(val result : PatientSummaryResult): UiEvent
-

--- a/app/src/main/java/org/simple/clinic/user/UserSession.kt
+++ b/app/src/main/java/org/simple/clinic/user/UserSession.kt
@@ -339,6 +339,7 @@ class UserSession @Inject constructor(
         .fromAction { appDatabase.userDao().createOrUpdate(user) }
         .doOnSubscribe { Timber.i("Storing user") }
         .andThen(facilityRepository.associateUserWithFacilities(user, facilityUuids, currentFacility = facilityUuids.first()))
+        .doOnError { Timber.e(it) }
   }
 
   private fun <T : Any> readErrorResponseJson(error: HttpException, clazz: KClass<T>): T {

--- a/app/src/main/res/layout/patients_summary_appointment_saved.xml
+++ b/app/src/main/res/layout/patients_summary_appointment_saved.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout android:id="@+id/patients_status_summary_appointment_saved"
+<RelativeLayout android:id="@+id/patients_summary_appointment_saved"
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
@@ -13,7 +13,7 @@
   tools:ignore="Overdraw">
 
   <LinearLayout
-    android:id="@+id/patients_status_summary_saved_details"
+    android:id="@+id/patients_summary_appointment_saved_details"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_alignParentStart="true"
@@ -28,12 +28,14 @@
       android:text="@string/patient_summary_saved_status" />
 
     <TextView
+      android:id="@+id/patients_summary_appointment_saved_name"
       style="@style/Clinic.V2.TextAppearance.Body2Left.Grey1"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:text="@string/patient_status_summary_saved_scheduled_appointment" />
 
     <TextView
+      android:id="@+id/patients_summary_appointment_saved_date"
       style="@style/Clinic.V2.TextAppearance.Subtitle1Left.Grey0"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"

--- a/app/src/main/res/layout/patients_summary_saved.xml
+++ b/app/src/main/res/layout/patients_summary_saved.xml
@@ -21,6 +21,7 @@
     tools:ignore="RelativeOverlap" />
 
   <TextView
+    android:id="@+id/patients_summary_saved_name"
     style="@style/Clinic.V2.TextAppearance.Body2Left.Grey1"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"

--- a/app/src/test/java/org/simple/clinic/home/patients/PatientsScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/patients/PatientsScreenControllerTest.kt
@@ -56,7 +56,6 @@ class PatientsScreenControllerTest {
   private val uiEvents: PublishSubject<UiEvent> = PublishSubject.create()
   private lateinit var controller: PatientsScreenController
 
-
   @Before
   fun setUp() {
     // This is needed because we manually subscribe to the refresh user status

--- a/app/src/test/java/org/simple/clinic/patient/PatientMocker.kt
+++ b/app/src/test/java/org/simple/clinic/patient/PatientMocker.kt
@@ -14,6 +14,7 @@ import org.simple.clinic.user.UserStatus
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
 import org.threeten.bp.ZoneOffset
+import org.threeten.bp.ZoneOffset.UTC
 import java.util.Random
 import java.util.UUID
 import kotlin.reflect.KClass
@@ -145,19 +146,31 @@ object PatientMocker {
         dosages = dosages)
   }
 
-  fun appointment(): Appointment {
+  fun appointment(
+      uuid: UUID = UUID.randomUUID(),
+      patientUuid: UUID = UUID.randomUUID(),
+      scheduledDate: LocalDate = LocalDate.now(UTC),
+      facilityUuid: UUID = UUID.randomUUID(),
+      status: Appointment.Status = Appointment.Status.SCHEDULED,
+      cancelReason: Appointment.CancelReason = Appointment.CancelReason.PATIENT_NOT_RESPONDING,
+      syncStatus: SyncStatus = SyncStatus.PENDING,
+      agreedToVisit: Boolean? = null,
+      remindOn: LocalDate? = LocalDate.now(UTC).minusDays(2),
+      createdAt: Instant = Instant.now(),
+      updatedAt: Instant = Instant.now()
+  ): Appointment {
     return Appointment(
-        uuid = mock(),
-        patientUuid = mock(),
-        scheduledDate = LocalDate.now(ZoneOffset.UTC).minusDays(10),
-        facilityUuid = mock(),
-        status = Appointment.Status.SCHEDULED,
-        cancelReason = Appointment.CancelReason.PATIENT_NOT_RESPONDING,
-        syncStatus = mock(),
-        agreedToVisit = null,
-        remindOn = LocalDate.now(ZoneOffset.UTC).minusDays(2),
-        createdAt = mock(),
-        updatedAt = mock()
+        uuid = uuid,
+        patientUuid = patientUuid,
+        scheduledDate = scheduledDate,
+        facilityUuid = facilityUuid,
+        status = status,
+        cancelReason = cancelReason,
+        syncStatus = syncStatus,
+        agreedToVisit = agreedToVisit,
+        remindOn = remindOn,
+        createdAt = createdAt,
+        updatedAt = updatedAt
     )
   }
 

--- a/app/src/test/java/org/simple/clinic/patient/PatientSummaryResultTest.kt
+++ b/app/src/test/java/org/simple/clinic/patient/PatientSummaryResultTest.kt
@@ -1,0 +1,36 @@
+package org.simple.clinic.patient
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.simple.clinic.di.NetworkModule
+import org.simple.clinic.patient.PatientSummaryResult.Saved
+import java.util.UUID
+
+class PatientSummaryResultTest {
+
+  /**
+   * If you're seeing this test fail, it means that you modified
+   * [PatientSummaryResult] without thinking about migration.
+   *
+   * The SharedPreferences key for [PatientSummaryResult] is
+   * versioned, so the migration can potentially happen when it's
+   * being read from SharedPreferences.
+   */
+
+  @Test
+  fun `fail when migration is required`() {
+
+    val moshi = NetworkModule().moshi()
+    val adapter = moshi.adapter(PatientSummaryResult::class.java)
+
+    val expectedJson = """
+      {
+      "patient_summary_result":"result_saved",
+      "patientUuid":"b8d2e316-ac37-474a-a8da-815b96a1122e"
+      }
+      """
+
+    val deserialize = adapter.fromJson(expectedJson)
+    assertThat(deserialize).isEqualTo(Saved(patientUuid = UUID.fromString("b8d2e316-ac37-474a-a8da-815b96a1122e")))
+  }
+}

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenControllerTest.kt
@@ -514,6 +514,13 @@ class PatientSummaryScreenControllerTest {
     )
   }
 
+  @Test
+  fun `when a new patient is registered, always show the status as saved`() {
+    uiEvents.onNext(PatientSummaryScreenCreated(patientUuid, PatientSummaryCaller.NEW_PATIENT, Instant.now(clock)))
+
+    verify(patientSummaryResult, times(1)).set(PatientSummaryResult.Saved(patientUuid))
+  }
+
   @Suppress("unused")
   fun medicalHistoryQuestionsWithoutNone() = MedicalHistoryQuestion.values().filter { it != MedicalHistoryQuestion.NONE }
 

--- a/router/src/main/java/org/simple/clinic/router/screen/ScreenRouter.kt
+++ b/router/src/main/java/org/simple/clinic/router/screen/ScreenRouter.kt
@@ -136,11 +136,6 @@ class ScreenRouter(
     }
   }
 
-  fun clearHistoryAndPushWithResult(screenKey: FullScreenKey, direction: RouterDirection, result: Any) {
-    flow().setHistory(History.single(screenKey), direction.flowDirection)
-    resultBus.send(result)
-  }
-
   private class DefaultKeyParceler : KeyParceler {
 
     override fun toParcelable(key: Any): Parcelable {


### PR DESCRIPTION
There is one issue for which a separate PR has been opened.
If a prescription is deleted from Patient Summary, we are not detecting that as a change. This happens because the query in the controller fetches only prescribed drugs and not deleted drugs, hence we cannot check that row. 