### PR TITLE
Catch uncaught RxJava errors in unit tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -146,7 +146,7 @@ android {
 dependencies {
   implementation project(path: ':router')
 
-  testImplementation "junit:junit:$versions.junit"
+  implementation "junit:junit:$versions.junit"
   testImplementation "org.mockito:mockito-core:$versions.mockito"
   testImplementation "com.nhaarman:mockito-kotlin:$versions.mockitoKotlin"
   testImplementation "pl.pragmatists:JUnitParams:$versions.junitParams"

--- a/app/src/androidTest/java/org/simple/clinic/MigrationAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/MigrationAndroidTest.kt
@@ -39,12 +39,10 @@ import java.util.UUID
 @RunWith(AndroidJUnit4::class)
 class MigrationAndroidTest {
 
-  @Rule
-  @JvmField
+  @get:Rule
   val helper = MigrationTestHelperWithForeignConstraints()
 
-  @Rule
-  @JvmField
+  @get:Rule
   val expectedException = ExpectedException.none()
 
   @Test

--- a/app/src/androidTest/java/org/simple/clinic/bp/BloodPressureRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/bp/BloodPressureRepositoryAndroidTest.kt
@@ -6,11 +6,13 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AuthenticationRule
 import org.simple.clinic.TestClinicApp
 import org.simple.clinic.TestData
 import org.simple.clinic.patient.SyncStatus
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestClock
 import org.threeten.bp.Clock
 import org.threeten.bp.Duration
@@ -34,8 +36,14 @@ class BloodPressureRepositoryAndroidTest {
   @Inject
   lateinit var testData: TestData
 
+  private val authenticationRule = AuthenticationRule()
+
+  private val rxErrorsRule = RxErrorsRule()
+
   @get:Rule
-  val authenticationRule = AuthenticationRule()
+  val ruleChain = RuleChain
+      .outerRule(authenticationRule)
+      .around(rxErrorsRule)!!
 
   val testClock: TestClock
     get() = clock as TestClock

--- a/app/src/androidTest/java/org/simple/clinic/bp/sync/BloodPressureSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/bp/sync/BloodPressureSyncAndroidTest.kt
@@ -4,6 +4,7 @@ import android.support.test.runner.AndroidJUnit4
 import com.f2prateek.rx.preferences2.Preference
 import org.junit.Before
 import org.junit.Rule
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AuthenticationRule
 import org.simple.clinic.TestClinicApp
@@ -13,6 +14,7 @@ import org.simple.clinic.bp.BloodPressureRepository
 import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.sync.BaseSyncCoordinatorAndroidTest
 import org.simple.clinic.util.Optional
+import org.simple.clinic.util.RxErrorsRule
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -35,8 +37,14 @@ class BloodPressureSyncAndroidTest : BaseSyncCoordinatorAndroidTest<BloodPressur
   @Inject
   lateinit var testData: TestData
 
+  private val authenticationRule = AuthenticationRule()
+
+  private val rxErrorsRule = RxErrorsRule()
+
   @get:Rule
-  val authenticationRule = AuthenticationRule()
+  val ruleChain = RuleChain
+      .outerRule(authenticationRule)
+      .around(rxErrorsRule)!!
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/org/simple/clinic/drugs/PrescriptionRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/drugs/PrescriptionRepositoryAndroidTest.kt
@@ -6,20 +6,15 @@ import io.bloco.faker.Faker
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.AuthenticationRule
 import org.simple.clinic.TestClinicApp
 import org.simple.clinic.TestData
-import org.simple.clinic.patient.Gender
-import org.simple.clinic.patient.Patient
-import org.simple.clinic.patient.PatientAddress
-import org.simple.clinic.patient.PatientStatus
 import org.simple.clinic.patient.SyncStatus
-import org.simple.clinic.protocol.ProtocolDrug
 import org.simple.clinic.user.UserSession
-import org.threeten.bp.Instant
-import org.threeten.bp.LocalDate
+import org.simple.clinic.util.RxErrorsRule
 import java.util.UUID
 import javax.inject.Inject
 
@@ -41,8 +36,14 @@ class PrescriptionRepositoryAndroidTest {
   @Inject
   lateinit var testData: TestData
 
+  private val authenticationRule = AuthenticationRule()
+
+  private val rxErrorsRule = RxErrorsRule()
+
   @get:Rule
-  val authenticationRule = AuthenticationRule()
+  val ruleChain = RuleChain
+      .outerRule(authenticationRule)
+      .around(rxErrorsRule)!!
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/org/simple/clinic/drugs/sync/PrescriptionSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/drugs/sync/PrescriptionSyncAndroidTest.kt
@@ -7,7 +7,6 @@ import org.junit.Rule
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AuthenticationRule
-import org.simple.clinic.sync.RegisterPatientRule
 import org.simple.clinic.TestClinicApp
 import org.simple.clinic.TestData
 import org.simple.clinic.drugs.PrescribedDrug
@@ -15,9 +14,11 @@ import org.simple.clinic.drugs.PrescriptionRepository
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.sync.BaseSyncCoordinatorAndroidTest
+import org.simple.clinic.sync.RegisterPatientRule
 import org.simple.clinic.user.User
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.Optional
+import org.simple.clinic.util.RxErrorsRule
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Named
@@ -47,20 +48,23 @@ class PrescriptionSyncAndroidTest : BaseSyncCoordinatorAndroidTest<PrescribedDru
   @Inject
   lateinit var facilityRepository: FacilityRepository
 
-  val user: User
+  private val user: User
     get() = userSession.loggedInUserImmediate()!!
 
-  val currentFacilityUuid: UUID
+  private val currentFacilityUuid: UUID
     get() = facilityRepository.currentFacilityUuid(user)!!
 
-  val authenticationRule = AuthenticationRule()
+  private val authenticationRule = AuthenticationRule()
 
-  val registerPatientRule = RegisterPatientRule(UUID.randomUUID())
+  private val registerPatientRule = RegisterPatientRule(UUID.randomUUID())
+
+  private val rxErrorsRule = RxErrorsRule()
 
   @get:Rule
   val ruleChain = RuleChain
       .outerRule(authenticationRule)
-      .around(registerPatientRule)!!
+      .around(registerPatientRule)
+      .around(rxErrorsRule)!!
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/org/simple/clinic/facility/FacilityRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/facility/FacilityRepositoryAndroidTest.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.facility
 import android.support.test.runner.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.AppDatabase
@@ -10,6 +11,7 @@ import org.simple.clinic.TestClinicApp
 import org.simple.clinic.TestData
 import org.simple.clinic.user.LoggedInUserFacilityMapping
 import org.simple.clinic.user.User
+import org.simple.clinic.util.RxErrorsRule
 import java.util.UUID
 import javax.inject.Inject
 
@@ -30,6 +32,9 @@ class FacilityRepositoryAndroidTest {
 
   @Inject
   lateinit var mappingDao: LoggedInUserFacilityMapping.RoomDao
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private lateinit var user: User
 

--- a/app/src/androidTest/java/org/simple/clinic/facility/FacilitySyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/facility/FacilitySyncAndroidTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.AuthenticationRule
@@ -15,6 +16,7 @@ import org.simple.clinic.sync.BaseSyncCoordinatorAndroidTest
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
+import org.simple.clinic.util.RxErrorsRule
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -49,8 +51,14 @@ class FacilitySyncAndroidTest {
   @Inject
   lateinit var testData: TestData
 
+  private val authenticationRule = AuthenticationRule()
+
+  private val rxErrorsRule = RxErrorsRule()
+
   @get:Rule
-  val authenticationRule = AuthenticationRule()
+  val ruleChain = RuleChain
+      .outerRule(authenticationRule)
+      .around(rxErrorsRule)!!
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/org/simple/clinic/medicalhistory/MedicalHistoryRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/medicalhistory/MedicalHistoryRepositoryAndroidTest.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.medicalhistory
 import com.google.common.truth.Truth.assertThat
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.TestClinicApp
 import org.simple.clinic.TestData
@@ -10,6 +11,7 @@ import org.simple.clinic.medicalhistory.MedicalHistory.Answer.NO
 import org.simple.clinic.medicalhistory.MedicalHistory.Answer.UNKNOWN
 import org.simple.clinic.medicalhistory.MedicalHistory.Answer.YES
 import org.simple.clinic.patient.SyncStatus
+import org.simple.clinic.util.RxErrorsRule
 import org.threeten.bp.Clock
 import org.threeten.bp.Instant
 import org.threeten.bp.temporal.ChronoUnit.DAYS
@@ -29,6 +31,9 @@ class MedicalHistoryRepositoryAndroidTest {
 
   @Inject
   lateinit var clock: Clock
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   @Before
   fun setup() {

--- a/app/src/androidTest/java/org/simple/clinic/medicalhistory/MedicalHistorySyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/medicalhistory/MedicalHistorySyncAndroidTest.kt
@@ -8,7 +8,6 @@ import org.junit.Rule
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AuthenticationRule
-import org.simple.clinic.sync.RegisterPatientRule
 import org.simple.clinic.TestClinicApp
 import org.simple.clinic.TestData
 import org.simple.clinic.medicalhistory.sync.MedicalHistoryPayload
@@ -18,7 +17,9 @@ import org.simple.clinic.medicalhistory.sync.MedicalHistorySyncApiV2
 import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.sync.BaseSyncCoordinatorAndroidTest
 import org.simple.clinic.sync.DataPushResponse
+import org.simple.clinic.sync.RegisterPatientRule
 import org.simple.clinic.util.Optional
+import org.simple.clinic.util.RxErrorsRule
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Named
@@ -42,14 +43,17 @@ class MedicalHistorySyncAndroidTest : BaseSyncCoordinatorAndroidTest<MedicalHist
   @Inject
   lateinit var testData: TestData
 
-  val authenticationRule = AuthenticationRule()
+  private val authenticationRule = AuthenticationRule()
 
-  val registerPatientRule = RegisterPatientRule(patientUuid = UUID.randomUUID())
+  private val rxErrorsRule = RxErrorsRule()
+
+  private val registerPatientRule = RegisterPatientRule(patientUuid = UUID.randomUUID())
 
   @get:Rule
   val ruleChain = RuleChain
       .outerRule(authenticationRule)
       .around(registerPatientRule)
+      .around(rxErrorsRule)!!
 
   @Before
   fun setup() {

--- a/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentRepositoryAndroidTest.kt
@@ -7,6 +7,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.AuthenticationRule
@@ -37,6 +38,7 @@ import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.patient.PatientStatus
 import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestClock
 import org.threeten.bp.Clock
 import org.threeten.bp.Duration
@@ -79,8 +81,14 @@ class AppointmentRepositoryAndroidTest {
   private val testClock: TestClock
     get() = clock as TestClock
 
+  private val authenticationRule = AuthenticationRule()
+
+  private val rxErrorsRule = RxErrorsRule()
+
   @get:Rule
-  val authenticationRule = AuthenticationRule()
+  val ruleChain = RuleChain
+      .outerRule(authenticationRule)
+      .around(rxErrorsRule)!!
 
   @Before
   fun setup() {

--- a/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentSyncAndroidTest.kt
@@ -5,6 +5,7 @@ import com.f2prateek.rx.preferences2.Preference
 import io.reactivex.Single
 import org.junit.Before
 import org.junit.Rule
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AuthenticationRule
 import org.simple.clinic.TestClinicApp
@@ -13,6 +14,7 @@ import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.sync.BaseSyncCoordinatorAndroidTest
 import org.simple.clinic.sync.DataPushResponse
 import org.simple.clinic.util.Optional
+import org.simple.clinic.util.RxErrorsRule
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -44,8 +46,14 @@ class AppointmentSyncAndroidTest : BaseSyncCoordinatorAndroidTest<Appointment, A
   val config: AppointmentConfig
     get() = appointmentConfigProvider.blockingGet()
 
+  private val authenticationRule = AuthenticationRule()
+
+  private val rxErrorsRule = RxErrorsRule()
+
   @get:Rule
-  val authenticationRule = AuthenticationRule()
+  val ruleChain = RuleChain
+      .outerRule(authenticationRule)
+      .around(rxErrorsRule)!!
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/org/simple/clinic/overdue/communication/CommunicationRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/overdue/communication/CommunicationRepositoryAndroidTest.kt
@@ -5,12 +5,14 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AuthenticationRule
 import org.simple.clinic.TestClinicApp
 import org.simple.clinic.TestData
 import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import java.util.UUID
 import javax.inject.Inject
 
@@ -26,8 +28,14 @@ class CommunicationRepositoryAndroidTest {
   @Inject
   lateinit var testData: TestData
 
+  private val authenticationRule = AuthenticationRule()
+
+  private val rxErrorsRule = RxErrorsRule()
+
   @get:Rule
-  val authenticationRule = AuthenticationRule()
+  val ruleChain = RuleChain
+      .outerRule(authenticationRule)
+      .around(rxErrorsRule)!!
 
   @Before
   fun setup() {

--- a/app/src/androidTest/java/org/simple/clinic/overdue/communication/CommunicationSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/overdue/communication/CommunicationSyncAndroidTest.kt
@@ -5,6 +5,7 @@ import com.f2prateek.rx.preferences2.Preference
 import io.reactivex.Single
 import org.junit.Before
 import org.junit.Rule
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AuthenticationRule
 import org.simple.clinic.TestClinicApp
@@ -17,6 +18,7 @@ import org.simple.clinic.sync.BaseSyncCoordinatorAndroidTest
 import org.simple.clinic.sync.DataPushResponse
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.Optional
+import org.simple.clinic.util.RxErrorsRule
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Named
@@ -49,8 +51,14 @@ class CommunicationSyncAndroidTest : BaseSyncCoordinatorAndroidTest<Communicatio
   @Inject
   lateinit var appointmentSyncApi: AppointmentSyncApiV2
 
+  private val authenticationRule = AuthenticationRule()
+
+  private val rxErrorsRule = RxErrorsRule()
+
   @get:Rule
-  val authenticationRule = AuthenticationRule()
+  val ruleChain = RuleChain
+      .outerRule(authenticationRule)
+      .around(rxErrorsRule)!!
 
   val appointmentUuid = UUID.randomUUID()
 

--- a/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
@@ -10,6 +10,7 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.AuthenticationRule
 import org.simple.clinic.TestClinicApp
@@ -21,6 +22,7 @@ import org.simple.clinic.medicalhistory.MedicalHistoryRepository
 import org.simple.clinic.overdue.AppointmentRepository
 import org.simple.clinic.overdue.communication.CommunicationRepository
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestClock
 import org.simple.clinic.util.unwrapJust
 import org.threeten.bp.Clock
@@ -53,12 +55,6 @@ class PatientRepositoryAndroidTest {
   @Inject
   lateinit var database: AppDatabase
 
-  @get:Rule
-  val authenticationRule = AuthenticationRule()
-
-  @get:Rule
-  val instantTaskExecutorRule = InstantTaskExecutorRule()
-
   @Inject
   lateinit var bpRepository: BloodPressureRepository
 
@@ -76,6 +72,18 @@ class PatientRepositoryAndroidTest {
 
   @Inject
   lateinit var configProvider: Single<PatientConfig>
+
+  private val authenticationRule = AuthenticationRule()
+
+  private val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+  private val rxErrorsRule = RxErrorsRule()
+
+  @get:Rule
+  val ruleChain = RuleChain
+      .outerRule(authenticationRule)
+      .around(instantTaskExecutorRule)
+      .around(rxErrorsRule)!!
 
   val config: PatientConfig
     get() = configProvider.blockingGet()

--- a/app/src/androidTest/java/org/simple/clinic/patient/PatientSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/patient/PatientSyncAndroidTest.kt
@@ -4,6 +4,7 @@ import android.support.test.runner.AndroidJUnit4
 import com.f2prateek.rx.preferences2.Preference
 import org.junit.Before
 import org.junit.Rule
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AuthenticationRule
 import org.simple.clinic.TestClinicApp
@@ -14,6 +15,7 @@ import org.simple.clinic.patient.sync.PatientSync
 import org.simple.clinic.patient.sync.PatientSyncApiV2
 import org.simple.clinic.sync.BaseSyncCoordinatorAndroidTest
 import org.simple.clinic.util.Optional
+import org.simple.clinic.util.RxErrorsRule
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -35,8 +37,15 @@ class PatientSyncAndroidTest : BaseSyncCoordinatorAndroidTest<PatientProfile, Pa
 
   @Inject
   lateinit var testData: TestData
+
+  private val authenticationRule = AuthenticationRule()
+
+  private val rxErrorsRule = RxErrorsRule()
+
   @get:Rule
-  val authenticationRule = AuthenticationRule()
+  val ruleChain = RuleChain
+      .outerRule(authenticationRule)
+      .around(rxErrorsRule)!!
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/org/simple/clinic/protocolv2/ProtocolRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/protocolv2/ProtocolRepositoryAndroidTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.AuthenticationRule
@@ -14,6 +15,7 @@ import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.protocol.ProtocolDrugAndDosages
 import org.simple.clinic.protocol.ProtocolRepository
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import java.util.UUID
 import javax.inject.Inject
 
@@ -35,8 +37,14 @@ class ProtocolRepositoryAndroidTest {
   @Inject
   lateinit var testData: TestData
 
+  private val authenticationRule = AuthenticationRule()
+
+  private val rxErrorsRule = RxErrorsRule()
+
   @get:Rule
-  val authenticationRule = AuthenticationRule()
+  val ruleChain = RuleChain
+      .outerRule(authenticationRule)
+      .around(rxErrorsRule)!!
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/org/simple/clinic/protocolv2/sync/ProtocolSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/protocolv2/sync/ProtocolSyncAndroidTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.AuthenticationRule
@@ -14,6 +15,7 @@ import org.simple.clinic.protocol.ProtocolRepository
 import org.simple.clinic.protocol.sync.ProtocolSync
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
+import org.simple.clinic.util.RxErrorsRule
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -33,8 +35,14 @@ class ProtocolSyncAndroidTest {
   @field:Named("last_protocol_pull_token")
   lateinit var lastPullToken: Preference<Optional<String>>
 
+  private val authenticationRule = AuthenticationRule()
+
+  private val rxErrorsRule = RxErrorsRule()
+
   @get:Rule
-  val authenticationRule = AuthenticationRule()
+  val ruleChain = RuleChain
+      .outerRule(authenticationRule)
+      .around(rxErrorsRule)!!
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/org/simple/clinic/security/pin/BruteForceProtectionAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/security/pin/BruteForceProtectionAndroidTest.kt
@@ -9,11 +9,13 @@ import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.schedulers.TestScheduler
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.TestClinicApp
 import org.simple.clinic.security.pin.BruteForceProtection.ProtectedState.Allowed
 import org.simple.clinic.security.pin.BruteForceProtection.ProtectedState.Blocked
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestClock
 import org.threeten.bp.Clock
 import org.threeten.bp.Duration
@@ -35,6 +37,9 @@ class BruteForceProtectionAndroidTest {
 
   @Inject
   lateinit var state: Preference<BruteForceProtectionState>
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val testClock
     get() = clock as TestClock

--- a/app/src/androidTest/java/org/simple/clinic/storage/DaoWithUpsertAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/storage/DaoWithUpsertAndroidTest.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.storage
 import com.google.common.truth.Truth.assertThat
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.TestClinicApp
@@ -11,6 +12,7 @@ import org.simple.clinic.patient.Gender.FEMALE
 import org.simple.clinic.patient.Gender.MALE
 import org.simple.clinic.patient.Patient
 import org.simple.clinic.patient.PatientAddress
+import org.simple.clinic.util.RxErrorsRule
 import java.util.UUID
 import javax.inject.Inject
 
@@ -21,6 +23,9 @@ class DaoWithUpsertAndroidTest {
 
   @Inject
   lateinit var testData: TestData
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/org/simple/clinic/user/OngoingLoginEntryRepositoryTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/user/OngoingLoginEntryRepositoryTest.kt
@@ -6,9 +6,11 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.TestClinicApp
+import org.simple.clinic.util.RxErrorsRule
 import java.util.UUID
 import javax.inject.Inject
 
@@ -21,9 +23,14 @@ class OngoingLoginEntryRepositoryTest {
   @Inject
   lateinit var database: AppDatabase
 
-  @Rule
-  @JvmField
-  val expectedException: ExpectedException = ExpectedException.none()
+  private val rxErrorsRule = RxErrorsRule()
+
+  private val expectedException = ExpectedException.none()
+
+  @get:Rule
+  val ruleChain = RuleChain
+      .outerRule(rxErrorsRule)
+      .around(expectedException)!!
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/org/simple/clinic/user/UserSessionAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/user/UserSessionAndroidTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.AuthenticationRule
@@ -20,6 +21,7 @@ import org.simple.clinic.registration.SaveUserLocallyResult
 import org.simple.clinic.user.User.LoggedInStatus.LOGGED_IN
 import org.simple.clinic.user.User.LoggedInStatus.NOT_LOGGED_IN
 import org.simple.clinic.user.User.LoggedInStatus.OTP_REQUESTED
+import org.simple.clinic.util.RxErrorsRule
 import java.util.UUID
 import javax.inject.Inject
 
@@ -41,8 +43,14 @@ class UserSessionAndroidTest {
   @Inject
   lateinit var facilityApi: FacilitySyncApiV2
 
+  private val authenticationRule = AuthenticationRule()
+
+  private val rxErrorsRule = RxErrorsRule()
+
   @get:Rule
-  val authenticationRule = AuthenticationRule()
+  val ruleChain = RuleChain
+      .outerRule(authenticationRule)
+      .around(rxErrorsRule)!!
 
   @Before
   fun setUp() {

--- a/app/src/main/java/org/simple/clinic/util/RxErrorsRule.kt
+++ b/app/src/main/java/org/simple/clinic/util/RxErrorsRule.kt
@@ -28,7 +28,7 @@ class RxErrorsRule : TestRule {
 
         try {
           base.evaluate()
-          
+
         } finally {
           RxJavaPlugins.setErrorHandler(null)
           assertNoErrors()

--- a/app/src/test/java/org/simple/clinic/ReportAnalyticsEventsTest.kt
+++ b/app/src/test/java/org/simple/clinic/ReportAnalyticsEventsTest.kt
@@ -4,13 +4,18 @@ import com.google.common.truth.Truth.assertThat
 import io.reactivex.subjects.PublishSubject
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.analytics.Analytics
 import org.simple.clinic.analytics.MockAnalyticsReporter
 import org.simple.clinic.analytics.MockAnalyticsReporter.Event
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 
 class ReportAnalyticsEventsTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private data class UiEvent1(val prop: String) : UiEvent {
     override val analyticsName = "UiEvent 1"

--- a/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
@@ -14,6 +14,7 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.forgotpin.createnewpin.ForgotPinCreateNewPinScreenKey
@@ -33,6 +34,7 @@ import org.simple.clinic.user.UserSession
 import org.simple.clinic.user.UserStatus
 import org.simple.clinic.util.Just
 import org.simple.clinic.util.None
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.TheActivityLifecycle
 import org.simple.clinic.widgets.UiEvent
 import org.threeten.bp.Instant
@@ -40,6 +42,9 @@ import java.util.concurrent.TimeUnit
 
 @RunWith(JUnitParamsRunner::class)
 class TheActivityControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val lockInMinutes = 15L
 

--- a/app/src/test/java/org/simple/clinic/bp/BloodPressureRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/BloodPressureRepositoryTest.kt
@@ -1,7 +1,6 @@
 package org.simple.clinic.bp
 
 import com.google.common.truth.Truth.assertThat
-import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.argThat
 import com.nhaarman.mockito_kotlin.check
 import com.nhaarman.mockito_kotlin.mock
@@ -12,19 +11,23 @@ import io.reactivex.Observable
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestClock
-import org.threeten.bp.Clock
 import org.threeten.bp.Instant
 import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
 class BloodPressureRepositoryTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val dao = mock<BloodPressureMeasurement.RoomDao>()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -13,18 +13,23 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.bp.BloodPressureConfig
 import org.simple.clinic.bp.BloodPressureMeasurement
 import org.simple.clinic.bp.BloodPressureRepository
 import org.simple.clinic.patient.PatientMocker
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 import org.threeten.bp.Instant
 import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
 class BloodPressureEntrySheetControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val sheet = mock<BloodPressureEntrySheet>()
   private val bloodPressureRepository = mock<BloodPressureRepository>()

--- a/app/src/test/java/org/simple/clinic/bp/entry/confirmremovebloodpressure/ConfirmRemoveBloodPressureDialogControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/confirmremovebloodpressure/ConfirmRemoveBloodPressureDialogControllerTest.kt
@@ -7,13 +7,18 @@ import io.reactivex.Completable
 import io.reactivex.Single
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.bp.BloodPressureRepository
 import org.simple.clinic.bp.entry.ConfirmRemoveBloodPressureDialog
 import org.simple.clinic.patient.PatientMocker
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 
 class ConfirmRemoveBloodPressureDialogControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   lateinit var bloodPressureRepository: BloodPressureRepository
   lateinit var controller: ConfirmRemoveBloodPressureDialogController

--- a/app/src/test/java/org/simple/clinic/drugs/PrescriptionRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/PrescriptionRepositoryTest.kt
@@ -10,6 +10,7 @@ import io.reactivex.Observable
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.AppDatabase
@@ -17,10 +18,14 @@ import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
 class PrescriptionRepositoryTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val database = mock<AppDatabase>()
   private val dao = mock<PrescribedDrug.RoomDao>()

--- a/app/src/test/java/org/simple/clinic/drugs/selection/PrescribedDrugsScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/PrescribedDrugsScreenControllerTest.kt
@@ -8,19 +8,24 @@ import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.drugs.PrescriptionRepository
-import org.simple.clinic.drugs.selection.ProtocolDrugSelectionListItem.*
+import org.simple.clinic.drugs.selection.ProtocolDrugSelectionListItem.DosageOption
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.protocol.ProtocolDrugAndDosages
 import org.simple.clinic.protocol.ProtocolRepository
 import org.simple.clinic.user.User
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 import java.util.UUID
 
 class PrescribedDrugsScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val screen = mock<PrescribedDrugsScreen>()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/drugs/selection/entry/CustomPrescriptionEntryControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/entry/CustomPrescriptionEntryControllerTest.kt
@@ -11,15 +11,20 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.drugs.PrescriptionRepository
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.nullIfBlank
 import org.simple.clinic.widgets.UiEvent
 import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
 class CustomPrescriptionEntryControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val sheet = mock<CustomPrescriptionEntrySheet>()
   private val prescriptionRepository = mock<PrescriptionRepository>()

--- a/app/src/test/java/org/simple/clinic/editpatient/PatientEditScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/PatientEditScreenControllerTest.kt
@@ -14,6 +14,7 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.editpatient.PatientEditValidationError.BOTH_DATEOFBIRTH_AND_AGE_ABSENT
@@ -45,6 +46,7 @@ import org.simple.clinic.registration.phone.PhoneNumberValidator.Result.LENGTH_T
 import org.simple.clinic.registration.phone.PhoneNumberValidator.Result.VALID
 import org.simple.clinic.util.Just
 import org.simple.clinic.util.None
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestClock
 import org.simple.clinic.util.toOptional
 import org.simple.clinic.widgets.UiEvent
@@ -62,6 +64,9 @@ import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
 class PatientEditScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val uiEvents = PublishSubject.create<UiEvent>()
   val clock: TestClock = TestClock()

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpScreenControllerTest.kt
@@ -13,6 +13,7 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
@@ -26,11 +27,15 @@ import org.simple.clinic.user.User
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.user.UserStatus
 import org.simple.clinic.util.Just
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.ScreenCreated
 import org.simple.clinic.widgets.UiEvent
 
 @RunWith(JUnitParamsRunner::class)
 class EnterOtpScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private lateinit var controller: EnterOtpScreenController
   private lateinit var userSession: UserSession

--- a/app/src/test/java/org/simple/clinic/facility/change/FacilityChangeScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/facility/change/FacilityChangeScreenControllerTest.kt
@@ -10,15 +10,20 @@ import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.facility.change.FacilitiesUpdateType.FIRST_UPDATE
 import org.simple.clinic.facility.change.FacilitiesUpdateType.SUBSEQUENT_UPDATE
 import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 
 class FacilityChangeScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val uiEvents = PublishSubject.create<UiEvent>()!!
   private val screen = mock<FacilityChangeScreen>()

--- a/app/src/test/java/org/simple/clinic/facility/change/FacilityListItemBuilderTest.kt
+++ b/app/src/test/java/org/simple/clinic/facility/change/FacilityListItemBuilderTest.kt
@@ -1,13 +1,18 @@
 package org.simple.clinic.facility.change
 
 import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.facility.change.FacilityListItem.Address
 import org.simple.clinic.facility.change.FacilityListItem.Builder
 import org.simple.clinic.facility.change.FacilityListItem.Name
 import org.simple.clinic.patient.PatientMocker
+import org.simple.clinic.util.RxErrorsRule
 
 class FacilityListItemBuilderTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   @Test
   fun `search query should be correctly highlighted`() {

--- a/app/src/test/java/org/simple/clinic/forgotpin/confirmpin/ForgotPinConfirmPinScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/forgotpin/confirmpin/ForgotPinConfirmPinScreenControllerTest.kt
@@ -13,6 +13,7 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.facility.FacilityRepository
@@ -25,10 +26,14 @@ import org.simple.clinic.user.ForgotPinResult.UnexpectedError
 import org.simple.clinic.user.ForgotPinResult.UserNotFound
 import org.simple.clinic.user.User
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 
 @RunWith(JUnitParamsRunner::class)
 class ForgotPinConfirmPinScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val uiEvents = PublishSubject.create<UiEvent>()
 

--- a/app/src/test/java/org/simple/clinic/forgotpin/createnewpin/ForgotPinCreateNewPinScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/forgotpin/createnewpin/ForgotPinCreateNewPinScreenControllerTest.kt
@@ -8,15 +8,20 @@ import com.nhaarman.mockito_kotlin.whenever
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.user.User
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.ScreenCreated
 import org.simple.clinic.widgets.UiEvent
 
 class ForgotPinCreateNewPinScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val screen = mock<ForgotPinCreateNewPinScreen>()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/home/HomeScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/HomeScreenControllerTest.kt
@@ -6,14 +6,19 @@ import com.nhaarman.mockito_kotlin.whenever
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.ScreenCreated
 import org.simple.clinic.widgets.UiEvent
 
 class HomeScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val uiEvents: PublishSubject<UiEvent> = PublishSubject.create()
   private lateinit var controller: HomeScreenController

--- a/app/src/test/java/org/simple/clinic/home/overdue/OverdueScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/OverdueScreenControllerTest.kt
@@ -12,6 +12,7 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.analytics.Analytics
@@ -21,11 +22,15 @@ import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.phone.Caller
 import org.simple.clinic.phone.MaskedPhoneCaller
 import org.simple.clinic.util.RuntimePermissionResult
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
 class OverdueScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val screen = mock<OverdueScreen>()
   private val uiEvents = PublishSubject.create<UiEvent>()

--- a/app/src/test/java/org/simple/clinic/home/overdue/appointmentreminder/AppointmentReminderSheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/appointmentreminder/AppointmentReminderSheetControllerTest.kt
@@ -10,9 +10,11 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.overdue.AppointmentRepository
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 import org.threeten.bp.LocalDate
 import org.threeten.bp.ZoneOffset
@@ -21,6 +23,9 @@ import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
 class AppointmentReminderSheetControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val sheet = mock<AppointmentReminderSheet>()
   private val repository = mock<AppointmentRepository>()

--- a/app/src/test/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentSheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentSheetControllerTest.kt
@@ -13,6 +13,7 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.overdue.AppointmentCancelReason.Dead
@@ -22,12 +23,16 @@ import org.simple.clinic.overdue.AppointmentCancelReason.PatientNotResponding
 import org.simple.clinic.overdue.AppointmentConfig
 import org.simple.clinic.overdue.AppointmentRepository
 import org.simple.clinic.patient.PatientRepository
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 import org.threeten.bp.Period
 import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
 class RemoveAppointmentSheetControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val sheet = mock<RemoveAppointmentSheet>()
   private val repository = mock<AppointmentRepository>()

--- a/app/src/test/java/org/simple/clinic/home/patients/PatientsScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/patients/PatientsScreenControllerTest.kt
@@ -15,6 +15,7 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
@@ -30,6 +31,7 @@ import org.simple.clinic.user.User.LoggedInStatus
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.user.UserStatus
 import org.simple.clinic.util.Just
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.exhaustive
 import org.simple.clinic.util.toOptional
 import org.simple.clinic.widgets.ScreenCreated
@@ -44,6 +46,9 @@ import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
 class PatientsScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val screen: PatientsScreen = mock()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/login/applock/AppLockScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/login/applock/AppLockScreenControllerTest.kt
@@ -8,15 +8,20 @@ import com.nhaarman.mockito_kotlin.whenever
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.Just
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 import org.threeten.bp.Instant
 
 class AppLockScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val screen = mock<AppLockScreen>()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/login/pin/LoginPinScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/login/pin/LoginPinScreenControllerTest.kt
@@ -11,16 +11,21 @@ import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.login.LoginResult
 import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.user.OngoingLoginEntry
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.Just
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 import java.util.UUID
 
 class LoginPinScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val screen = mock<LoginPinScreen>()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreenControllerTest.kt
@@ -9,6 +9,7 @@ import io.reactivex.Completable
 import io.reactivex.Single
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.medicalhistory.MedicalHistory
 import org.simple.clinic.medicalhistory.MedicalHistory.Answer.UNKNOWN
@@ -26,11 +27,15 @@ import org.simple.clinic.patient.OngoingNewPatientEntry
 import org.simple.clinic.patient.OngoingNewPatientEntry.PersonalDetails
 import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.patient.PatientRepository
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.ScreenCreated
 import org.simple.clinic.widgets.UiEvent
 import java.util.UUID
 
 class NewMedicalHistoryScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val screen: NewMedicalHistoryScreen = mock()
   private val medicalHistoryRepository: MedicalHistoryRepository = mock()

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
@@ -17,6 +17,7 @@ import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.analytics.Analytics
@@ -34,6 +35,7 @@ import org.simple.clinic.registration.phone.PhoneNumberValidator.Type.LANDLINE_O
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.Just
 import org.simple.clinic.util.None
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.ScreenCreated
 import org.simple.clinic.widgets.TheActivityLifecycle
 import org.simple.clinic.widgets.UiEvent
@@ -43,6 +45,9 @@ import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Re
 
 @RunWith(JUnitParamsRunner::class)
 class PatientEntryScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val screen = mock<PatientEntryScreen>()
   private val patientRepository = mock<PatientRepository>()

--- a/app/src/test/java/org/simple/clinic/newentry/clearbutton/ClearFieldImageButtonControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/clearbutton/ClearFieldImageButtonControllerTest.kt
@@ -5,10 +5,15 @@ import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 
 class ClearFieldImageButtonControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val button = mock<ClearFieldImageButton>()
 
@@ -21,7 +26,7 @@ class ClearFieldImageButtonControllerTest {
 
     uiEvents
         .compose(controller)
-        .subscribe({ uiChange -> uiChange(button) })
+        .subscribe { uiChange -> uiChange(button) }
   }
 
   @Test

--- a/app/src/test/java/org/simple/clinic/onboarding/OnboardingScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/onboarding/OnboardingScreenControllerTest.kt
@@ -6,10 +6,15 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 
 class OnboardingScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val screen = mock<OnboardingScreen>()
   private val hasUserCompletedOnboarding = mock<Preference<Boolean>>()

--- a/app/src/test/java/org/simple/clinic/overdue/AppointmentSyncTest.kt
+++ b/app/src/test/java/org/simple/clinic/overdue/AppointmentSyncTest.kt
@@ -11,18 +11,22 @@ import io.reactivex.Single
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.sync.DataPullResponse
 import org.simple.clinic.sync.DataPushResponse
 import org.simple.clinic.sync.SyncCoordinator
 import org.simple.clinic.util.Optional
-import org.threeten.bp.Duration
+import org.simple.clinic.util.RxErrorsRule
 import org.threeten.bp.Period
 
 @Suppress("UNCHECKED_CAST")
 @RunWith(JUnitParamsRunner::class)
 class AppointmentSyncTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val syncCoordinator = mock<SyncCoordinator>()
   private val repository = mock<AppointmentRepository>()

--- a/app/src/test/java/org/simple/clinic/patient/PatientRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/patient/PatientRepositoryTest.kt
@@ -15,6 +15,7 @@ import io.reactivex.Single
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.AppDatabase
@@ -25,6 +26,7 @@ import org.simple.clinic.patient.sync.PatientPayload
 import org.simple.clinic.patient.sync.PatientPhoneNumberPayload
 import org.simple.clinic.registration.phone.PhoneNumberValidator
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestClock
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
 import org.threeten.bp.format.DateTimeFormatter
@@ -32,6 +34,9 @@ import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
 class PatientRepositoryTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private lateinit var repository: PatientRepository
   private lateinit var searchPatientByName: SearchPatientByName

--- a/app/src/test/java/org/simple/clinic/phone/TwilioMaskedPhoneCallerTest.kt
+++ b/app/src/test/java/org/simple/clinic/phone/TwilioMaskedPhoneCallerTest.kt
@@ -5,9 +5,14 @@ import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockito_kotlin.mock
 import io.reactivex.Single
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.simple.clinic.util.RxErrorsRule
 
 class TwilioMaskedPhoneCallerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private lateinit var maskedPhoneCaller: MaskedPhoneCaller
   private lateinit var config: PhoneNumberMaskerConfig

--- a/app/src/test/java/org/simple/clinic/protocol/SyncProtocolsOnLoginTest.kt
+++ b/app/src/test/java/org/simple/clinic/protocol/SyncProtocolsOnLoginTest.kt
@@ -9,14 +9,19 @@ import io.reactivex.Observable
 import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.schedulers.Schedulers
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.protocol.sync.ProtocolSync
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.Just
 import org.simple.clinic.util.None
+import org.simple.clinic.util.RxErrorsRule
 
 class SyncProtocolsOnLoginTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val userSession = mock<UserSession>()
   private val protocolSync = mock<ProtocolSync>()

--- a/app/src/test/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinScreenControllerTest.kt
@@ -13,15 +13,20 @@ import io.reactivex.Completable
 import io.reactivex.Single
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.user.OngoingRegistrationEntry
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestClock
 import org.simple.clinic.widgets.UiEvent
 import org.threeten.bp.Instant
 import java.util.UUID
 
 class RegistrationConfirmPinScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val uiEvents = PublishSubject.create<UiEvent>()!!
   private val screen = mock<RegistrationConfirmPinScreen>()

--- a/app/src/test/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionScreenControllerTest.kt
@@ -11,6 +11,7 @@ import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.facility.FacilityPullResult
@@ -23,12 +24,16 @@ import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.registration.RegistrationScheduler
 import org.simple.clinic.user.OngoingRegistrationEntry
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.ScreenCreated
 import org.simple.clinic.widgets.UiEvent
 import org.threeten.bp.Instant
 import java.util.UUID
 
 class RegistrationFacilitySelectionScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val uiEvents = PublishSubject.create<UiEvent>()!!
   private val screen = mock<RegistrationFacilitySelectionScreen>()

--- a/app/src/test/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreenControllerTest.kt
@@ -4,11 +4,16 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.util.RuntimePermissionResult
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 
 class RegistrationLocationPermissionScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   val uiEvents = PublishSubject.create<UiEvent>()!!
   val screen = mock<RegistrationLocationPermissionScreen>()

--- a/app/src/test/java/org/simple/clinic/registration/name/RegistrationFullNameScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/name/RegistrationFullNameScreenControllerTest.kt
@@ -11,15 +11,19 @@ import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.facility.FacilitySync
-import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.user.OngoingRegistrationEntry
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 
 class RegistrationFullNameScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   val uiEvents = PublishSubject.create<UiEvent>()!!
   val screen = mock<RegistrationFullNameScreen>()
@@ -58,7 +62,7 @@ class RegistrationFullNameScreenControllerTest {
         fullName = "Ashok Kumar",
         phoneNumber = "1234567890")
     whenever(userSession.ongoingRegistrationEntry()).thenReturn(Single.just(ongoingEntry))
-    whenever(facilityRepository.facilities()).thenReturn(Observable.never())
+    whenever(facilityRepository.recordCount()).thenReturn(Observable.never())
 
     uiEvents.onNext(RegistrationFullNameScreenCreated())
 
@@ -112,7 +116,7 @@ class RegistrationFullNameScreenControllerTest {
 
   @Test
   fun `when screen is started and facilities have already been synced then facilities should not be synced again`() {
-    whenever(facilityRepository.facilities()).thenReturn(Observable.just(listOf(PatientMocker.facility())))
+    whenever(facilityRepository.recordCount()).thenReturn(Observable.just(1))
     whenever(userSession.ongoingRegistrationEntry()).thenReturn(Single.just(OngoingRegistrationEntry()))
     whenever(facilitySync.sync()).thenReturn(Completable.complete())
 

--- a/app/src/test/java/org/simple/clinic/registration/phone/RegistrationPhoneScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/phone/RegistrationPhoneScreenControllerTest.kt
@@ -12,6 +12,7 @@ import io.reactivex.Completable
 import io.reactivex.Single
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.registration.FindUserResult
 import org.simple.clinic.registration.SaveUserLocallyResult
@@ -22,10 +23,14 @@ import org.simple.clinic.user.LoggedInUserPayload
 import org.simple.clinic.user.OngoingLoginEntry
 import org.simple.clinic.user.OngoingRegistrationEntry
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 import java.util.UUID
 
 class RegistrationPhoneScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val screen = mock<RegistrationPhoneScreen>()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/registration/pin/RegistrationPinScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/pin/RegistrationPinScreenControllerTest.kt
@@ -10,12 +10,17 @@ import io.reactivex.Completable
 import io.reactivex.Single
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.user.OngoingRegistrationEntry
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 
 class RegistrationPinScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   val uiEvents = PublishSubject.create<UiEvent>()!!
   val screen = mock<RegistrationPinScreen>()

--- a/app/src/test/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheetControllerTest.kt
@@ -10,10 +10,12 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.overdue.AppointmentRepository
 import org.simple.clinic.patient.PatientMocker
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 import org.threeten.bp.LocalDate
 import org.threeten.bp.ZoneOffset.UTC
@@ -22,6 +24,9 @@ import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
 class ScheduleAppointmentSheetControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val sheet = mock<ScheduleAppointmentSheet>()
   private val repository = mock<AppointmentRepository>()

--- a/app/src/test/java/org/simple/clinic/search/PatientSearchScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/search/PatientSearchScreenControllerTest.kt
@@ -7,11 +7,16 @@ import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.patient.PatientRepository
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 
 class PatientSearchScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val screen: PatientSearchScreen = mock()
   private val repository: PatientRepository = mock()

--- a/app/src/test/java/org/simple/clinic/search/results/PatientSearchResultsControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/search/results/PatientSearchResultsControllerTest.kt
@@ -12,6 +12,7 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.facility.FacilityRepository
@@ -20,10 +21,14 @@ import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.patient.PatientSearchResult
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 
 @RunWith(JUnitParamsRunner::class)
 class PatientSearchResultsControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val screen: PatientSearchResultsScreen = mock()
   private val patientRepository: PatientRepository = mock()

--- a/app/src/test/java/org/simple/clinic/security/BCryptPasswordHasherTest.kt
+++ b/app/src/test/java/org/simple/clinic/security/BCryptPasswordHasherTest.kt
@@ -1,8 +1,13 @@
 package org.simple.clinic.security
 
+import org.junit.Rule
 import org.junit.Test
+import org.simple.clinic.util.RxErrorsRule
 
 class BCryptPasswordHasherTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   @Test
   fun `comparison test`() {

--- a/app/src/test/java/org/simple/clinic/security/pin/BruteForceProtectionTest.kt
+++ b/app/src/test/java/org/simple/clinic/security/pin/BruteForceProtectionTest.kt
@@ -7,15 +7,20 @@ import com.nhaarman.mockito_kotlin.whenever
 import io.reactivex.Observable
 import io.reactivex.Single
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.security.pin.BruteForceProtection.ProtectedState
 import org.simple.clinic.util.Just
 import org.simple.clinic.util.None
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestClock
 import org.threeten.bp.Duration
 import org.threeten.bp.Instant
 
 class BruteForceProtectionTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val clock = TestClock()
   private val state = mock<Preference<BruteForceProtectionState>>()

--- a/app/src/test/java/org/simple/clinic/security/pin/PinEntryCardControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/security/pin/PinEntryCardControllerTest.kt
@@ -15,6 +15,7 @@ import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.patient.PatientMocker
@@ -23,6 +24,7 @@ import org.simple.clinic.security.PasswordHasher
 import org.simple.clinic.security.pin.BruteForceProtection.ProtectedState
 import org.simple.clinic.security.pin.PinEntryCardView.State
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestClock
 import org.simple.clinic.widgets.UiEvent
 import org.threeten.bp.Duration
@@ -30,6 +32,9 @@ import org.threeten.bp.Instant
 
 @RunWith(JUnitParamsRunner::class)
 class  PinEntryCardControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val screen = mock<PinEntryCardView>()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenControllerTest.kt
@@ -19,6 +19,7 @@ import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.analytics.Analytics
@@ -48,6 +49,7 @@ import org.simple.clinic.patient.PatientSummaryResult
 import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.util.Just
 import org.simple.clinic.util.None
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 import org.threeten.bp.Clock
 import org.threeten.bp.Duration
@@ -60,6 +62,9 @@ import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
 class PatientSummaryScreenControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val screen = mock<PatientSummaryScreen>()
   private val patientRepository = mock<PatientRepository>()

--- a/app/src/test/java/org/simple/clinic/summary/updatephone/UpdatePhoneNumberDialogControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/updatephone/UpdatePhoneNumberDialogControllerTest.kt
@@ -12,6 +12,7 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.patient.PatientMocker
@@ -25,12 +26,16 @@ import org.simple.clinic.registration.phone.PhoneNumberValidator.Result.VALID
 import org.simple.clinic.registration.phone.PhoneNumberValidator.Result.values
 import org.simple.clinic.registration.phone.PhoneNumberValidator.Type.LANDLINE_OR_MOBILE
 import org.simple.clinic.util.Just
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.exhaustive
 import org.simple.clinic.widgets.UiEvent
 import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
 class UpdatePhoneNumberDialogControllerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val uiEvents = PublishSubject.create<UiEvent>()
   private val dialog = mock<UpdatePhoneNumberDialog>()

--- a/app/src/test/java/org/simple/clinic/sync/ModelSyncTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/ModelSyncTest.kt
@@ -8,6 +8,7 @@ import io.reactivex.Completable
 import io.reactivex.Single
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.bp.sync.BloodPressureSync
@@ -21,10 +22,14 @@ import org.simple.clinic.patient.sync.PatientSync
 import org.simple.clinic.protocol.sync.ProtocolSync
 import org.simple.clinic.sync.ModelSyncTest.SyncOperation.PULL
 import org.simple.clinic.sync.ModelSyncTest.SyncOperation.PUSH
+import org.simple.clinic.util.RxErrorsRule
 import org.threeten.bp.Period
 
 @RunWith(JUnitParamsRunner::class)
 class ModelSyncTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   @Suppress("Unused")
   private fun `sync models that both push and pull`(): List<List<Any>> {

--- a/app/src/test/java/org/simple/clinic/sync/SyncCoordinatorTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/SyncCoordinatorTest.kt
@@ -9,13 +9,18 @@ import com.nhaarman.mockito_kotlin.whenever
 import io.reactivex.Completable
 import io.reactivex.Single
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.util.Optional
+import org.simple.clinic.util.RxErrorsRule
 import org.threeten.bp.Instant
 import java.util.UUID
 
 class SyncCoordinatorTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private lateinit var syncCoordinator: SyncCoordinator
   private lateinit var syncConfig: SyncConfig

--- a/app/src/test/java/org/simple/clinic/user/NewlyVerifiedUserTest.kt
+++ b/app/src/test/java/org/simple/clinic/user/NewlyVerifiedUserTest.kt
@@ -5,14 +5,19 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.util.Just
 import org.simple.clinic.util.Optional
+import org.simple.clinic.util.RxErrorsRule
 
 @RunWith(JUnitParamsRunner::class)
 class NewlyVerifiedUserTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private lateinit var newlyVerifiedUser: NewlyVerifiedUser
   private lateinit var receivedUsers: MutableList<User>

--- a/app/src/test/java/org/simple/clinic/user/UserSessionTest.kt
+++ b/app/src/test/java/org/simple/clinic/user/UserSessionTest.kt
@@ -24,6 +24,7 @@ import okhttp3.MediaType
 import okhttp3.ResponseBody
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.AppDatabase
@@ -50,6 +51,7 @@ import org.simple.clinic.security.pin.BruteForceProtection
 import org.simple.clinic.sync.SyncScheduler
 import org.simple.clinic.util.Just
 import org.simple.clinic.util.Optional
+import org.simple.clinic.util.RxErrorsRule
 import retrofit2.HttpException
 import retrofit2.Response
 import java.io.IOException
@@ -57,6 +59,9 @@ import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
 class UserSessionTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val loginApi = mock<LoginApiV1>()
   private val registrationApi = mock<RegistrationApiV1>()

--- a/app/src/test/java/org/simple/clinic/util/RxErrorsRule.kt
+++ b/app/src/test/java/org/simple/clinic/util/RxErrorsRule.kt
@@ -1,0 +1,53 @@
+package org.simple.clinic.util
+
+import io.reactivex.plugins.RxJavaPlugins
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import java.util.concurrent.LinkedBlockingDeque
+
+/**
+ * Starting from RxJava2, uncaught errors are not thrown but instead sent to
+ * the thread's default error handler. This results in a situation where JUnit
+ * would always pass even if any RxJava chain encountered an error.
+ *
+ * More info about this issue:
+ * https://github.com/ReactiveX/RxJava/issues/5234.
+ *
+ * This rule was copied from AutoDispose:
+ * https://github.com/uber/AutoDispose/blob/master/test-utils/src/main/java/com/uber/autodispose/test/RxErrorsRule.java
+ */
+class RxErrorsRule : TestRule {
+
+  private val errors = LinkedBlockingDeque<Throwable>()
+
+  override fun apply(base: Statement, description: Description): Statement {
+    return object : Statement() {
+      override fun evaluate() {
+        RxJavaPlugins.setErrorHandler { t -> errors.add(t) }
+
+        try {
+          base.evaluate()
+          
+        } finally {
+          RxJavaPlugins.setErrorHandler(null)
+          assertNoErrors()
+        }
+      }
+    }
+  }
+
+  private fun hasErrors(): Boolean {
+    val error = errors.peek()
+    return error != null
+  }
+
+  fun assertNoErrors() {
+    if (hasErrors()) {
+      errors.forEach {
+        it.printStackTrace()
+      }
+      throw AssertionError("Expected no errors but found $errors")
+    }
+  }
+}

--- a/app/src/test/java/org/simple/clinic/widgets/RecyclerViewUserScrollDetectorTest.kt
+++ b/app/src/test/java/org/simple/clinic/widgets/RecyclerViewUserScrollDetectorTest.kt
@@ -9,11 +9,16 @@ import io.reactivex.Observable
 import io.reactivex.rxkotlin.Observables
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.simple.clinic.util.RxErrorsRule
 
 @RunWith(JUnitParamsRunner::class)
 class RecyclerViewUserScrollDetectorTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   @Test
   @Parameters(value = [


### PR DESCRIPTION
Starting from RxJava2, uncaught errors are not thrown but instead sent to the thread's default error handler. This results in a situation where JUnit would always pass even if any RxJava chain encounters an error.

More information here: https://github.com/ReactiveX/RxJava/issues/5234

This commit introduces a JUnit rule that observes uncaught errors, but it needs to be manually added to every test. The rule was copied from [AutoDispose](https://github.com/uber/AutoDispose).