### PR TITLE
Exclude deleted blood pressures (Part 2)

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/TestData.kt
+++ b/app/src/androidTest/java/org/simple/clinic/TestData.kt
@@ -74,15 +74,15 @@ class TestData @Inject constructor(
   fun patientProfile(
       patientUuid: UUID = UUID.randomUUID(),
       patientAddressUuid: UUID = UUID.randomUUID(),
-      syncStatus: SyncStatus = randomOfEnum(SyncStatus::class)
+      syncStatus: SyncStatus = randomOfEnum(SyncStatus::class),
+      generatePhoneNumber: Boolean = faker.bool.bool()
   ): PatientProfile {
-    val numberOfPhoneNumbersToAdd = (0..1).shuffled().first()
+    val phoneNumbers = if(generatePhoneNumber) listOf(patientPhoneNumber(patientUuid = patientUuid)) else emptyList()
 
     return PatientProfile(
         patient = patient(uuid = patientUuid, syncStatus = syncStatus, addressUuid = patientAddressUuid),
         address = patientAddress(uuid = patientAddressUuid),
-        phoneNumbers = (0 until numberOfPhoneNumbersToAdd).map { patientPhoneNumber(patientUuid = patientUuid) }
-    )
+        phoneNumbers = phoneNumbers)
   }
 
   fun patient(

--- a/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
+++ b/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
@@ -114,7 +114,7 @@ class DebugClinicApp : ClinicApp() {
         .bloodPressureModule(object : BloodPressureModule() {
           override fun provideBloodPressureEntryConfig(): BloodPressureConfig {
             return super.provideBloodPressureEntryConfig()
-                .copy(deleteBloodPressureFeatureEnabled = true, dateEntryEnabled = true)
+                .copy(dateEntryEnabled = true)
           }
         })
         .build()

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureConfig.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureConfig.kt
@@ -1,6 +1,3 @@
 package org.simple.clinic.bp
 
-data class BloodPressureConfig(
-    val deleteBloodPressureFeatureEnabled: Boolean,
-    val dateEntryEnabled: Boolean
-)
+data class BloodPressureConfig(val dateEntryEnabled: Boolean)

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureMeasurement.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureMeasurement.kt
@@ -78,6 +78,13 @@ data class BloodPressureMeasurement (
     fun count(): Flowable<Int>
 
     @Query("""
+      SELECT COUNT(uuid)
+      FROM bloodpressuremeasurement
+      WHERE patientUuid = :patientUuid AND deletedAt IS NULL
+    """)
+    fun recordedBloodPressureCountForPatient(patientUuid: UUID): Flowable<Int>
+
+    @Query("""
       SELECT * FROM bloodpressuremeasurement
         WHERE patientUuid = :patientUuid AND deletedAt IS NULL
         ORDER BY createdAt DESC LIMIT :limit

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureModule.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureModule.kt
@@ -50,9 +50,7 @@ open class BloodPressureModule {
    */
   @Provides
   open fun provideBloodPressureEntryConfig(): BloodPressureConfig {
-    return BloodPressureConfig(
-        deleteBloodPressureFeatureEnabled = false,
-        dateEntryEnabled = true)
+    return BloodPressureConfig(dateEntryEnabled = true)
   }
 
   @Provides

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureRepository.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureRepository.kt
@@ -132,4 +132,10 @@ class BloodPressureRepository @Inject constructor(
       dao.save(listOf(deletedBloodPressureMeasurement))
     }
   }
+
+  fun bloodPressureCount(patientUuid: UUID): Observable<Int> {
+    return dao
+        .recordedBloodPressureCountForPatient(patientUuid)
+        .toObservable()
+  }
 }

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
@@ -3,14 +3,12 @@ package org.simple.clinic.bp.entry
 import io.reactivex.Observable
 import io.reactivex.ObservableSource
 import io.reactivex.ObservableTransformer
-import io.reactivex.Single
 import io.reactivex.rxkotlin.Observables
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.rxkotlin.withLatestFrom
 import io.reactivex.schedulers.Schedulers.io
 import org.simple.clinic.ReplayUntilScreenIsDestroyed
 import org.simple.clinic.ReportAnalyticsEvents
-import org.simple.clinic.bp.BloodPressureConfig
 import org.simple.clinic.bp.BloodPressureRepository
 import org.simple.clinic.bp.entry.BloodPressureEntrySheetController.Validation.ERROR_DIASTOLIC_EMPTY
 import org.simple.clinic.bp.entry.BloodPressureEntrySheetController.Validation.ERROR_DIASTOLIC_TOO_HIGH
@@ -29,7 +27,6 @@ import javax.inject.Inject
 @Deprecated(message = "Use BloodPressureEntrySheetControllerV2 instead")
 class BloodPressureEntrySheetController @Inject constructor(
     private val bloodPressureRepository: BloodPressureRepository,
-    private val configProvider: Single<BloodPressureConfig>,
     private val clock: Clock
 ) : ObservableTransformer<UiEvent, UiChange> {
 
@@ -257,22 +254,16 @@ class BloodPressureEntrySheetController @Inject constructor(
   }
 
   private fun toggleRemoveBloodPressureButton(events: Observable<UiEvent>): Observable<UiChange> {
-    val featureEnabledStream = configProvider
-        .map { it.deleteBloodPressureFeatureEnabled }
-        .toObservable()
-
-    val openAsStream = events
+    val hideRemoveBpButton = events
         .ofType<BloodPressureEntrySheetCreated>()
         .map { it.openAs }
-
-    val hideRemoveBpButton = Observables
-        .combineLatest(featureEnabledStream, openAsStream)
-        .filter { (featureEnabled, openAs) -> featureEnabled.not() || openAs is OpenAs.New }
+        .ofType<OpenAs.New>()
         .map { { ui: Ui -> ui.hideRemoveBpButton() } }
 
-    val showRemoveBpButton = Observables
-        .combineLatest(featureEnabledStream, openAsStream)
-        .filter { (featureEnabled, openAs) -> featureEnabled && openAs is OpenAs.Update }
+    val showRemoveBpButton = events
+        .ofType<BloodPressureEntrySheetCreated>()
+        .map { it.openAs }
+        .ofType<OpenAs.Update>()
         .map { { ui: Ui -> ui.showRemoveBpButton() } }
 
     return hideRemoveBpButton.mergeWith(showRemoveBpButton)

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueAppointment.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueAppointment.kt
@@ -103,7 +103,7 @@ data class OverdueAppointment(
           FROM Patient P
 
           INNER JOIN Appointment A ON A.patientUuid = P.uuid
-          INNER JOIN BloodPressureMeasurement BP ON BP.patientUuid = P.uuid
+          INNER JOIN BloodPressureMeasurement BP ON (BP.patientUuid = P.uuid AND BP.deletedAt IS NULL)
           LEFT JOIN PatientPhoneNumber PPN ON PPN.patientUuid = P.uuid
           LEFT JOIN MedicalHistory MH ON MH.patientUuid = P.uuid
 

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
@@ -19,7 +19,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.simple.clinic.bp.BloodPressureConfig
 import org.simple.clinic.bp.BloodPressureMeasurement
 import org.simple.clinic.bp.BloodPressureRepository
 import org.simple.clinic.bp.entry.BloodPressureEntrySheet.ScreenType.BP_ENTRY
@@ -60,7 +59,6 @@ class BloodPressureEntrySheetControllerTestV2 {
   private val bpValidator = mock<BpValidator>()
 
   private val uiEvents = PublishSubject.create<UiEvent>()
-  private val configEmitter = PublishSubject.create<BloodPressureConfig>()
   private lateinit var controller: BloodPressureEntrySheetControllerV2
 
   private val patientUuid = UUID.randomUUID()
@@ -74,7 +72,6 @@ class BloodPressureEntrySheetControllerTestV2 {
 
     controller = BloodPressureEntrySheetControllerV2(
         bloodPressureRepository = bloodPressureRepository,
-        configProvider = configEmitter.firstOrError(),
         dateValidator = dateValidator,
         bpValidator = bpValidator,
         clock = testClock,
@@ -275,42 +272,12 @@ class BloodPressureEntrySheetControllerTestV2 {
     )
   }
 
-  // TODO: Remove this test when feature flag is lifted.
-  @Test
-  @Parameters(method = "params for enabling delete bp feature")
-  fun `when the delete blood pressure feature flag is enabled and the sheet is opened for update, the remove BP button must be shown`(
-      featureEnabled: Boolean,
-      openAs: OpenAs,
-      shouldShowRemoveBpButton: Boolean
-  ) {
-    configEmitter.onNext(BloodPressureConfig(deleteBloodPressureFeatureEnabled = featureEnabled, dateEntryEnabled = false))
-    whenever(bloodPressureRepository.measurement(any())).thenReturn(Observable.just(PatientMocker.bp()))
-
-    uiEvents.onNext(BloodPressureEntrySheetCreated(openAs))
-
-    if (shouldShowRemoveBpButton) {
-      verify(sheet).showRemoveBpButton()
-    } else {
-      verify(sheet).hideRemoveBpButton()
-    }
-  }
-
-  @Suppress("Unused")
-  private fun `params for enabling delete bp feature`(): List<List<Any>> {
-    return listOf(
-        listOf(true, OpenAs.New(UUID.randomUUID()), false),
-        listOf(true, OpenAs.Update(UUID.randomUUID()), true),
-        listOf(false, OpenAs.New(UUID.randomUUID()), false),
-        listOf(false, OpenAs.Update(UUID.randomUUID()), false))
-  }
-
   @Test
   @Parameters(method = "params for showing remove button")
   fun `the remove BP button must be shown when the sheet is opened for update`(
       openAs: OpenAs,
       shouldShowRemoveBpButton: Boolean
   ) {
-    configEmitter.onNext(BloodPressureConfig(deleteBloodPressureFeatureEnabled = true, dateEntryEnabled = false))
     whenever(bloodPressureRepository.measurement(any())).thenReturn(Observable.just(PatientMocker.bp()))
 
     uiEvents.onNext(BloodPressureEntrySheetCreated(openAs))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/163046626

# Changes
- Excluded deleted blood pressures from overdue appointments.
- Removed feature flag for toggling the "Remove Blood Pressure" feature.