### PR TITLE
Store appointment cancel reason enums as raw strings

### DIFF
--- a/app/schemas/org.simple.clinic.AppDatabase/21.json
+++ b/app/schemas/org.simple.clinic.AppDatabase/21.json
@@ -1,0 +1,892 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 21,
+    "identityHash": "2cfa7c092506a7381bf32ca8c4ec2c4f",
+    "entities": [
+      {
+        "tableName": "Patient",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `addressUuid` TEXT NOT NULL, `fullName` TEXT NOT NULL, `searchableName` TEXT NOT NULL, `gender` TEXT NOT NULL, `dateOfBirth` TEXT, `status` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `syncStatus` TEXT NOT NULL, `age_value` INTEGER, `age_updatedAt` TEXT, `age_computedDateOfBirth` TEXT, PRIMARY KEY(`uuid`), FOREIGN KEY(`addressUuid`) REFERENCES `PatientAddress`(`uuid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addressUuid",
+            "columnName": "addressUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "searchableName",
+            "columnName": "searchableName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gender",
+            "columnName": "gender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateOfBirth",
+            "columnName": "dateOfBirth",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "age.value",
+            "columnName": "age_value",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "age.updatedAt",
+            "columnName": "age_updatedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "age.computedDateOfBirth",
+            "columnName": "age_computedDateOfBirth",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Patient_addressUuid",
+            "unique": false,
+            "columnNames": [
+              "addressUuid"
+            ],
+            "createSql": "CREATE  INDEX `index_Patient_addressUuid` ON `${TABLE_NAME}` (`addressUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "PatientAddress",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "addressUuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "PatientAddress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `colonyOrVillage` TEXT, `district` TEXT NOT NULL, `state` TEXT NOT NULL, `country` TEXT, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colonyOrVillage",
+            "columnName": "colonyOrVillage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "district",
+            "columnName": "district",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PatientPhoneNumber",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `patientUuid` TEXT NOT NULL, `number` TEXT NOT NULL, `phoneType` TEXT NOT NULL, `active` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`patientUuid`) REFERENCES `Patient`(`uuid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patientUuid",
+            "columnName": "patientUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneType",
+            "columnName": "phoneType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_PatientPhoneNumber_patientUuid",
+            "unique": false,
+            "columnNames": [
+              "patientUuid"
+            ],
+            "createSql": "CREATE  INDEX `index_PatientPhoneNumber_patientUuid` ON `${TABLE_NAME}` (`patientUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Patient",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "patientUuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "BloodPressureMeasurement",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `systolic` INTEGER NOT NULL, `diastolic` INTEGER NOT NULL, `syncStatus` TEXT NOT NULL, `userUuid` TEXT NOT NULL, `facilityUuid` TEXT NOT NULL, `patientUuid` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "systolic",
+            "columnName": "systolic",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "diastolic",
+            "columnName": "diastolic",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userUuid",
+            "columnName": "userUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "facilityUuid",
+            "columnName": "facilityUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patientUuid",
+            "columnName": "patientUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_BloodPressureMeasurement_patientUuid",
+            "unique": false,
+            "columnNames": [
+              "patientUuid"
+            ],
+            "createSql": "CREATE  INDEX `index_BloodPressureMeasurement_patientUuid` ON `${TABLE_NAME}` (`patientUuid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PrescribedDrug",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL, `dosage` TEXT, `rxNormCode` TEXT, `isDeleted` INTEGER NOT NULL, `isProtocolDrug` INTEGER NOT NULL, `patientUuid` TEXT NOT NULL, `facilityUuid` TEXT NOT NULL, `syncStatus` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dosage",
+            "columnName": "dosage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rxNormCode",
+            "columnName": "rxNormCode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "isDeleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isProtocolDrug",
+            "columnName": "isProtocolDrug",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patientUuid",
+            "columnName": "patientUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "facilityUuid",
+            "columnName": "facilityUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_PrescribedDrug_patientUuid",
+            "unique": false,
+            "columnNames": [
+              "patientUuid"
+            ],
+            "createSql": "CREATE  INDEX `index_PrescribedDrug_patientUuid` ON `${TABLE_NAME}` (`patientUuid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Facility",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL, `facilityType` TEXT, `streetAddress` TEXT, `villageOrColony` TEXT, `district` TEXT NOT NULL, `state` TEXT NOT NULL, `country` TEXT NOT NULL, `pinCode` TEXT, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `syncStatus` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "facilityType",
+            "columnName": "facilityType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "streetAddress",
+            "columnName": "streetAddress",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "villageOrColony",
+            "columnName": "villageOrColony",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "district",
+            "columnName": "district",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinCode",
+            "columnName": "pinCode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "LoggedInUser",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `fullName` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, `pinDigest` TEXT NOT NULL, `status` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `loggedInStatus` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinDigest",
+            "columnName": "pinDigest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "loggedInStatus",
+            "columnName": "loggedInStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "LoggedInUserFacilityMapping",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userUuid` TEXT NOT NULL, `facilityUuid` TEXT NOT NULL, `isCurrentFacility` INTEGER NOT NULL, PRIMARY KEY(`userUuid`, `facilityUuid`), FOREIGN KEY(`userUuid`) REFERENCES `LoggedInUser`(`uuid`) ON UPDATE NO ACTION ON DELETE NO ACTION , FOREIGN KEY(`facilityUuid`) REFERENCES `Facility`(`uuid`) ON UPDATE NO ACTION ON DELETE NO ACTION )",
+        "fields": [
+          {
+            "fieldPath": "userUuid",
+            "columnName": "userUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "facilityUuid",
+            "columnName": "facilityUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCurrentFacility",
+            "columnName": "isCurrentFacility",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "userUuid",
+            "facilityUuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_LoggedInUserFacilityMapping_facilityUuid",
+            "unique": false,
+            "columnNames": [
+              "facilityUuid"
+            ],
+            "createSql": "CREATE  INDEX `index_LoggedInUserFacilityMapping_facilityUuid` ON `${TABLE_NAME}` (`facilityUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "LoggedInUser",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "userUuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          },
+          {
+            "table": "Facility",
+            "onDelete": "NO ACTION",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "facilityUuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "Appointment",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `patientUuid` TEXT NOT NULL, `facilityUuid` TEXT NOT NULL, `scheduledDate` TEXT NOT NULL, `status` TEXT NOT NULL, `cancelReason` TEXT, `remindOn` TEXT, `agreedToVisit` INTEGER, `syncStatus` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patientUuid",
+            "columnName": "patientUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "facilityUuid",
+            "columnName": "facilityUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scheduledDate",
+            "columnName": "scheduledDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cancelReason",
+            "columnName": "cancelReason",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "remindOn",
+            "columnName": "remindOn",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "agreedToVisit",
+            "columnName": "agreedToVisit",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Communication",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `appointmentUuid` TEXT NOT NULL, `userUuid` TEXT NOT NULL, `type` TEXT NOT NULL, `result` TEXT NOT NULL, `syncStatus` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appointmentUuid",
+            "columnName": "appointmentUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userUuid",
+            "columnName": "userUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "result",
+            "columnName": "result",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "MedicalHistory",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `patientUuid` TEXT NOT NULL, `diagnosedWithHypertension` TEXT NOT NULL, `isOnTreatmentForHypertension` TEXT NOT NULL, `hasHadHeartAttack` TEXT NOT NULL, `hasHadStroke` TEXT NOT NULL, `hasHadKidneyDisease` TEXT NOT NULL, `hasDiabetes` TEXT NOT NULL, `syncStatus` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patientUuid",
+            "columnName": "patientUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "diagnosedWithHypertension",
+            "columnName": "diagnosedWithHypertension",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOnTreatmentForHypertension",
+            "columnName": "isOnTreatmentForHypertension",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasHadHeartAttack",
+            "columnName": "hasHadHeartAttack",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasHadStroke",
+            "columnName": "hasHadStroke",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasHadKidneyDisease",
+            "columnName": "hasHadKidneyDisease",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasDiabetes",
+            "columnName": "hasDiabetes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "OngoingLoginEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, `pin` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pin",
+            "columnName": "pin",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"2cfa7c092506a7381bf32ca8c4ec2c4f\")"
+    ]
+  }
+}

--- a/app/src/androidTest/java/org/simple/clinic/MigrationAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/MigrationAndroidTest.kt
@@ -26,6 +26,7 @@ import org.simple.clinic.storage.Migration_9_10
 
 private fun Cursor.string(column: String): String = getString(getColumnIndex(column))
 private fun Cursor.boolean(column: String): Boolean = getInt(getColumnIndex(column)) == 1
+private fun Cursor.integer(columnName: String): Int = getInt(getColumnIndex(columnName))
 
 @RunWith(AndroidJUnit4::class)
 class MigrationAndroidTest {
@@ -297,12 +298,12 @@ class MigrationAndroidTest {
       it.moveToFirst()
 
       val falseAsInt = 0
-      assertThat(it.getString(it.getColumnIndex("uuid"))).isNotEqualTo("old-uuid")
-      assertThat(it.getInt(it.getColumnIndex("hasHadHeartAttack"))).isEqualTo(falseAsInt)
-      assertThat(it.getInt(it.getColumnIndex("hasHadStroke"))).isEqualTo(falseAsInt)
-      assertThat(it.getInt(it.getColumnIndex("hasHadKidneyDisease"))).isEqualTo(falseAsInt)
-      assertThat(it.getInt(it.getColumnIndex("isOnTreatmentForHypertension"))).isEqualTo(falseAsInt)
-      assertThat(it.getInt(it.getColumnIndex("hasDiabetes"))).isEqualTo(falseAsInt)
+      assertThat(it.string("uuid")).isNotEqualTo("old-uuid")
+      assertThat(it.integer("hasHadHeartAttack")).isEqualTo(falseAsInt)
+      assertThat(it.integer("hasHadStroke")).isEqualTo(falseAsInt)
+      assertThat(it.integer("hasHadKidneyDisease")).isEqualTo(falseAsInt)
+      assertThat(it.integer("isOnTreatmentForHypertension")).isEqualTo(falseAsInt)
+      assertThat(it.integer("hasDiabetes")).isEqualTo(falseAsInt)
     }
   }
 
@@ -333,8 +334,8 @@ class MigrationAndroidTest {
       assertThat(it.columnCount).isEqualTo(11)
 
       it.moveToFirst()
-      assertThat(it.getString(it.getColumnIndex("uuid"))).isEqualTo("464bcda8-b26a-484d-bb70-49b3675f4a38")
-      assertThat(it.getString(it.getColumnIndex("diagnosedWithHypertension"))).isEqualTo("0")
+      assertThat(it.string("uuid")).isEqualTo("464bcda8-b26a-484d-bb70-49b3675f4a38")
+      assertThat(it.string("diagnosedWithHypertension")).isEqualTo("0")
     }
   }
 
@@ -550,12 +551,12 @@ class MigrationAndroidTest {
       assertThat(it.count).isEqualTo(1)
 
       it.moveToFirst()
-      assertThat(it.getString(it.getColumnIndex("diagnosedWithHypertension"))).isEqualTo("NO")
-      assertThat(it.getString(it.getColumnIndex("isOnTreatmentForHypertension"))).isEqualTo("YES")
-      assertThat(it.getString(it.getColumnIndex("hasHadHeartAttack"))).isEqualTo("NO")
-      assertThat(it.getString(it.getColumnIndex("hasHadStroke"))).isEqualTo("YES")
-      assertThat(it.getString(it.getColumnIndex("hasHadKidneyDisease"))).isEqualTo("NO")
-      assertThat(it.getString(it.getColumnIndex("hasDiabetes"))).isEqualTo("YES")
+      assertThat(it.string("diagnosedWithHypertension")).isEqualTo("NO")
+      assertThat(it.string("isOnTreatmentForHypertension")).isEqualTo("YES")
+      assertThat(it.string("hasHadHeartAttack")).isEqualTo("NO")
+      assertThat(it.string("hasHadStroke")).isEqualTo("YES")
+      assertThat(it.string("hasHadKidneyDisease")).isEqualTo("NO")
+      assertThat(it.string("hasDiabetes")).isEqualTo("YES")
     }
   }
 }

