### PR TITLE
Fix: Update updated-at timestamp when updating appointments

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentRepositoryAndroidTest.kt
@@ -103,7 +103,12 @@ class AppointmentRepositoryAndroidTest {
     val patientId = UUID.randomUUID()
 
     val date1 = LocalDate.now(clock)
+    val timeOfSchedule = Instant.now(clock)
     appointmentRepository.schedule(patientId, date1).blockingAwait()
+
+    appointmentRepository.setSyncStatus(from = SyncStatus.PENDING, to = SyncStatus.DONE).blockingAwait()
+
+    testClock.advanceBy(Duration.ofHours(24))
 
     val date2 = LocalDate.now(clock).plusDays(10)
     appointmentRepository.schedule(patientId, date2).blockingAwait()
@@ -111,15 +116,19 @@ class AppointmentRepositoryAndroidTest {
     val savedAppointment = appointmentRepository.recordsWithSyncStatus(SyncStatus.PENDING).blockingGet()
     assertThat(savedAppointment).hasSize(2)
 
-    savedAppointment[0].apply {
+    val oldAppointment = savedAppointment[0]
+    oldAppointment.apply {
       assertThat(this.patientUuid).isEqualTo(patientId)
       assertThat(this.scheduledDate).isEqualTo(date1)
       assertThat(this.status).isEqualTo(Appointment.Status.VISITED)
       assertThat(this.cancelReason).isEqualTo(null)
       assertThat(this.syncStatus).isEqualTo(SyncStatus.PENDING)
+      assertThat(this.updatedAt).isNotEqualTo(timeOfSchedule)
+      assertThat(this.updatedAt).isEqualTo(Instant.now(clock))
     }
 
-    savedAppointment[1].apply {
+    val newAppointment = savedAppointment[1]
+    newAppointment.apply {
       assertThat(this.patientUuid).isEqualTo(patientId)
       assertThat(this.scheduledDate).isEqualTo(date2)
       assertThat(this.status).isEqualTo(SCHEDULED)
@@ -304,24 +313,30 @@ class AppointmentRepositoryAndroidTest {
   fun when_setting_appointment_reminder_then_reminder_with_correct_date_should_be_set() {
     val patientId = UUID.randomUUID()
     val appointmentDate = LocalDate.now(clock)
+    val timeOfSchedule = Instant.now(clock)
     appointmentRepository.schedule(patientId, appointmentDate).blockingAwait()
 
     val appointments = appointmentRepository.recordsWithSyncStatus(SyncStatus.PENDING).blockingGet()
     assertThat(appointments).hasSize(1)
     assertThat(appointments.first().remindOn).isNull()
 
-    val uuid = appointments[0].uuid
-    appointmentRepository.setSyncStatus(listOf(uuid), SyncStatus.DONE).blockingGet()
+    appointmentRepository.setSyncStatus(from = SyncStatus.PENDING, to = SyncStatus.DONE).blockingAwait()
 
+    testClock.advanceBy(Duration.ofHours(24))
+
+    val uuid = appointments[0].uuid
     val reminderDate = LocalDate.now(clock).plusDays(10)
     appointmentRepository.createReminder(uuid, reminderDate).blockingGet()
 
-    val updatedList = appointmentRepository.recordsWithSyncStatus(SyncStatus.PENDING).blockingGet()
-    assertThat(updatedList).hasSize(1)
-    updatedList[0].apply {
+    val updatedAppointments = appointmentRepository.recordsWithSyncStatus(SyncStatus.PENDING).blockingGet()
+    assertThat(updatedAppointments).hasSize(1)
+    updatedAppointments[0].apply {
       assertThat(this.uuid).isEqualTo(uuid)
       assertThat(this.remindOn).isEqualTo(reminderDate)
       assertThat(this.agreedToVisit).isNull()
+      assertThat(this.syncStatus).isEqualTo(SyncStatus.PENDING)
+      assertThat(this.updatedAt).isNotEqualTo(timeOfSchedule)
+      assertThat(this.updatedAt).isEqualTo(Instant.now(clock))
     }
   }
 
@@ -329,6 +344,7 @@ class AppointmentRepositoryAndroidTest {
   fun when_marking_appointment_as_agreed_to_visit_reminder_for_30_days_should_be_set() {
     val patientId = UUID.randomUUID()
     val appointmentDate = LocalDate.now(clock)
+    val timeOfSchedule = Instant.now(clock)
     appointmentRepository.schedule(patientId, appointmentDate).blockingAwait()
 
     val appointments = appointmentRepository.recordsWithSyncStatus(SyncStatus.PENDING).blockingGet()
@@ -337,8 +353,10 @@ class AppointmentRepositoryAndroidTest {
     assertThat(appointments.first().agreedToVisit).isNull()
 
     val uuid = appointments[0].uuid
-    appointmentRepository.setSyncStatus(listOf(uuid), SyncStatus.DONE).blockingGet()
-    appointmentRepository.markAsAgreedToVisit(uuid).blockingGet()
+    appointmentRepository.setSyncStatus(from = SyncStatus.PENDING, to = SyncStatus.DONE).blockingAwait()
+
+    testClock.advanceBy(Duration.ofDays(1))
+    appointmentRepository.markAsAgreedToVisit(uuid).blockingAwait()
 
     val updatedList = appointmentRepository.recordsWithSyncStatus(SyncStatus.PENDING).blockingGet()
     assertThat(updatedList).hasSize(1)
@@ -346,6 +364,8 @@ class AppointmentRepositoryAndroidTest {
       assertThat(this.uuid).isEqualTo(uuid)
       assertThat(this.remindOn).isEqualTo(LocalDate.now(clock).plusDays(30))
       assertThat(this.agreedToVisit).isTrue()
+      assertThat(this.updatedAt).isNotEqualTo(timeOfSchedule)
+      assertThat(this.updatedAt).isEqualTo(Instant.now(clock))
     }
   }
 
@@ -353,6 +373,7 @@ class AppointmentRepositoryAndroidTest {
   fun when_removing_appointment_from_list_then_appointment_status_and_cancel_reason_should_be_updated() {
     val patientId = UUID.randomUUID()
     val appointmentDate = LocalDate.now(clock)
+    val timeOfSchedule = Instant.now(clock)
     appointmentRepository.schedule(patientId, appointmentDate).blockingAwait()
 
     val appointments = appointmentRepository.recordsWithSyncStatus(SyncStatus.PENDING).blockingGet()
@@ -360,7 +381,10 @@ class AppointmentRepositoryAndroidTest {
     assertThat(appointments.first().cancelReason).isNull()
 
     val uuid = appointments[0].uuid
-    appointmentRepository.setSyncStatus(listOf(uuid), SyncStatus.DONE).blockingGet()
+    appointmentRepository.setSyncStatus(from = SyncStatus.PENDING, to = SyncStatus.DONE).blockingAwait()
+
+    testClock.advanceBy(Duration.ofDays(1))
+
     appointmentRepository.cancelWithReason(uuid, Appointment.CancelReason.PATIENT_NOT_RESPONDING).blockingGet()
 
     val updatedList = appointmentRepository.recordsWithSyncStatus(SyncStatus.PENDING).blockingGet()
@@ -369,6 +393,8 @@ class AppointmentRepositoryAndroidTest {
       assertThat(this.uuid).isEqualTo(uuid)
       assertThat(this.cancelReason).isEqualTo(Appointment.CancelReason.PATIENT_NOT_RESPONDING)
       assertThat(this.status).isEqualTo(CANCELLED)
+      assertThat(this.updatedAt).isNotEqualTo(timeOfSchedule)
+      assertThat(this.updatedAt).isEqualTo(Instant.now(clock))
     }
   }
 
@@ -376,6 +402,7 @@ class AppointmentRepositoryAndroidTest {
   fun when_removing_appointment_with_reason_as_patient_already_visited_then_appointment_should_be_marked_as_visited() {
     val patientId = UUID.randomUUID()
     val appointmentDate = LocalDate.now(clock)
+    val timeOfSchedule = Instant.now(clock)
     appointmentRepository.schedule(patientId, appointmentDate).blockingAwait()
 
     val appointments = appointmentRepository.recordsWithSyncStatus(SyncStatus.PENDING).blockingGet()
@@ -383,8 +410,11 @@ class AppointmentRepositoryAndroidTest {
     assertThat(appointments.first().status).isEqualTo(SCHEDULED)
 
     val uuid = appointments[0].uuid
-    appointmentRepository.setSyncStatus(listOf(uuid), SyncStatus.DONE).blockingGet()
-    appointmentRepository.markAsVisited(uuid).blockingGet()
+    appointmentRepository.setSyncStatus(from = SyncStatus.PENDING, to = SyncStatus.DONE).blockingAwait()
+
+    testClock.advanceBy(Duration.ofDays(1))
+
+    appointmentRepository.markAsAlreadyVisited(uuid).blockingAwait()
 
     val updatedList = appointmentRepository.recordsWithSyncStatus(SyncStatus.PENDING).blockingGet()
     assertThat(updatedList).hasSize(1)
@@ -392,6 +422,8 @@ class AppointmentRepositoryAndroidTest {
       assertThat(this.uuid).isEqualTo(uuid)
       assertThat(this.cancelReason).isNull()
       assertThat(this.status).isEqualTo(VISITED)
+      assertThat(this.updatedAt).isEqualTo(Instant.now(clock))
+      assertThat(this.updatedAt).isNotEqualTo(timeOfSchedule)
     }
   }
 
@@ -494,24 +526,22 @@ class AppointmentRepositoryAndroidTest {
 
   @Test
   fun when_fetching_appointment_for_patient_it_should_return_scheduled_appointment_only() {
-      val patientId = UUID.randomUUID()
-      val appointmentDateNow = LocalDate.now()
-      val appointmentDateLater = LocalDate.now().plusDays(1)
-      appointmentRepository.schedule(patientId, appointmentDateNow).blockingAwait()
-      appointmentRepository.schedule(patientId, appointmentDateLater).blockingAwait()
+    val patientId = UUID.randomUUID()
+    val appointmentDateNow = LocalDate.now()
+    val appointmentDateLater = LocalDate.now().plusDays(1)
+    appointmentRepository.schedule(patientId, appointmentDateNow).blockingAwait()
+    appointmentRepository.schedule(patientId, appointmentDateLater).blockingAwait()
 
-      val appointment = appointmentRepository.scheduledAppointmentForPatient(patientId).blockingFirst()
-      assertThat(appointment).isNotNull()
-      assertThat(appointment.patientUuid).isEqualTo(patientId)
-      assertThat(appointment.status).isEqualTo(SCHEDULED)
-      assertThat(appointment.scheduledDate).isEqualTo(appointmentDateLater)
-    }
-
-    @After
-    fun tearDown() {
-      database.clearAllTables()
-      testClock.resetToEpoch()
-    }
-
-
+    val appointment = appointmentRepository.scheduledAppointmentForPatient(patientId).blockingFirst()
+    assertThat(appointment).isNotNull()
+    assertThat(appointment.patientUuid).isEqualTo(patientId)
+    assertThat(appointment.status).isEqualTo(SCHEDULED)
+    assertThat(appointment.scheduledDate).isEqualTo(appointmentDateLater)
   }
+
+  @After
+  fun tearDown() {
+    database.clearAllTables()
+    testClock.resetToEpoch()
+  }
+}

--- a/app/src/main/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentSheetController.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentSheetController.kt
@@ -56,7 +56,7 @@ class RemoveAppointmentSheetController @Inject constructor(
     val markAsVisitedStream = doneWithLatestFromReasons
         .filter { (_, _, reason) -> reason is AlreadyVisitedReasonClicked }
         .flatMap { (_, uuid, _) ->
-          appointmentRepository.markAsVisited(uuid)
+          appointmentRepository.markAsAlreadyVisited(uuid)
               .andThen(Observable.just { ui: Ui -> ui.closeSheet() })
         }
 

--- a/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
@@ -85,31 +85,60 @@ data class Appointment(
     fun count(): Flowable<Int>
 
     @Query("""UPDATE Appointment
-      SET status = :updatedStatus, syncStatus = :newSyncStatus
+      SET status = :updatedStatus, syncStatus = :newSyncStatus, updatedAt = :newUpdatedAt
       WHERE patientUuid = :patientUuid AND status = :scheduledStatus""")
     fun markOlderAppointmentsAsVisited(
         patientUuid: UUID,
         updatedStatus: Status,
         scheduledStatus: Status,
-        newSyncStatus: SyncStatus
+        newSyncStatus: SyncStatus,
+        newUpdatedAt: Instant
     )
 
-    @Query("UPDATE Appointment SET remindOn = :reminderDate WHERE uuid = :appointmentUUID")
-    fun createReminder(appointmentUUID: UUID, reminderDate: LocalDate)
+    @Query("""UPDATE Appointment
+       SET remindOn = :reminderDate, syncStatus = :newSyncStatus, updatedAt = :newUpdatedAt
+       WHERE uuid = :appointmentUUID""")
+    fun saveRemindDate(
+        appointmentUUID: UUID,
+        reminderDate: LocalDate,
+        newSyncStatus: SyncStatus,
+        newUpdatedAt: Instant
+    )
 
     @Query("""UPDATE Appointment
-      SET remindOn = :reminderDate, agreedToVisit = :agreed
+      SET remindOn = :reminderDate, agreedToVisit = :agreed, syncStatus = :newSyncStatus, updatedAt = :newUpdatedAt
       WHERE uuid = :appointmentUUID""")
-    fun markAsAgreedToVisit(appointmentUUID: UUID, reminderDate: LocalDate, agreed: Boolean)
+    fun markAsAgreedToVisit(
+        appointmentUUID: UUID,
+        reminderDate: LocalDate,
+        agreed: Boolean = true,
+        newSyncStatus: SyncStatus,
+        newUpdatedAt: Instant
+    )
 
-    @Query("UPDATE Appointment SET status = :newStatus WHERE uuid = :appointmentUuid")
-    fun markAsVisited(appointmentUuid: UUID, newStatus: Status)
-
-    @Query("""UPDATE Appointment
-      SET cancelReason = :cancelReason, status = :newStatus
+    @Query("""
+      UPDATE Appointment
+      SET status = :newStatus, syncStatus = :newSyncStatus, updatedAt = :newUpdatedAt
       WHERE uuid = :appointmentUuid
     """)
-    fun cancelWithReason(appointmentUuid: UUID, cancelReason: CancelReason, newStatus: Status)
+    fun markAsVisited(
+        appointmentUuid: UUID,
+        newStatus: Status,
+        newSyncStatus: SyncStatus,
+        newUpdatedAt: Instant
+    )
+
+    @Query("""UPDATE Appointment
+      SET cancelReason = :cancelReason, status = :newStatus, syncStatus = :newSyncStatus, updatedAt = :newUpdatedAt
+      WHERE uuid = :appointmentUuid
+    """)
+    fun cancelWithReason(
+        appointmentUuid: UUID,
+        cancelReason: CancelReason,
+        newStatus: Status,
+        newSyncStatus: SyncStatus,
+        newUpdatedAt: Instant
+    )
 
     @Query("DELETE FROM Appointment")
     fun clear()

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
@@ -56,51 +56,51 @@ class AppointmentRepository @Inject constructor(
           patientUuid = patientUuid,
           updatedStatus = Appointment.Status.VISITED,
           scheduledStatus = Appointment.Status.SCHEDULED,
-          newSyncStatus = SyncStatus.PENDING)
+          newSyncStatus = SyncStatus.PENDING,
+          newUpdatedAt = Instant.now(clock)
+      )
     }
   }
 
   fun createReminder(appointmentUuid: UUID, reminderDate: LocalDate): Completable {
     return Completable.fromAction {
-      database.runInTransaction {
-        appointmentDao.createReminder(appointmentUuid, reminderDate)
-        appointmentDao.updateSyncStatus(listOf(appointmentUuid), SyncStatus.PENDING)
-      }
+      appointmentDao.saveRemindDate(
+          appointmentUUID = appointmentUuid,
+          reminderDate = reminderDate,
+          newSyncStatus = SyncStatus.PENDING,
+          newUpdatedAt = Instant.now(clock)
+      )
     }
   }
 
   fun markAsAgreedToVisit(appointmentUuid: UUID): Completable {
     return Completable.fromAction {
-      database.runInTransaction {
-        appointmentDao.markAsAgreedToVisit(
-            appointmentUUID = appointmentUuid,
-            reminderDate = LocalDate.now(clock).plusDays(30),
-            agreed = true)
-        appointmentDao.updateSyncStatus(listOf(appointmentUuid), SyncStatus.PENDING)
-      }
+      appointmentDao.markAsAgreedToVisit(
+          appointmentUUID = appointmentUuid,
+          reminderDate = LocalDate.now(clock).plusDays(30),
+          newSyncStatus = SyncStatus.PENDING,
+          newUpdatedAt = Instant.now(clock))
     }
   }
 
-  fun markAsVisited(appointmentUuid: UUID): Completable {
+  fun markAsAlreadyVisited(appointmentUuid: UUID): Completable {
     return Completable.fromAction {
-      database.runInTransaction {
-        appointmentDao.markAsVisited(
-            appointmentUuid = appointmentUuid,
-            newStatus = Appointment.Status.VISITED)
-        appointmentDao.updateSyncStatus(listOf(appointmentUuid), SyncStatus.PENDING)
-      }
+      appointmentDao.markAsVisited(
+          appointmentUuid = appointmentUuid,
+          newStatus = Appointment.Status.VISITED,
+          newSyncStatus = SyncStatus.PENDING,
+          newUpdatedAt = Instant.now(clock))
     }
   }
 
   fun cancelWithReason(appointmentUuid: UUID, reason: Appointment.CancelReason): Completable {
     return Completable.fromAction {
-      database.runInTransaction {
-        appointmentDao.cancelWithReason(
-            appointmentUuid = appointmentUuid,
-            cancelReason = reason,
-            newStatus = Appointment.Status.CANCELLED)
-        appointmentDao.updateSyncStatus(listOf(appointmentUuid), SyncStatus.PENDING)
-      }
+      appointmentDao.cancelWithReason(
+          appointmentUuid = appointmentUuid,
+          cancelReason = reason,
+          newStatus = Appointment.Status.CANCELLED,
+          newSyncStatus = SyncStatus.PENDING,
+          newUpdatedAt = Instant.now(clock))
     }
   }
 

--- a/app/src/test/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentSheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentSheetControllerTest.kt
@@ -51,7 +51,7 @@ class RemoveAppointmentSheetControllerTest {
 
   @Test
   fun `when done is clicked, and reason is "already visited", then repository should update and sheet should close`() {
-    whenever(repository.markAsVisited(appointmentUuid)).thenReturn(Completable.complete())
+    whenever(repository.markAsAlreadyVisited(appointmentUuid)).thenReturn(Completable.complete())
 
     uiEvents.onNext(RemoveAppointmentSheetCreated(appointmentUuid))
     uiEvents.onNext(RemoveReasonDoneClicked)
@@ -66,7 +66,7 @@ class RemoveAppointmentSheetControllerTest {
 
     val inOrder = inOrder(sheet, repository)
     inOrder.verify(sheet, times(5)).enableDoneButton()
-    inOrder.verify(repository).markAsVisited(appointmentUuid)
+    inOrder.verify(repository).markAsAlreadyVisited(appointmentUuid)
     inOrder.verify(sheet).closeSheet()
   }
 
@@ -83,7 +83,7 @@ class RemoveAppointmentSheetControllerTest {
     uiEvents.onNext(PatientDeadClicked(patientUuid))
     uiEvents.onNext(RemoveReasonDoneClicked)
 
-    verify(repository, never()).markAsVisited(any())
+    verify(repository, never()).markAsAlreadyVisited(any())
 
     val inOrder = inOrder(sheet, repository, patientRepository)
     inOrder.verify(sheet, times(4)).enableDoneButton()
@@ -104,7 +104,7 @@ class RemoveAppointmentSheetControllerTest {
     uiEvents.onNext(CancelReasonClicked(MOVED))
     uiEvents.onNext(RemoveReasonDoneClicked)
 
-    verify(repository, never()).markAsVisited(any())
+    verify(repository, never()).markAsAlreadyVisited(any())
 
     val inOrder = inOrder(sheet, repository)
     inOrder.verify(sheet, times(4)).enableDoneButton()


### PR DESCRIPTION
This commit is another reminder why we need Database triggers to automatically set rows as "dirty" when they are updated on device. We were seeing a bug where canceled/dismissed appointments were coming back to the overdue list after a sync with the server. This was happening because updates to appointments were not getting synced with the server. They were instead getting replaced by server copies.