### PR TITLE
Improve filtering of network related errors before reporting to Sentry

### DIFF
--- a/app/src/main/java/org/simple/clinic/sync/DataSync.kt
+++ b/app/src/main/java/org/simple/clinic/sync/DataSync.kt
@@ -66,11 +66,12 @@ class DataSync @Inject constructor(
       is ResolvedError.Unexpected -> {
         Timber.i("(breadcrumb) Reporting to sentry. Error: $e. Resolved error: $resolvedError")
         crashReporter.report(resolvedError.actualCause)
+        Timber.e(resolvedError.actualCause)
       }
       is ResolvedError.NetworkRelated -> {
         // Connectivity issues are expected.
+        Timber.e(e)
       }
     }.exhaustive()
-    Timber.e(e)
   }
 }

--- a/app/src/main/java/org/simple/clinic/util/ErrorResolver.kt
+++ b/app/src/main/java/org/simple/clinic/util/ErrorResolver.kt
@@ -25,7 +25,7 @@ object ErrorResolver {
   fun resolve(error: Throwable): ResolvedError {
     val actualCause = findActualCause(error)
 
-    return if (error::class in KNOWN_NETWORK_ERRORS) {
+    return if (actualCause::class in KNOWN_NETWORK_ERRORS) {
       ResolvedError.NetworkRelated(actualCause)
     } else {
       ResolvedError.Unexpected(actualCause)


### PR DESCRIPTION
I tested this by adding a bunch of `doOnError()` blocks in the Rx chain and manually throwing `TraceurExceptions`:

```kotlin
private fun sync(): Completable {
  return patientSync.sync()
      .andThen(Completable.mergeArrayDelayError(
          bloodPressureSync.sync(),
          prescriptionSync.sync(),
          appointmentSync.sync(),
          communicationSync.sync(),
          medicalHistorySync.sync(),
          facilitySync.sync(),
          protocolSync.sync()
      ))
      .doOnError { e ->
        TraceurException.create().appendTo(e)
      }
      .doOnError { e ->
        TraceurException.create().appendTo(e)
      }
      .doOnError { e ->
        TraceurException.create().appendTo(e)
      }
      .doOnError(logError())
      .onErrorComplete()
}
```