--- a/app/src/androidTest/java/org/simple/clinic/TestData.kt
+++ b/app/src/androidTest/java/org/simple/clinic/TestData.kt
@@ -13,6 +13,7 @@ import org.simple.clinic.medicalhistory.MedicalHistory
 import org.simple.clinic.medicalhistory.MedicalHistory.Answer
 import org.simple.clinic.medicalhistory.sync.MedicalHistoryPayload
 import org.simple.clinic.overdue.Appointment
+import org.simple.clinic.overdue.AppointmentCancelReason
 import org.simple.clinic.overdue.AppointmentPayload
 import org.simple.clinic.overdue.communication.Communication
 import org.simple.clinic.overdue.communication.CommunicationPayload
@@ -365,7 +366,7 @@ class TestData @Inject constructor(
         scheduledDate = LocalDate.now(UTC).plusDays(30),
         facilityUuid = qaUserFacilityUuid(),
         status = randomOfEnum(Appointment.Status::class),
-        cancelReason = randomOfEnum(Appointment.CancelReason::class),
+        cancelReason = AppointmentCancelReason.random(),
         remindOn = null,
         agreedToVisit = null,
         syncStatus = syncStatus,
@@ -379,7 +380,7 @@ class TestData @Inject constructor(
       date: LocalDate = LocalDate.now(UTC).plusDays(30),
       facilityUuid: UUID = qaUserFacilityUuid(),
       status: Appointment.Status = randomOfEnum(Appointment.Status::class),
-      cancelReason: Appointment.CancelReason = randomOfEnum(Appointment.CancelReason::class),
+      cancelReason: AppointmentCancelReason = AppointmentCancelReason.random(),
       createdAt: Instant = Instant.now(),
       updatedAt: Instant = Instant.now()
   ): AppointmentPayload {

--- a/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentRepositoryAndroidTest.kt
@@ -388,13 +388,13 @@ class AppointmentRepositoryAndroidTest {
 
     testClock.advanceBy(Duration.ofDays(1))
 
-    appointmentRepository.cancelWithReason(uuid, Appointment.CancelReason.PATIENT_NOT_RESPONDING).blockingGet()
+    appointmentRepository.cancelWithReason(uuid, AppointmentCancelReason.PatientNotResponding).blockingGet()
 
     val updatedList = appointmentRepository.recordsWithSyncStatus(SyncStatus.PENDING).blockingGet()
     assertThat(updatedList).hasSize(1)
     updatedList[0].apply {
       assertThat(this.uuid).isEqualTo(uuid)
-      assertThat(this.cancelReason).isEqualTo(Appointment.CancelReason.PATIENT_NOT_RESPONDING)
+      assertThat(this.cancelReason).isEqualTo(AppointmentCancelReason.PatientNotResponding)
       assertThat(this.status).isEqualTo(CANCELLED)
       assertThat(this.updatedAt).isNotEqualTo(timeOfSchedule)
       assertThat(this.updatedAt).isEqualTo(Instant.now(clock))

--- a/app/src/main/java/org/simple/clinic/AppDatabase.kt
+++ b/app/src/main/java/org/simple/clinic/AppDatabase.kt
@@ -42,7 +42,7 @@ import org.simple.clinic.util.UuidRoomTypeConverter
       Communication::class,
       MedicalHistory::class,
       OngoingLoginEntry::class],
-    version = 20,
+    version = 21,
     exportSchema = true)
 @TypeConverters(
     Gender.RoomTypeConverter::class,

--- a/app/src/main/java/org/simple/clinic/AppDatabase.kt
+++ b/app/src/main/java/org/simple/clinic/AppDatabase.kt
@@ -9,6 +9,7 @@ import org.simple.clinic.facility.Facility
 import org.simple.clinic.home.overdue.OverdueAppointment
 import org.simple.clinic.medicalhistory.MedicalHistory
 import org.simple.clinic.overdue.Appointment
+import org.simple.clinic.overdue.AppointmentCancelReason
 import org.simple.clinic.overdue.communication.Communication
 import org.simple.clinic.patient.Gender
 import org.simple.clinic.patient.Patient
@@ -51,7 +52,7 @@ import org.simple.clinic.util.UuidRoomTypeConverter
     UserStatus.RoomTypeConverter::class,
     User.LoggedInStatus.RoomTypeConverter::class,
     Appointment.Status.RoomTypeConverter::class,
-    Appointment.CancelReason.RoomTypeConverter::class,
+    AppointmentCancelReason.RoomTypeConverter::class,
     Communication.Type.RoomTypeConverter::class,
     Communication.Result.RoomTypeConverter::class,
     MedicalHistory.Answer.RoomTypeConverter::class,

--- a/app/src/main/java/org/simple/clinic/di/AppModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/AppModule.kt
@@ -27,6 +27,7 @@ import org.simple.clinic.storage.Migration_16_17
 import org.simple.clinic.storage.Migration_17_18
 import org.simple.clinic.storage.Migration_18_19
 import org.simple.clinic.storage.Migration_19_20
+import org.simple.clinic.storage.Migration_20_21
 import org.simple.clinic.storage.Migration_3_4
 import org.simple.clinic.storage.Migration_4_5
 import org.simple.clinic.storage.Migration_5_6
@@ -92,7 +93,8 @@ open class AppModule(
             Migration_16_17(),
             Migration_17_18(),
             Migration_18_19(),
-            Migration_19_20())
+            Migration_19_20(),
+            Migration_20_21())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/di/NetworkModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/NetworkModule.kt
@@ -8,6 +8,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.simple.clinic.BuildConfig
 import org.simple.clinic.analytics.NetworkAnalyticsInterceptor
+import org.simple.clinic.overdue.AppointmentCancelReason
 import org.simple.clinic.patient.PatientSummaryResult
 import org.simple.clinic.user.LoggedInUserHttpInterceptor
 import org.simple.clinic.util.InstantMoshiAdapter
@@ -30,6 +31,7 @@ open class NetworkModule {
         .add(UuidMoshiAdapter())
         .add(MoshiOptionalAdapterFactory())
         .add(patientSummaryResultAdapterFactory())
+        .add(AppointmentCancelReason.MoshiTypeConverter())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentEvents.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentEvents.kt
@@ -1,6 +1,6 @@
 package org.simple.clinic.home.overdue.removepatient
 
-import org.simple.clinic.overdue.Appointment
+import org.simple.clinic.overdue.AppointmentCancelReason
 import org.simple.clinic.widgets.UiEvent
 import java.util.UUID
 
@@ -18,6 +18,6 @@ data class PatientDeadClicked(val patientUuid: UUID) : UiEvent {
   override val analyticsName = "Remove Appointment with Reason:Reason changed to Patient Dead"
 }
 
-data class CancelReasonClicked(val selectedReason: Appointment.CancelReason) : UiEvent {
+data class CancelReasonClicked(val selectedReason: AppointmentCancelReason) : UiEvent {
   override val analyticsName = "Remove Appointment with Reason:Reason changed to $selectedReason"
 }

--- a/app/src/main/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentSheet.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentSheet.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.home.overdue.removepatient
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -12,9 +13,9 @@ import io.reactivex.subjects.PublishSubject
 import kotterknife.bindView
 import org.simple.clinic.R
 import org.simple.clinic.activity.TheActivity
-import org.simple.clinic.overdue.Appointment.CancelReason.MOVED
-import org.simple.clinic.overdue.Appointment.CancelReason.OTHER
-import org.simple.clinic.overdue.Appointment.CancelReason.PATIENT_NOT_RESPONDING
+import org.simple.clinic.overdue.AppointmentCancelReason.Moved
+import org.simple.clinic.overdue.AppointmentCancelReason.Other
+import org.simple.clinic.overdue.AppointmentCancelReason.PatientNotResponding
 import org.simple.clinic.widgets.BottomSheetActivity
 import org.simple.clinic.widgets.PrimarySolidButton
 import org.simple.clinic.widgets.UiEvent
@@ -45,6 +46,7 @@ class RemoveAppointmentSheet : BottomSheetActivity() {
 
   private val onDestroys = PublishSubject.create<Any>()
 
+  @SuppressLint("CheckResult")
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
@@ -60,22 +62,29 @@ class RemoveAppointmentSheet : BottomSheetActivity() {
   }
 
   private fun sheetCreates(): Observable<UiEvent> {
-    val appointmentUuid = intent.extras.getSerializable(KEY_APPOINTMENT_UUID) as UUID
+    val appointmentUuid = intent.extras!!.getSerializable(KEY_APPOINTMENT_UUID) as UUID
     return Observable.just(RemoveAppointmentSheetCreated(appointmentUuid))
   }
 
-  private fun doneClicks(): Observable<UiEvent> = RxView.clicks(reasonSelectedDoneButton).map { RemoveReasonDoneClicked }
+  private fun doneClicks() =
+      RxView
+          .clicks(reasonSelectedDoneButton)
+          .map { RemoveReasonDoneClicked }
 
-  private fun alreadyVisitedClicks() = RxView.clicks(alreadyVisitedRadioButton).map { AlreadyVisitedReasonClicked }
+  private fun alreadyVisitedClicks() =
+      RxView
+          .clicks(alreadyVisitedRadioButton)
+          .map { AlreadyVisitedReasonClicked }
 
-  private fun patientDiedClicks() = RxView.clicks(diedRadioButton).map {
-    PatientDeadClicked(patientUuid = intent.extras.getSerializable(KEY_PATIENT_UUID) as UUID)
-  }
+  private fun patientDiedClicks() =
+      RxView
+          .clicks(diedRadioButton)
+          .map { PatientDeadClicked(patientUuid = intent.extras!!.getSerializable(KEY_PATIENT_UUID) as UUID) }
 
   private fun cancelReasonClicks(): Observable<UiEvent> {
-    val movedOutStream = RxView.clicks(movedOutRadioButton).map { CancelReasonClicked(MOVED) }
-    val notRespondingStream = RxView.clicks(notRespondingRadioButton).map { CancelReasonClicked(PATIENT_NOT_RESPONDING) }
-    val otherStream = RxView.clicks(otherReasonRadioButton).map { CancelReasonClicked(OTHER) }
+    val movedOutStream = RxView.clicks(movedOutRadioButton).map { CancelReasonClicked(Moved) }
+    val notRespondingStream = RxView.clicks(notRespondingRadioButton).map { CancelReasonClicked(PatientNotResponding) }
+    val otherStream = RxView.clicks(otherReasonRadioButton).map { CancelReasonClicked(Other) }
 
     return Observable.merge(movedOutStream, notRespondingStream, otherStream)
   }

--- a/app/src/main/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentSheetController.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentSheetController.kt
@@ -6,7 +6,7 @@ import io.reactivex.ObservableTransformer
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.rxkotlin.withLatestFrom
 import org.simple.clinic.ReportAnalyticsEvents
-import org.simple.clinic.overdue.Appointment.CancelReason.DEAD
+import org.simple.clinic.overdue.AppointmentCancelReason.Dead
 import org.simple.clinic.overdue.AppointmentRepository
 import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.widgets.UiEvent
@@ -64,7 +64,7 @@ class RemoveAppointmentSheetController @Inject constructor(
         .filter { (_, _, reason) -> reason is PatientDeadClicked }
         .flatMap { (_, uuid, reason) ->
           patientRepository.updatePatientStatusToDead((reason as PatientDeadClicked).patientUuid)
-              .andThen(appointmentRepository.cancelWithReason(uuid, DEAD))
+              .andThen(appointmentRepository.cancelWithReason(uuid, Dead))
               .andThen(Observable.just { ui: Ui -> ui.closeSheet() })
         }
 

--- a/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
@@ -21,7 +21,7 @@ data class Appointment(
     val facilityUuid: UUID,
     val scheduledDate: LocalDate,
     val status: Status,
-    val cancelReason: CancelReason?,
+    val cancelReason: AppointmentCancelReason?,
     val remindOn: LocalDate?,
     val agreedToVisit: Boolean?,
     val syncStatus: SyncStatus,
@@ -41,23 +41,6 @@ data class Appointment(
     VISITED;
 
     class RoomTypeConverter : RoomEnumTypeConverter<Status>(Status::class.java)
-  }
-
-  enum class CancelReason {
-
-    @Json(name = "not_responding")
-    PATIENT_NOT_RESPONDING,
-
-    @Json(name = "moved")
-    MOVED,
-
-    @Json(name = "dead")
-    DEAD,
-
-    @Json(name = "other")
-    OTHER;
-
-    class RoomTypeConverter : RoomEnumTypeConverter<CancelReason>(CancelReason::class.java)
   }
 
   @Dao
@@ -134,7 +117,7 @@ data class Appointment(
     """)
     fun cancelWithReason(
         appointmentUuid: UUID,
-        cancelReason: CancelReason,
+        cancelReason: AppointmentCancelReason,
         newStatus: Status,
         newSyncStatus: SyncStatus,
         newUpdatedAt: Instant

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentCancelReason.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentCancelReason.kt
@@ -1,0 +1,94 @@
+package org.simple.clinic.overdue
+
+import android.arch.persistence.room.TypeConverter
+import android.support.annotation.VisibleForTesting
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+
+sealed class AppointmentCancelReason {
+
+  /**
+   * A human-readable string that can be printed when, say a reason is logged to analytics.
+   * Unlike enums, calling toString() on sealed classes will print their fully qualified name
+   * (e.g., org.simple.clinic.overdue.AppointmentCancelReason$Moved@6aceb1a5), which is not
+   * very readable.
+   */
+  abstract override fun toString(): String
+
+  object PatientNotResponding : AppointmentCancelReason() {
+    override fun toString() = "PatientNotResponding"
+  }
+
+  object Moved : AppointmentCancelReason() {
+    override fun toString() = "Moved"
+  }
+
+  object Dead : AppointmentCancelReason() {
+    override fun toString() = "Dead"
+  }
+
+  object Other : AppointmentCancelReason() {
+    override fun toString() = "Other"
+  }
+
+  data class Unknown(val actualValue: String) : AppointmentCancelReason() {
+    override fun toString() = "Unknown ($actualValue)"
+  }
+
+  /**
+   * It'll be nice to write a code generator instead of hand-typing
+   * and manually maintaining this adapter in the future.
+   */
+  object TypeAdapter {
+
+    val KNOWN_MAPPINGS = mapOf(
+        PatientNotResponding to "not_responding",
+        Moved to "moved",
+        Dead to "dead",
+        Other to "other")
+
+    fun toEnum(reason: String?): AppointmentCancelReason? {
+      if (reason == null) {
+        return null
+      }
+
+      val foundEnum = KNOWN_MAPPINGS.entries
+          .find { (_, jsonKey) -> jsonKey == reason }
+          ?.key
+      return foundEnum ?: Unknown(actualValue = reason)
+    }
+
+    fun fromEnum(reason: AppointmentCancelReason?): String? {
+      if (reason == null) {
+        return null
+      }
+
+      return if (reason is Unknown) {
+        reason.actualValue
+      } else {
+        KNOWN_MAPPINGS[reason] ?: throw AssertionError("Unknown reason enum: $reason")
+      }
+    }
+  }
+
+  class MoshiTypeConverter {
+    @FromJson
+    fun toEnum(reason: String?): AppointmentCancelReason? = TypeAdapter.toEnum(reason)
+
+    @ToJson
+    fun fromEnum(reason: AppointmentCancelReason?): String? = TypeAdapter.fromEnum(reason)
+  }
+
+  class RoomTypeConverter {
+    @TypeConverter
+    fun toEnum(reason: String?): AppointmentCancelReason? = TypeAdapter.toEnum(reason)
+
+    @TypeConverter
+    fun fromEnum(reason: AppointmentCancelReason?): String? = TypeAdapter.fromEnum(reason)
+  }
+
+  companion object {
+    @VisibleForTesting
+    fun random() = TypeAdapter.KNOWN_MAPPINGS.entries.shuffled().first().key
+  }
+}

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentPayload.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentPayload.kt
@@ -25,7 +25,7 @@ data class AppointmentPayload(
     val status: Appointment.Status,
 
     @Json(name = "cancel_reason")
-    val cancelReason: Appointment.CancelReason?,
+    val cancelReason: AppointmentCancelReason?,
 
     @Json(name = "remind_on")
     val remindOn: LocalDate?,

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
@@ -93,7 +93,7 @@ class AppointmentRepository @Inject constructor(
     }
   }
 
-  fun cancelWithReason(appointmentUuid: UUID, reason: Appointment.CancelReason): Completable {
+  fun cancelWithReason(appointmentUuid: UUID, reason: AppointmentCancelReason): Completable {
     return Completable.fromAction {
       appointmentDao.cancelWithReason(
           appointmentUuid = appointmentUuid,

--- a/app/src/main/java/org/simple/clinic/storage/Migration_20_21.kt
+++ b/app/src/main/java/org/simple/clinic/storage/Migration_20_21.kt
@@ -1,0 +1,36 @@
+package org.simple.clinic.storage
+
+import android.arch.persistence.db.SupportSQLiteDatabase
+import android.arch.persistence.room.migration.Migration
+
+@Suppress("ClassName")
+class Migration_20_21 : Migration(20, 21) {
+
+  override fun migrate(database: SupportSQLiteDatabase) {
+    database.inTransaction {
+      database.execSQL("""
+        UPDATE "Appointment"
+        SET "cancelReason" = 'not_responding'
+        WHERE "cancelReason" = 'PATIENT_NOT_RESPONDING'
+      """)
+
+      database.execSQL("""
+        UPDATE "Appointment"
+        SET "cancelReason" = 'moved'
+        WHERE "cancelReason" = 'MOVED'
+      """)
+
+      database.execSQL("""
+        UPDATE "Appointment"
+        SET "cancelReason" = 'dead'
+        WHERE "cancelReason" = 'DEAD'
+      """)
+
+      database.execSQL("""
+        UPDATE "Appointment"
+        SET "cancelReason" = 'other'
+        WHERE "cancelReason" = 'OTHER'
+      """)
+    }
+  }
+}

--- a/app/src/test/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentSheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentSheetControllerTest.kt
@@ -11,10 +11,10 @@ import io.reactivex.Completable
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
 import org.junit.Test
-import org.simple.clinic.overdue.Appointment.CancelReason.DEAD
-import org.simple.clinic.overdue.Appointment.CancelReason.MOVED
-import org.simple.clinic.overdue.Appointment.CancelReason.OTHER
-import org.simple.clinic.overdue.Appointment.CancelReason.PATIENT_NOT_RESPONDING
+import org.simple.clinic.overdue.AppointmentCancelReason.Dead
+import org.simple.clinic.overdue.AppointmentCancelReason.Moved
+import org.simple.clinic.overdue.AppointmentCancelReason.Other
+import org.simple.clinic.overdue.AppointmentCancelReason.PatientNotResponding
 import org.simple.clinic.overdue.AppointmentRepository
 import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.widgets.UiEvent
@@ -55,10 +55,10 @@ class RemoveAppointmentSheetControllerTest {
 
     uiEvents.onNext(RemoveAppointmentSheetCreated(appointmentUuid))
     uiEvents.onNext(RemoveReasonDoneClicked)
-    uiEvents.onNext(CancelReasonClicked(DEAD))
+    uiEvents.onNext(CancelReasonClicked(Dead))
     uiEvents.onNext(AlreadyVisitedReasonClicked)
-    uiEvents.onNext(CancelReasonClicked(PATIENT_NOT_RESPONDING))
-    uiEvents.onNext(CancelReasonClicked(OTHER))
+    uiEvents.onNext(CancelReasonClicked(PatientNotResponding))
+    uiEvents.onNext(CancelReasonClicked(Other))
     uiEvents.onNext(AlreadyVisitedReasonClicked)
     uiEvents.onNext(RemoveReasonDoneClicked)
 
@@ -72,14 +72,14 @@ class RemoveAppointmentSheetControllerTest {
 
   @Test
   fun `when done is clicked, and reason is "Patient dead", then patient repository should be updated`(){
-    whenever(repository.cancelWithReason(appointmentUuid, DEAD)).thenReturn(Completable.complete())
+    whenever(repository.cancelWithReason(appointmentUuid, Dead)).thenReturn(Completable.complete())
     val patientUuid = UUID.randomUUID()
     whenever(patientRepository.updatePatientStatusToDead(patientUuid)).thenReturn(Completable.complete())
 
     uiEvents.onNext(RemoveAppointmentSheetCreated(appointmentUuid))
     uiEvents.onNext(AlreadyVisitedReasonClicked)
-    uiEvents.onNext(CancelReasonClicked(PATIENT_NOT_RESPONDING))
-    uiEvents.onNext(CancelReasonClicked(DEAD))
+    uiEvents.onNext(CancelReasonClicked(PatientNotResponding))
+    uiEvents.onNext(CancelReasonClicked(Dead))
     uiEvents.onNext(PatientDeadClicked(patientUuid))
     uiEvents.onNext(RemoveReasonDoneClicked)
 
@@ -88,27 +88,27 @@ class RemoveAppointmentSheetControllerTest {
     val inOrder = inOrder(sheet, repository, patientRepository)
     inOrder.verify(sheet, times(4)).enableDoneButton()
     inOrder.verify(patientRepository).updatePatientStatusToDead(patientUuid)
-    inOrder.verify(repository).cancelWithReason(appointmentUuid, DEAD)
+    inOrder.verify(repository).cancelWithReason(appointmentUuid, Dead)
     inOrder.verify(sheet).closeSheet()
   }
 
   @Test
   fun `when done is clicked, and a cancel reason is selected, then repository should update and sheet should close`() {
-    whenever(repository.cancelWithReason(appointmentUuid, MOVED)).thenReturn(Completable.complete())
+    whenever(repository.cancelWithReason(appointmentUuid, Moved)).thenReturn(Completable.complete())
 
     uiEvents.onNext(RemoveAppointmentSheetCreated(appointmentUuid))
     uiEvents.onNext(RemoveReasonDoneClicked)
     uiEvents.onNext(AlreadyVisitedReasonClicked)
-    uiEvents.onNext(CancelReasonClicked(PATIENT_NOT_RESPONDING))
+    uiEvents.onNext(CancelReasonClicked(PatientNotResponding))
     uiEvents.onNext(AlreadyVisitedReasonClicked)
-    uiEvents.onNext(CancelReasonClicked(MOVED))
+    uiEvents.onNext(CancelReasonClicked(Moved))
     uiEvents.onNext(RemoveReasonDoneClicked)
 
     verify(repository, never()).markAsAlreadyVisited(any())
 
     val inOrder = inOrder(sheet, repository)
     inOrder.verify(sheet, times(4)).enableDoneButton()
-    inOrder.verify(repository).cancelWithReason(appointmentUuid, MOVED)
+    inOrder.verify(repository).cancelWithReason(appointmentUuid, Moved)
     inOrder.verify(sheet).closeSheet()
   }
 }

--- a/app/src/test/java/org/simple/clinic/overdue/AppointmentCancelReasonTypeAdapterTest.kt
+++ b/app/src/test/java/org/simple/clinic/overdue/AppointmentCancelReasonTypeAdapterTest.kt
@@ -1,0 +1,68 @@
+package org.simple.clinic.overdue
+
+import com.google.common.truth.Truth.assertThat
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(JUnitParamsRunner::class)
+class AppointmentCancelReasonTypeAdapterTest {
+
+  @Test
+  @Parameters(method = "reason types to json keys")
+  fun `reason types should be correctly serialized to their json keys`(
+      reason: AppointmentCancelReason,
+      expectedJsonKey: String
+  ) {
+    val serialized = AppointmentCancelReason.TypeAdapter.fromEnum(reason)
+    assertThat(serialized).isEqualTo(expectedJsonKey)
+  }
+
+  @Suppress("unused")
+  fun `reason types to json keys`(): List<List<Any>> {
+    return listOf(
+        listOf(AppointmentCancelReason.PatientNotResponding, "not_responding"),
+        listOf(AppointmentCancelReason.Moved, "moved"),
+        listOf(AppointmentCancelReason.Dead, "dead"),
+        listOf(AppointmentCancelReason.Other, "other")
+    )
+  }
+
+  @Test
+  @Parameters(method = "json keys to reason types")
+  fun `reason types should be correctly deserialized from their json keys`(
+      jsonKey: String,
+      expectedReason: AppointmentCancelReason
+  ) {
+    val deserialized = AppointmentCancelReason.TypeAdapter.toEnum(jsonKey)
+    assertThat(deserialized).isEqualTo(expectedReason)
+  }
+
+  @Suppress("unused")
+  fun `json keys to reason types`(): List<List<Any>> {
+    return listOf(
+        listOf("not_responding", AppointmentCancelReason.PatientNotResponding),
+        listOf("moved", AppointmentCancelReason.Moved),
+        listOf("dead", AppointmentCancelReason.Dead),
+        listOf("other", AppointmentCancelReason.Other)
+    )
+  }
+
+  @Test
+  @Parameters("abducted_by_joker", "disapparated_in_hogwarts")
+  fun `unknown reason enum should be serialized to its actual value`(reason: String) {
+    val unknownReason = AppointmentCancelReason.Unknown(actualValue = reason)
+    val serialized = AppointmentCancelReason.TypeAdapter.fromEnum(unknownReason)
+
+    assertThat(serialized).isEqualTo(unknownReason.actualValue)
+  }
+
+  @Test
+  fun `unknown reason strings should be deserialized correctly`() {
+    val unknownReasonString = "abducted_by_joker"
+    val deserialized = AppointmentCancelReason.TypeAdapter.toEnum(unknownReasonString)
+
+    assertThat(deserialized).isEqualTo(AppointmentCancelReason.Unknown(actualValue = unknownReasonString))
+  }
+}

--- a/app/src/test/java/org/simple/clinic/patient/PatientMocker.kt
+++ b/app/src/test/java/org/simple/clinic/patient/PatientMocker.kt
@@ -10,6 +10,7 @@ import org.simple.clinic.medicalhistory.MedicalHistory.Answer
 import org.simple.clinic.medicalhistory.MedicalHistory.Answer.NO
 import org.simple.clinic.medicalhistory.MedicalHistory.Answer.YES
 import org.simple.clinic.overdue.Appointment
+import org.simple.clinic.overdue.AppointmentCancelReason
 import org.simple.clinic.protocol.ProtocolDrug
 import org.simple.clinic.user.LoggedInUserPayload
 import org.simple.clinic.user.User
@@ -161,7 +162,7 @@ object PatientMocker {
       scheduledDate: LocalDate = LocalDate.now(UTC),
       facilityUuid: UUID = UUID.randomUUID(),
       status: Appointment.Status = Appointment.Status.SCHEDULED,
-      cancelReason: Appointment.CancelReason = Appointment.CancelReason.PATIENT_NOT_RESPONDING,
+      cancelReason: AppointmentCancelReason = AppointmentCancelReason.PatientNotResponding,
       syncStatus: SyncStatus = SyncStatus.PENDING,
       agreedToVisit: Boolean? = null,
       remindOn: LocalDate? = LocalDate.now(UTC).minusDays(2),


### PR DESCRIPTION
Enums are great for representing constants as they offer a type-safe API for usage, but blow-up when unknown strings are received from the server. Our JSON library, Moshi, provides a way to use a default enum as a fallback for unknown strings, but that results in the original string getting lost. When the enum has to be sent back to the server during our two way sync, there's no way to retrieve the actual value.

This commit replaces enums with sealed classes for storing Appointment cancellation reasons. The conversion of cancellation reason strings <-> sealed classes happen only when they're being read, allowing us to store the strings received from the server as-is. The usages also get to keep their type-safe API. Kotlin FTW!