### PR TITLE
Exclude deleted Blood Pressures from UI (Part 1)

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/TestClinicApp.kt
+++ b/app/src/androidTest/java/org/simple/clinic/TestClinicApp.kt
@@ -104,7 +104,7 @@ class TestClinicApp : ClinicApp() {
 
           override fun providePatientConfig(): Single<PatientConfig> {
             return super.providePatientConfig()
-                .map { it.copy(isFuzzySearchV2Enabled = true, limitOfSearchResults = 50) }
+                .map { it.copy(limitOfSearchResults = 50) }
           }
         })
         .crashReporterModule(object : CrashReporterModule() {

--- a/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
@@ -7,7 +7,6 @@ import io.reactivex.Observable
 import io.reactivex.Single
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -189,24 +188,6 @@ class PatientRepositoryAndroidTest {
         .andThen(patientRepository.saveOngoingEntryAsPatient())
         .test()
         .assertError(AssertionError::class.java)
-  }
-
-  @Test
-  @Ignore("deprecated because of search v2")
-  fun patient_search_should_ignore_spaces_and_whitespace_characters() {
-    val names = arrayOf("Riya Puri" to "ya p", "Manabi    Mehra" to "bime", "Amit:Sodhi" to "ito")
-
-    names.forEach { (fullName, query) ->
-      val patientEntry = testData.ongoingPatientEntry(fullName = fullName, age = "20")
-
-      patientRepository.saveOngoingEntry(patientEntry)
-          .andThen(patientRepository.saveOngoingEntryAsPatient())
-          .blockingGet()
-
-      val search = patientRepository.search(query).blockingFirst()
-
-      assertThat(search.any { it.fullName == fullName }).isTrue()
-    }
   }
 
   @Test

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureMeasurement.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureMeasurement.kt
@@ -77,7 +77,11 @@ data class BloodPressureMeasurement (
     @Query("SELECT COUNT(uuid) FROM bloodpressuremeasurement")
     fun count(): Flowable<Int>
 
-    @Query("SELECT * FROM bloodpressuremeasurement WHERE patientUuid = :patientUuid ORDER BY createdAt DESC LIMIT :limit")
+    @Query("""
+      SELECT * FROM bloodpressuremeasurement
+        WHERE patientUuid = :patientUuid AND deletedAt IS NULL
+        ORDER BY createdAt DESC LIMIT :limit
+    """)
     fun newestMeasurementsForPatient(patientUuid: UUID, limit: Int): Flowable<List<BloodPressureMeasurement>>
 
     @Query("DELETE FROM bloodpressuremeasurement")

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureMeasurement.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureMeasurement.kt
@@ -87,7 +87,11 @@ data class BloodPressureMeasurement (
     @Query("DELETE FROM bloodpressuremeasurement")
     fun clearData(): Int
 
-    @Query("SELECT patientUuid, facilityUuid FROM bloodpressuremeasurement WHERE patientUuid IN (:patientUuids)")
+    @Query("""
+      SELECT patientUuid, facilityUuid
+      FROM bloodpressuremeasurement
+      WHERE patientUuid IN (:patientUuids) AND deletedAt IS NULL
+      """)
     fun patientToFacilityIds(patientUuids: List<UUID>): Flowable<List<PatientToFacilityId>>
   }
 }

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureRepository.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureRepository.kt
@@ -114,7 +114,7 @@ class BloodPressureRepository @Inject constructor(
         .toObservable()
   }
 
-  fun measurement(uuid: UUID): Single<BloodPressureMeasurement> = Single.fromCallable { dao.getOne(uuid) }
+  fun measurement(uuid: UUID): Observable<BloodPressureMeasurement> = dao.bloodPressure(uuid).toObservable()
 
   fun markBloodPressureAsDeleted(bloodPressureMeasurement: BloodPressureMeasurement): Completable {
     return Completable.fromAction {
@@ -126,12 +126,5 @@ class BloodPressureRepository @Inject constructor(
 
       dao.save(listOf(deletedBloodPressureMeasurement))
     }
-  }
-
-  fun deletedMeasurements(bloodPressureMeasurementUuid: UUID): Observable<BloodPressureMeasurement> {
-    return dao
-        .bloodPressure(bloodPressureMeasurementUuid)
-        .filter { it.deletedAt != null }
-        .toObservable()
   }
 }

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
@@ -17,7 +17,7 @@ class BloodPressureSaveClicked : UiEvent {
 }
 
 object BloodPressureRemoveClicked : UiEvent {
-  override val analyticsName = "BloodPressureEntry:Remove Clicked"
+  override val analyticsName = "Blood Pressure Entry:Remove Clicked"
 }
 
 object BloodPressureDiastolicBackspaceClicked : UiEvent

--- a/app/src/main/java/org/simple/clinic/bp/entry/confirmremovebloodpressure/ConfirmRemoveBloodPressureDialogController.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/confirmremovebloodpressure/ConfirmRemoveBloodPressureDialogController.kt
@@ -34,7 +34,8 @@ class ConfirmRemoveBloodPressureDialogController @Inject constructor(
     return events
         .ofType<ConfirmRemoveBloodPressureDialogRemoveClicked>()
         .withLatestFrom(savedBloodPressureMeasurementUuidStream) { _, bloodPressureMeasurementUuid -> bloodPressureMeasurementUuid }
-        .flatMapSingle { bloodPressureRepository.measurement(it) }
+        .flatMap { bloodPressureRepository.measurement(it) }
+        .take(1)
         .flatMap {
           bloodPressureRepository
               .markBloodPressureAsDeleted(it)

--- a/app/src/main/java/org/simple/clinic/patient/PatientConfig.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientConfig.kt
@@ -7,7 +7,7 @@ package org.simple.clinic.patient
  * */
 const val MAXIMUM_SQLITE_QUERY_LIMIT = 1000
 
-data class PatientConfig(val isFuzzySearchV2Enabled: Boolean, val limitOfSearchResults: Int) {
+data class PatientConfig(val limitOfSearchResults: Int) {
   init {
     if (limitOfSearchResults !in 1 until MAXIMUM_SQLITE_QUERY_LIMIT) {
       throw AssertionError("limit of search results must be within [1, 999]")

--- a/app/src/main/java/org/simple/clinic/patient/PatientFuzzySearch.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientFuzzySearch.kt
@@ -13,8 +13,6 @@ class PatientFuzzySearch {
   // TODO: See if this can merged with the PatientSearchDao.
   interface PatientFuzzySearchDao {
 
-    fun searchForPatientsWithNameLikeAndAgeWithin(query: String, dobUpperBound: String, dobLowerBound: String): Single<List<PatientSearchResult>>
-
     fun searchForPatientsWithNameLike(query: String): Single<List<PatientSearchResult>>
   }
 
@@ -22,19 +20,6 @@ class PatientFuzzySearch {
       private val sqLiteOpenHelper: SupportSQLiteOpenHelper,
       private val patientSearchDao: PatientSearchResult.RoomDao
   ) : PatientFuzzySearchDao {
-
-    override fun searchForPatientsWithNameLikeAndAgeWithin(
-        query: String,
-        dobUpperBound: String,
-        dobLowerBound: String
-    ): Single<List<PatientSearchResult>> {
-      return patientUuidsMatching(query).flatMap { uuidsSortedByScore ->
-        val uuids = uuidsSortedByScore.map { it.uuid }
-        patientSearchDao
-            .searchByIds(uuids, dobUpperBound, dobLowerBound, PatientStatus.ACTIVE)
-            .compose(sortPatientSearchResultsByScore(uuidsSortedByScore))
-      }
-    }
 
     override fun searchForPatientsWithNameLike(query: String): Single<List<PatientSearchResult>> {
       return patientUuidsMatching(query).flatMap { uuidsSortedByScore ->

--- a/app/src/main/java/org/simple/clinic/patient/PatientModule.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientModule.kt
@@ -29,5 +29,5 @@ open class PatientModule {
       resultsComparator = SortByWeightedNameParts())
 
   @Provides
-  open fun providePatientConfig(): Single<PatientConfig> = Single.just(PatientConfig(isFuzzySearchV2Enabled = true, limitOfSearchResults = 100))
+  open fun providePatientConfig(): Single<PatientConfig> = Single.just(PatientConfig(limitOfSearchResults = 100))
 }

--- a/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
@@ -68,15 +68,18 @@ data class PatientSearchResult(
           LEFT JOIN PatientPhoneNumber PP ON PP.patientUuid = P.uuid
           LEFT JOIN (
         		SELECT BP.patientUuid, BP.createdAt, F.name facilityName, F.uuid facilityUuid
-        		FROM BloodPressureMeasurement BP
+        		FROM (
+                SELECT BP.patientUuid, BP.createdAt, BP.facilityUuid
+                FROM BloodPressureMeasurement BP
+                WHERE BP.deletedAt IS NULL
+                ORDER BY BP.createdAt DESC
+            ) BP
         		INNER JOIN Facility F ON BP.facilityUuid = F.uuid
-            GROUP BY BP.patientUuid
-        		ORDER BY BP.createdAt DESC
         	) BP ON (BP.patientUuid = P.uuid)
     """
     }
 
-    @Query("""$mainQuery WHERE P.uuid IN (:uuids) AND P.status = :status""")
+    @Query("""$mainQuery WHERE P.uuid IN (:uuids) AND P.status = :status GROUP BY P.uuid""")
     fun searchByIds(uuids: List<UUID>, status: PatientStatus): Single<List<PatientSearchResult>>
 
     @Query("""

--- a/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
@@ -52,6 +52,10 @@ data class PatientSearchResult(
     val lastBp: LastBp?
 ) {
 
+  override fun toString(): String {
+    return "Name: $fullName, UUID: $uuid, Facility UUID: ${lastBp?.takenAtFacilityUuid}"
+  }
+
   @Dao
   interface RoomDao {
 

--- a/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
@@ -79,36 +79,6 @@ data class PatientSearchResult(
     @Query("""$mainQuery WHERE P.uuid IN (:uuids) AND P.status = :status""")
     fun searchByIds(uuids: List<UUID>, status: PatientStatus): Single<List<PatientSearchResult>>
 
-    @Query("""$mainQuery
-      WHERE (P.uuid IN (:uuids))
-      AND ((P.dateOfBirth BETWEEN :dobUpperBound AND :dobLowerBound) OR (P.age_computedDateOfBirth BETWEEN :dobUpperBound AND :dobLowerBound))
-      AND P.status = :status
-      """)
-    fun searchByIds(uuids: List<UUID>, dobUpperBound: String, dobLowerBound: String, status: PatientStatus): Single<List<PatientSearchResult>>
-
-    @Query("""$mainQuery
-      WHERE P.searchableName LIKE '%' || :name || '%'
-      AND ((P.dateOfBirth BETWEEN :dobUpperBound AND :dobLowerBound) OR (P.age_computedDateOfBirth BETWEEN :dobUpperBound AND :dobLowerBound))
-      AND P.status = :status
-      """)
-    fun search(name: String, dobUpperBound: String, dobLowerBound: String, status: PatientStatus): Flowable<List<PatientSearchResult>>
-
-    @Query("""$mainQuery
-      WHERE P.searchableName LIKE '%' || :name || '%' AND P.status = :status
-    """)
-    fun search(name: String, status: PatientStatus): Flowable<List<PatientSearchResult>>
-
-    @Query("$mainQuery WHERE P.syncStatus == :status")
-    fun withSyncStatus(status: SyncStatus): Flowable<List<PatientSearchResult>>
-
-    @Query("""
-      SELECT Patient.uuid, Patient.fullName
-        FROM Patient
-        WHERE Patient.status = :status
-        AND ((Patient.dateOfBirth BETWEEN :dobUpperBound AND :dobLowerBound) OR (Patient.age_computedDateOfBirth BETWEEN :dobUpperBound AND :dobLowerBound))
-    """)
-    fun nameAndIdWithDobBounds(dobUpperBound: String, dobLowerBound: String, status: PatientStatus): Flowable<List<PatientNameAndId>>
-
     @Query("""
       SELECT Patient.uuid, Patient.fullName FROM Patient WHERE Patient.status = :status
     """)

--- a/app/src/main/res/layout/sheet_blood_pressure_entry.xml
+++ b/app/src/main/res/layout/sheet_blood_pressure_entry.xml
@@ -9,17 +9,32 @@
   android:paddingBottom="@dimen/spacing_24"
   android:paddingTop="@dimen/spacing_16">
 
-  <FrameLayout
+  <RelativeLayout
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="horizontal">
+    android:layout_height="wrap_content">
+
+    <Button
+      android:id="@+id/bloodpressureentry_remove"
+      style="@style/Widget.AppCompat.Button.Borderless"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_alignParentEnd="true"
+      android:layout_marginEnd="@dimen/spacing_16"
+      android:text="@string/bloodpressureentry_remove"
+      android:textAppearance="@style/Clinic.V2.TextAppearance.Button2.Red1"
+      android:visibility="gone"
+      tools:visibility="visible" />
 
     <TextView
       android:id="@+id/bloodpressureentry_edit_blood_pressure"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_gravity="start|center_vertical"
+      android:layout_alignParentStart="true"
+      android:layout_centerVertical="true"
       android:layout_marginStart="@dimen/spacing_24"
+      android:layout_toStartOf="@id/bloodpressureentry_remove"
+      android:ellipsize="end"
+      android:lines="1"
       android:text="@string/bloodpressureentry_sheet_title_edit_blood_pressure"
       android:textAppearance="@style/Clinic.V2.TextAppearance.H6.Grey0"
       android:visibility="gone"
@@ -28,28 +43,16 @@
 
     <TextView
       android:id="@+id/bloodpressureentry_enter_blood_pressure"
-      android:layout_width="match_parent"
+      android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:gravity="center_horizontal"
+      android:layout_centerHorizontal="true"
+      android:lines="1"
       android:text="@string/bloodpressureentry_sheet_title_enter_blood_pressure"
       android:textAppearance="@style/Clinic.V2.TextAppearance.H6.Grey0"
       android:visibility="gone"
-      tools:ignore="UnusedAttribute"
-      tools:visibility="visible" />
+      tools:ignore="UnusedAttribute" />
 
-    <Button
-      android:id="@+id/bloodpressureentry_remove"
-      style="@style/Widget.AppCompat.Button.Borderless"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_gravity="end"
-      android:layout_marginEnd="@dimen/spacing_16"
-      android:text="@string/bloodpressureentry_remove"
-      android:textAppearance="@style/Clinic.V2.TextAppearance.Button2.Red1"
-      android:visibility="gone"
-      tools:visibility="visible" />
-
-  </FrameLayout>
+  </RelativeLayout>
 
   <LinearLayout
     android:layout_width="match_parent"

--- a/app/src/test/java/org/simple/clinic/bp/BloodPressureRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/BloodPressureRepositoryTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockito_kotlin.check
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
-import io.reactivex.Flowable
 import io.reactivex.Observable
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
@@ -20,7 +19,6 @@ import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestClock
-import org.threeten.bp.Instant
 import java.util.UUID
 
 @RunWith(JUnitParamsRunner::class)
@@ -87,24 +85,5 @@ class BloodPressureRepositoryTest {
     } else {
       verify(dao).save(argThat { isEmpty() })
     }
-  }
-
-  @Test
-  fun `observing a deleted blood pressure should work correctly`() {
-    val bloodPressureUuid = UUID.randomUUID()
-    val bloodPressures = listOf(
-        PatientMocker.bp(uuid = bloodPressureUuid, deletedAt = null),
-        PatientMocker.bp(uuid = bloodPressureUuid, deletedAt = Instant.now(testClock)),
-        PatientMocker.bp(uuid = bloodPressureUuid, deletedAt = null),
-        PatientMocker.bp(uuid = bloodPressureUuid, deletedAt = Instant.now(testClock)),
-        PatientMocker.bp(uuid = bloodPressureUuid, deletedAt = null)
-    )
-    whenever(dao.bloodPressure(bloodPressureUuid)).thenReturn(Flowable.fromIterable(bloodPressures))
-
-    val deletedBloodPressures = repository.deletedMeasurements(bloodPressureUuid)
-        .blockingIterable()
-        .toList()
-
-    assertThat(deletedBloodPressures).isEqualTo(listOf(bloodPressures[1], bloodPressures[3]))
   }
 }

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -9,6 +9,8 @@ import com.nhaarman.mockito_kotlin.whenever
 import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.Single
+import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
@@ -41,6 +43,7 @@ class BloodPressureEntrySheetControllerTest {
 
   @Before
   fun setUp() {
+    RxJavaPlugins.setIoSchedulerHandler { Schedulers.trampoline() }
     controller = BloodPressureEntrySheetController(bloodPressureRepository, configEmitter.firstOrError())
 
     uiEvents

--- a/app/src/test/java/org/simple/clinic/bp/entry/confirmremovebloodpressure/ConfirmRemoveBloodPressureDialogControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/confirmremovebloodpressure/ConfirmRemoveBloodPressureDialogControllerTest.kt
@@ -4,7 +4,7 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import io.reactivex.Completable
-import io.reactivex.Single
+import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import org.junit.Before
 import org.junit.Rule
@@ -42,7 +42,7 @@ class ConfirmRemoveBloodPressureDialogControllerTest {
   fun `when remove is clicked, the blood pressure must be marked as deleted and the dialog should be dismissed`() {
     val bloodPressure = PatientMocker.bp()
     val markBloodPressureDeletedCompletable = Completable.complete()
-    whenever(bloodPressureRepository.measurement(bloodPressure.uuid)).thenReturn(Single.just(bloodPressure))
+    whenever(bloodPressureRepository.measurement(bloodPressure.uuid)).thenReturn(Observable.just(bloodPressure))
     whenever(bloodPressureRepository.markBloodPressureAsDeleted(bloodPressure)).thenReturn(markBloodPressureDeletedCompletable)
 
     uiEvents.onNext(ConfirmRemoveBloodPressureDialogCreated(bloodPressureMeasurementUuid = bloodPressure.uuid))


### PR DESCRIPTION
## Changes
- Exclude deleted blood pressures from Patient Summary.
- Exclude deleted blood pressures from Search Results.
- Remove search v1 related feature flag and unused methods.

## Misc Things To Do
- [x] Use the `BloodPressureRepository#measurement` instead of a separate method in the `BloodPressureEntrySheetController` to listen for deleted blood pressure measurements.
- [x] Prefill the blood pressure measurement when editing a blood pressure on the `io` scheduler because it occasionally runs on the main thread and causes a crash.
- [x] Handle the possibility that the "Edit Blood Pressure" label may overlap with the "Remove" button.