### PR TITLE
Retro active bp entry (v2)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -182,6 +182,7 @@ dependencies {
   implementation "com.android.support:recyclerview-v7:$versions.supportLib"
   implementation "com.android.support:design:$versions.supportLib"
   implementation "com.android.support:cardview-v7:$versions.supportLib"
+  implementation "com.android.support.constraint:constraint-layout:$versions.constraintLayout"
   implementation "android.arch.persistence.room:runtime:$versions.archComponents"
   kapt "android.arch.persistence.room:compiler:$versions.archComponents"
   implementation "android.arch.persistence.room:rxjava2:$versions.archComponents"

--- a/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
+++ b/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
@@ -112,9 +112,9 @@ class DebugClinicApp : ClinicApp() {
           }
         })
         .bloodPressureModule(object : BloodPressureModule() {
-          override fun provideBloodPressureEntryConfig(): Single<BloodPressureConfig> {
+          override fun provideBloodPressureEntryConfig(): BloodPressureConfig {
             return super.provideBloodPressureEntryConfig()
-                .map { it.copy(deleteBloodPressureFeatureEnabled = true) }
+                .copy(deleteBloodPressureFeatureEnabled = true, dateEntryEnabled = false)
           }
         })
         .build()

--- a/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
+++ b/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
@@ -114,7 +114,7 @@ class DebugClinicApp : ClinicApp() {
         .bloodPressureModule(object : BloodPressureModule() {
           override fun provideBloodPressureEntryConfig(): BloodPressureConfig {
             return super.provideBloodPressureEntryConfig()
-                .copy(deleteBloodPressureFeatureEnabled = true, dateEntryEnabled = false)
+                .copy(deleteBloodPressureFeatureEnabled = true, dateEntryEnabled = true)
           }
         })
         .build()

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureConfig.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureConfig.kt
@@ -1,3 +1,6 @@
 package org.simple.clinic.bp
 
-data class BloodPressureConfig(val deleteBloodPressureFeatureEnabled: Boolean)
+data class BloodPressureConfig(
+    val deleteBloodPressureFeatureEnabled: Boolean,
+    val dateEntryEnabled: Boolean
+)

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureModule.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureModule.kt
@@ -2,15 +2,22 @@ package org.simple.clinic.bp
 
 import com.f2prateek.rx.preferences2.Preference
 import com.f2prateek.rx.preferences2.RxSharedPreferences
+import dagger.Lazy
 import dagger.Module
 import dagger.Provides
+import io.reactivex.ObservableTransformer
 import io.reactivex.Single
 import org.simple.clinic.AppDatabase
+import org.simple.clinic.bp.entry.BloodPressureEntrySheet
+import org.simple.clinic.bp.entry.BloodPressureEntrySheetController
+import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2
+import org.simple.clinic.bp.entry.UiChange
 import org.simple.clinic.bp.sync.BloodPressureSyncApiV2
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.OptionalRxPreferencesConverter
 import org.simple.clinic.util.StringPreferenceConverter
+import org.simple.clinic.widgets.UiEvent
 import retrofit2.Retrofit
 import javax.inject.Named
 
@@ -33,8 +40,34 @@ open class BloodPressureModule {
     return rxSharedPrefs.getObject("last_bp_pull_token_v2", None, OptionalRxPreferencesConverter(StringPreferenceConverter()))
   }
 
+  /**
+   * This is bad. Configs should be provided asynchronously because they'll be persisted in the
+   * future, but injecting [BloodPressureEntrySheet] controller asynchronously becomes verbose.
+   * Considering that this will get removed very soon once [BloodPressureConfig.dateEntryEnabled]
+   * is enabled, I guess this is okay for now.
+   */
   @Provides
-  open fun provideBloodPressureEntryConfig(): Single<BloodPressureConfig> {
-    return Single.just(BloodPressureConfig(deleteBloodPressureFeatureEnabled = false))
+  open fun provideBloodPressureEntryConfig(): BloodPressureConfig {
+    return BloodPressureConfig(
+        deleteBloodPressureFeatureEnabled = false,
+        dateEntryEnabled = false)
+  }
+
+  @Provides
+  fun provideBloodPressureEntryConfigProvider(config: BloodPressureConfig): Single<BloodPressureConfig> {
+    return Single.just(config)
+  }
+
+  @Provides
+  @Named("bp_entry_controller")
+  fun controller(
+      controllerV1: Lazy<BloodPressureEntrySheetController>,
+      controllerV2: Lazy<BloodPressureEntrySheetControllerV2>,
+      config: BloodPressureConfig
+  ): ObservableTransformer<UiEvent, UiChange> {
+    return when {
+      config.dateEntryEnabled -> controllerV2.get()
+      else -> controllerV1.get()
+    }
   }
 }

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureRepository.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureRepository.kt
@@ -60,9 +60,9 @@ class BloodPressureRepository @Inject constructor(
     return Completable.fromAction { dao.save(records) }
   }
 
-  fun updateMeasurement(bloodPressureMeasurement: BloodPressureMeasurement): Completable {
+  fun updateMeasurement(measurement: BloodPressureMeasurement): Completable {
     return Completable.fromAction {
-      val updatedMeasurement = bloodPressureMeasurement.copy(
+      val updatedMeasurement = measurement.copy(
           updatedAt = Instant.now(clock),
           syncStatus = SyncStatus.PENDING
       )

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureRepository.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureRepository.kt
@@ -25,7 +25,7 @@ class BloodPressureRepository @Inject constructor(
     private val clock: Clock
 ) : SynceableRepository<BloodPressureMeasurement, BloodPressureMeasurementPayload> {
 
-  fun saveMeasurement(patientUuid: UUID, systolic: Int, diastolic: Int): Single<BloodPressureMeasurement> {
+  fun saveMeasurement(patientUuid: UUID, systolic: Int, diastolic: Int, createdAt: Instant = Instant.now(clock)): Single<BloodPressureMeasurement> {
     if (systolic < 0 || diastolic < 0) {
       throw AssertionError("Cannot have negative BP readings.")
     }
@@ -47,8 +47,8 @@ class BloodPressureRepository @Inject constructor(
               userUuid = user!!.uuid,
               facilityUuid = facility.uuid,
               patientUuid = patientUuid,
-              createdAt = Instant.now(clock),
-              updatedAt = Instant.now(clock),
+              createdAt = createdAt,
+              updatedAt = createdAt,
               deletedAt = null)
         }
         .flatMap {

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
@@ -10,7 +10,6 @@ import android.view.inputmethod.EditorInfo
 import android.widget.Button
 import android.widget.EditText
 import android.widget.TextView
-import android.widget.ViewFlipper
 import com.jakewharton.rxbinding2.view.RxView
 import com.jakewharton.rxbinding2.widget.RxTextView
 import io.reactivex.Observable
@@ -22,12 +21,15 @@ import io.reactivex.subjects.PublishSubject
 import kotterknife.bindView
 import org.simple.clinic.R
 import org.simple.clinic.activity.TheActivity
+import org.simple.clinic.bp.entry.ScreenType.BP_ENTRY
+import org.simple.clinic.bp.entry.ScreenType.DATE_ENTRY
 import org.simple.clinic.router.screen.BackPressInterceptCallback
 import org.simple.clinic.router.screen.BackPressInterceptor
 import org.simple.clinic.router.screen.ScreenRouter
 import org.simple.clinic.widgets.BottomSheetActivity
 import org.simple.clinic.widgets.ScreenDestroyed
 import org.simple.clinic.widgets.UiEvent
+import org.simple.clinic.widgets.ViewFlipperWithDebugPreview
 import org.simple.clinic.widgets.setTextAndCursor
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -55,7 +57,7 @@ class BloodPressureEntrySheet : BottomSheetActivity() {
   private val dayEditText by bindView<EditText>(R.id.bloodpressureentry_day)
   private val monthEditText by bindView<EditText>(R.id.bloodpressureentry_month)
   private val yearEditText by bindView<EditText>(R.id.bloodpressureentry_year)
-  private val viewFlipper by bindView<ViewFlipper>(R.id.bloodpressureentry_view_flipper)
+  private val viewFlipper by bindView<ViewFlipperWithDebugPreview>(R.id.bloodpressureentry_view_flipper)
 
   private val screenDestroys = PublishSubject.create<ScreenDestroyed>()
 
@@ -182,12 +184,11 @@ class BloodPressureEntrySheet : BottomSheetActivity() {
     }
   }
 
-  private fun screenTypeChanges(): Observable<UiEvent> {
-    // RxViewFlipper
-    //     .displayedChildChanges
-    //     .map()
-    return Observable.just(BloodPressureScreenChanged(ScreenType.BP_ENTRY))
-  }
+  private fun screenTypeChanges(): Observable<UiEvent> =
+      viewFlipper.displayedChildChanges
+          .map {
+            BloodPressureScreenChanged(if (it == 0) BP_ENTRY else DATE_ENTRY)
+          }
 
   private fun dayTextChanges() =
       RxTextView.textChanges(dayEditText)

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
@@ -21,6 +21,9 @@ import io.reactivex.subjects.PublishSubject
 import kotterknife.bindView
 import org.simple.clinic.R
 import org.simple.clinic.activity.TheActivity
+import org.simple.clinic.router.screen.BackPressInterceptCallback
+import org.simple.clinic.router.screen.BackPressInterceptor
+import org.simple.clinic.router.screen.ScreenRouter
 import org.simple.clinic.widgets.BottomSheetActivity
 import org.simple.clinic.widgets.ScreenDestroyed
 import org.simple.clinic.widgets.UiEvent
@@ -35,6 +38,9 @@ class BloodPressureEntrySheet : BottomSheetActivity() {
   @Inject
   @field:Named("bp_entry_controller")
   lateinit var controller: ObservableTransformer<UiEvent, UiChange>
+
+  @Inject
+  lateinit var screenRouter: ScreenRouter
 
   private val rootLayout by bindView<LinearLayoutWithPreImeKeyEventListener>(R.id.bloodpressureentry_root)
   private val systolicEditText by bindView<EditText>(R.id.bloodpressureentry_systolic)
@@ -72,15 +78,17 @@ class BloodPressureEntrySheet : BottomSheetActivity() {
     setContentView(R.layout.sheet_blood_pressure_entry)
     TheActivity.component.inject(this)
 
-    Observable.mergeArray(
-    sheetCreates(),
-    screenDestroys,
-    systolicTextChanges(),
-    diastolicTextChanges(),
-    diastolicImeOptionClicks(),
-    diastolicBackspaceClicks(),
-    removeClicks())
-    .observeOn(Schedulers.io())
+    Observable
+        .mergeArray(
+            sheetCreates(),
+            screenDestroys,
+            systolicTextChanges(),
+            diastolicTextChanges(),
+            diastolicImeOptionClicks(),
+            diastolicBackspaceClicks(),
+            removeClicks(),
+            hardwareBackPresses())
+        .observeOn(Schedulers.io())
         .compose(controller)
         .observeOn(AndroidSchedulers.mainThread())
         .takeUntil(screenDestroys)
@@ -135,6 +143,19 @@ class BloodPressureEntrySheet : BottomSheetActivity() {
 
   private fun removeClicks(): Observable<UiEvent> =
       RxView.clicks(removeBloodPressureButton).map { BloodPressureRemoveClicked }
+
+  private fun hardwareBackPresses(): Observable<UiEvent> {
+    return Observable.create { emitter ->
+      val interceptor = object : BackPressInterceptor {
+        override fun onInterceptBackPress(callback: BackPressInterceptCallback) {
+          emitter.onNext(BloodPressureBackPressed)
+          callback.markBackPressIntercepted()
+        }
+      }
+      emitter.setCancellable { screenRouter.unregisterBackPressInterceptor(interceptor) }
+      screenRouter.registerBackPressInterceptor(interceptor)
+    }
+  }
 
   fun changeFocusToDiastolic() {
     diastolicEditText.requestFocus()

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
@@ -72,16 +72,15 @@ class BloodPressureEntrySheet : BottomSheetActivity() {
     setContentView(R.layout.sheet_blood_pressure_entry)
     TheActivity.component.inject(this)
 
-    Observable
-        .mergeArray(
-            sheetCreates(),
-            screenDestroys,
-            systolicTextChanges(),
-            diastolicTextChanges(),
-            diastolicImeOptionClicks(),
-            diastolicBackspaceClicks(),
-            removeClicks())
-        .observeOn(Schedulers.io())
+    Observable.mergeArray(
+    sheetCreates(),
+    screenDestroys,
+    systolicTextChanges(),
+    diastolicTextChanges(),
+    diastolicImeOptionClicks(),
+    diastolicBackspaceClicks(),
+    removeClicks())
+    .observeOn(Schedulers.io())
         .compose(controller)
         .observeOn(AndroidSchedulers.mainThread())
         .takeUntil(screenDestroys)

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
@@ -30,6 +30,7 @@ import org.simple.clinic.widgets.BottomSheetActivity
 import org.simple.clinic.widgets.ScreenDestroyed
 import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.ViewFlipperWithDebugPreview
+import org.simple.clinic.widgets.displayedChildResId
 import org.simple.clinic.widgets.setTextAndCursor
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -185,9 +186,14 @@ class BloodPressureEntrySheet : BottomSheetActivity() {
   }
 
   private fun screenTypeChanges(): Observable<UiEvent> =
-      viewFlipper.displayedChildChanges
+      viewFlipper
+          .displayedChildChanges
           .map {
-            BloodPressureScreenChanged(if (it == 0) BP_ENTRY else DATE_ENTRY)
+            BloodPressureScreenChanged(when (viewFlipper.displayedChildResId) {
+              R.id.bloodpressureentry_flipper_bp_entry -> BP_ENTRY
+              R.id.bloodpressureentry_flipper_date_entry -> DATE_ENTRY
+              else -> throw AssertionError()
+            })
           }
 
   private fun dayTextChanges() =
@@ -290,11 +296,11 @@ class BloodPressureEntrySheet : BottomSheetActivity() {
   }
 
   fun showBpEntryScreen() {
-    viewFlipper.displayedChild = 0
+    viewFlipper.displayedChildResId = R.id.bloodpressureentry_flipper_bp_entry
   }
 
   fun showDateEntryScreen() {
-    viewFlipper.displayedChild = 1
+    viewFlipper.displayedChildResId = R.id.bloodpressureentry_flipper_date_entry
   }
 
   fun showInvalidDateError() {

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
@@ -256,4 +256,8 @@ class BloodPressureEntrySheet : BottomSheetActivity() {
   fun showDateIsInFutureError() {
     TODO()
   }
+
+  fun setDate(dayOfMonth: Int, month: Int, year: Int) {
+    TODO()
+  }
 }

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
@@ -122,7 +122,7 @@ class BloodPressureEntrySheet : BottomSheetActivity() {
         .merge(
             RxTextView.editorActions(systolicEditText) { actionId -> actionId == EditorInfo.IME_ACTION_DONE },
             RxTextView.editorActions(diastolicEditText) { actionId -> actionId == EditorInfo.IME_ACTION_DONE })
-        .map { BloodPressureSaveClicked() }
+        .map { BloodPressureSaveClicked }
   }
 
   private fun diastolicBackspaceClicks(): Observable<UiEvent> {

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
@@ -13,6 +13,7 @@ import android.widget.TextView
 import com.jakewharton.rxbinding2.view.RxView
 import com.jakewharton.rxbinding2.widget.RxTextView
 import io.reactivex.Observable
+import io.reactivex.ObservableTransformer
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.rxkotlin.cast
 import io.reactivex.schedulers.Schedulers
@@ -27,11 +28,13 @@ import org.simple.clinic.widgets.setTextAndCursor
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import javax.inject.Named
 
 class BloodPressureEntrySheet : BottomSheetActivity() {
 
   @Inject
-  lateinit var controller: BloodPressureEntrySheetController
+  @field:Named("bp_entry_controller")
+  lateinit var controller: ObservableTransformer<UiEvent, UiChange>
 
   private val rootLayout by bindView<LinearLayoutWithPreImeKeyEventListener>(R.id.bloodpressureentry_root)
   private val systolicEditText by bindView<EditText>(R.id.bloodpressureentry_systolic)
@@ -142,7 +145,7 @@ class BloodPressureEntrySheet : BottomSheetActivity() {
     systolicEditText.requestFocus()
   }
 
-  fun setBPSavedResultAndFinish() {
+  fun setBpSavedResultAndFinish() {
     val intent = Intent()
     intent.putExtra(EXTRA_WAS_BP_SAVED, true)
     setResult(Activity.RESULT_OK, intent)
@@ -216,5 +219,21 @@ class BloodPressureEntrySheet : BottomSheetActivity() {
 
   fun showConfirmRemoveBloodPressureDialog(uuid: UUID) {
     ConfirmRemoveBloodPressureDialog.show(uuid, supportFragmentManager)
+  }
+
+  fun showBpEntryScreen() {
+    TODO()
+  }
+
+  fun showDateEntryScreen() {
+    TODO()
+  }
+
+  fun showInvalidDateError() {
+    TODO()
+  }
+
+  fun showDateIsInFutureError() {
+    TODO()
   }
 }

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
@@ -177,8 +177,20 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
   }
 
   private fun showBpEntryWhenBackArrowIsPressed(events: Observable<UiEvent>): Observable<UiChange> {
-    return events
+    val previousArrowClicks = events
         .ofType<BloodPressurePreviousArrowClicked>()
+
+    val screenChanges = events
+        .ofType<BloodPressureScreenChanged>()
+        .map { it.type }
+
+    val backPresses = events
+        .ofType<BloodPressureBackPressed>()
+        .withLatestFrom(screenChanges)
+        .filter { (_, screen) -> screen == DATE_ENTRY }
+
+    return Observable
+        .merge(previousArrowClicks, backPresses)
         .map { { ui: Ui -> ui.showBpEntryScreen() } }
   }
 

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
@@ -177,7 +177,9 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
   }
 
   private fun showBpEntryWhenBackArrowIsPressed(events: Observable<UiEvent>): Observable<UiChange> {
-    return Observable.never()
+    return events
+        .ofType<BloodPressurePreviousArrowClicked>()
+        .map { { ui: Ui -> ui.showBpEntryScreen() } }
   }
 
   private fun validateBpInput() = ObservableTransformer<UiEvent, UiEvent> { events ->

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
@@ -161,8 +161,14 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
           .map { Ui::showDateEntryScreen }
 
   private fun validateBpInput() = ObservableTransformer<UiEvent, UiEvent> { events ->
+    val screenChanges = events
+        .ofType<BloodPressureScreenChanged>()
+        .map { it.type }
+
     val saveBpClicks = events
         .ofType<BloodPressureSaveClicked>()
+        .withLatestFrom(screenChanges)
+        .filter { (_, screen) -> screen == ScreenType.BP_ENTRY }
 
     val systolicChanges = events
         .ofType<BloodPressureSystolicTextChanged>()

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
@@ -307,10 +307,10 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
 
   private fun validateDateInput() = ObservableTransformer<UiEvent, UiEvent> { events ->
     val screenChanges = events.ofType<BloodPressureScreenChanged>()
+        .filter { it.type == ScreenType.DATE_ENTRY }
 
     val saveBpClicks = events.ofType<BloodPressureSaveClicked>()
         .withLatestFrom(screenChanges)
-        .filter { (_, screen) -> screen.type == ScreenType.DATE_ENTRY }
 
     val dateChanges = events
         .ofType<BloodPressureDateChanged>()

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
@@ -12,15 +12,14 @@ import org.simple.clinic.ReplayUntilScreenIsDestroyed
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.bp.BloodPressureConfig
 import org.simple.clinic.bp.BloodPressureRepository
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ERROR_DIASTOLIC_EMPTY
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ERROR_DIASTOLIC_TOO_HIGH
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ERROR_DIASTOLIC_TOO_LOW
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ERROR_SYSTOLIC_EMPTY
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ERROR_SYSTOLIC_LESS_THAN_DIASTOLIC
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ERROR_SYSTOLIC_TOO_HIGH
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ERROR_SYSTOLIC_TOO_LOW
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.SUCCESS
-import org.simple.clinic.bp.entry.ScreenType.BP_ENTRY
+import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ErrorDiastolicEmpty
+import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ErrorDiastolicTooHigh
+import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ErrorDiastolicTooLow
+import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ErrorSystolicEmpty
+import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ErrorSystolicLessThanDiastolic
+import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ErrorSystolicTooHigh
+import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ErrorSystolicTooLow
+import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.Success
 import org.simple.clinic.util.exhaustive
 import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
@@ -47,6 +46,7 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
     val replayedEvents = ReplayUntilScreenIsDestroyed(events)
         .compose(ReportAnalyticsEvents())
         .compose(combineDateInputs())
+        .compose(validateBpInput())
         .compose(validateDateInput())
         .replay()
 
@@ -54,7 +54,7 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
         automaticFocusChanges(replayedEvents),
         validationErrorResets(replayedEvents),
         prefillWhenUpdatingABloodPressure(replayedEvents),
-        bpValidations(replayedEvents),
+        showBpValidationErrors(replayedEvents),
         proceedToDateEntryWhenBpEntryIsDone(replayedEvents),
         //        updateBp(replayedEvents),
         toggleRemoveBloodPressureButton(replayedEvents),
@@ -136,43 +136,33 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
         }
   }
 
-  private fun bpValidations(events: Observable<UiEvent>): Observable<UiChange> {
-    val imeDoneClicks = events.ofType<BloodPressureSaveClicked>()
-
-    val systolicChanges = events
-        .ofType<BloodPressureSystolicTextChanged>()
-        .map { it.systolic }
-
-    val diastolicChanges = events
-        .ofType<BloodPressureDiastolicTextChanged>()
-        .map { it.diastolic }
-
-    return imeDoneClicks
-        .withLatestFrom(systolicChanges, diastolicChanges) { _, systolic, diastolic -> systolic to diastolic }
-        .map { (systolic, diastolic) ->
-          { ui: Ui ->
-            when (validateBpInput(systolic, diastolic)) {
-              ERROR_SYSTOLIC_LESS_THAN_DIASTOLIC -> ui.showSystolicLessThanDiastolicError()
-              ERROR_SYSTOLIC_TOO_HIGH -> ui.showSystolicHighError()
-              ERROR_SYSTOLIC_TOO_LOW -> ui.showSystolicLowError()
-              ERROR_DIASTOLIC_TOO_HIGH -> ui.showDiastolicHighError()
-              ERROR_DIASTOLIC_TOO_LOW -> ui.showDiastolicLowError()
-              ERROR_SYSTOLIC_EMPTY -> ui.showSystolicEmptyError()
-              ERROR_DIASTOLIC_EMPTY -> ui.showDiastolicEmptyError()
-              SUCCESS -> {
-                // Nothing to do here, SUCCESS handled below separately!
-              }
-            }.exhaustive()
+  private fun showBpValidationErrors(events: Observable<UiEvent>): Observable<UiChange> =
+      events.ofType<BloodPressureBpValidated>()
+          .map {
+            { ui: Ui ->
+              when (it.result) {
+                ErrorSystolicLessThanDiastolic -> ui.showSystolicLessThanDiastolicError()
+                ErrorSystolicTooHigh -> ui.showSystolicHighError()
+                ErrorSystolicTooLow -> ui.showSystolicLowError()
+                ErrorDiastolicTooHigh -> ui.showDiastolicHighError()
+                ErrorDiastolicTooLow -> ui.showDiastolicLowError()
+                ErrorSystolicEmpty -> ui.showSystolicEmptyError()
+                ErrorDiastolicEmpty -> ui.showDiastolicEmptyError()
+                Success -> {
+                  // Nothing to do here, SUCCESS handled below separately!
+                }
+              }.exhaustive()
+            }
           }
-        }
-  }
 
-  private fun proceedToDateEntryWhenBpEntryIsDone(events: Observable<UiEvent>): Observable<UiChange> {
-    val screenChanges = events.ofType<BloodPressureScreenChanged>()
+  private fun proceedToDateEntryWhenBpEntryIsDone(events: Observable<UiEvent>): Observable<UiChange> =
+      events.ofType<BloodPressureBpValidated>()
+          .filter { it.result is Success }
+          .map { Ui::showDateEntryScreen }
 
-    val saveBpClicks = events.ofType<BloodPressureSaveClicked>()
-        .withLatestFrom(screenChanges)
-        .filter { (_, screen) -> screen.type == BP_ENTRY }
+  private fun validateBpInput() = ObservableTransformer<UiEvent, UiEvent> { events ->
+    val saveBpClicks = events
+        .ofType<BloodPressureSaveClicked>()
 
     val systolicChanges = events
         .ofType<BloodPressureSystolicTextChanged>()
@@ -182,42 +172,43 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
         .ofType<BloodPressureDiastolicTextChanged>()
         .map { it.diastolic }
 
-    return saveBpClicks
+    val validations = saveBpClicks
         .withLatestFrom(systolicChanges, diastolicChanges)
-        .filter { (_, systolic, diastolic) -> validateBpInput(systolic, diastolic) == SUCCESS }
-        .map { Ui::showDateEntryScreen }
+        .map { (_, systolic, diastolic) -> BloodPressureBpValidated(bpResult(systolic, diastolic)) }
+
+    events.mergeWith(validations)
   }
 
-  private fun validateBpInput(systolic: String, diastolic: String): Validation {
+  private fun bpResult(systolic: String, diastolic: String): Validation {
     if (systolic.isBlank()) {
-      return ERROR_SYSTOLIC_EMPTY
+      return ErrorSystolicEmpty
     }
     if (diastolic.isBlank()) {
-      return ERROR_DIASTOLIC_EMPTY
+      return ErrorDiastolicEmpty
     }
 
     val systolicNumber = systolic.trim().toInt()
     val diastolicNumber = diastolic.trim().toInt()
 
     return when {
-      systolicNumber < 70 -> ERROR_SYSTOLIC_TOO_LOW
-      systolicNumber > 300 -> ERROR_SYSTOLIC_TOO_HIGH
-      diastolicNumber < 40 -> ERROR_DIASTOLIC_TOO_LOW
-      diastolicNumber > 180 -> ERROR_DIASTOLIC_TOO_HIGH
-      systolicNumber < diastolicNumber -> ERROR_SYSTOLIC_LESS_THAN_DIASTOLIC
-      else -> SUCCESS
+      systolicNumber < 70 -> ErrorSystolicTooLow
+      systolicNumber > 300 -> ErrorSystolicTooHigh
+      diastolicNumber < 40 -> ErrorDiastolicTooLow
+      diastolicNumber > 180 -> ErrorDiastolicTooHigh
+      systolicNumber < diastolicNumber -> ErrorSystolicLessThanDiastolic
+      else -> Success
     }
   }
 
-  enum class Validation {
-    SUCCESS,
-    ERROR_SYSTOLIC_EMPTY,
-    ERROR_DIASTOLIC_EMPTY,
-    ERROR_SYSTOLIC_TOO_HIGH,
-    ERROR_SYSTOLIC_TOO_LOW,
-    ERROR_DIASTOLIC_TOO_HIGH,
-    ERROR_DIASTOLIC_TOO_LOW,
-    ERROR_SYSTOLIC_LESS_THAN_DIASTOLIC
+  sealed class Validation {
+    object Success : Validation()
+    object ErrorSystolicEmpty : Validation()
+    object ErrorDiastolicEmpty : Validation()
+    object ErrorSystolicTooHigh : Validation()
+    object ErrorSystolicTooLow : Validation()
+    object ErrorDiastolicTooHigh : Validation()
+    object ErrorDiastolicTooLow : Validation()
+    object ErrorSystolicLessThanDiastolic : Validation()
   }
 
   private fun toggleRemoveBloodPressureButton(events: Observable<UiEvent>): Observable<UiChange> {

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
@@ -24,11 +24,11 @@ import org.simple.clinic.bp.entry.ScreenType.BP_ENTRY
 import org.simple.clinic.bp.entry.ScreenType.DATE_ENTRY
 import org.simple.clinic.util.exhaustive
 import org.simple.clinic.widgets.UiEvent
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Invalid
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Invalid.DateIsInFuture
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Invalid.InvalidPattern
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Valid
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result2.Invalid
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result2.Invalid.DateIsInFuture
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result2.Invalid.InvalidPattern
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result2.Valid
 import org.threeten.bp.Clock
 import org.threeten.bp.LocalDate
 import org.threeten.bp.ZoneOffset.UTC
@@ -43,7 +43,7 @@ typealias UiChange = (Ui) -> Unit
 class BloodPressureEntrySheetControllerV2 @Inject constructor(
     private val bloodPressureRepository: BloodPressureRepository,
     private val configProvider: Single<BloodPressureConfig>,
-    private val dateValidator: DateOfBirthFormatValidator,
+    private val dateValidator: UserInputDateValidator,
     private val bpValidator: BpValidator,
     private val clock: Clock
 ) : ObservableTransformer<UiEvent, UiChange> {

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
@@ -63,7 +63,6 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
         prefillDate(replayedEvents),
         showBpValidationErrors(replayedEvents),
         proceedToDateEntryWhenBpEntryIsDone(replayedEvents),
-        showDateEntryWhenNextArrowIsPressed(replayedEvents),
         showBpEntryWhenBackArrowIsPressed(replayedEvents),
         toggleRemoveBloodPressureButton(replayedEvents),
         updateSheetTitle(replayedEvents),
@@ -195,18 +194,6 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
       events.ofType<BloodPressureBpValidated>()
           .filter { it.result is Success }
           .map { Ui::showDateEntryScreen }
-
-  private fun showDateEntryWhenNextArrowIsPressed(events: Observable<UiEvent>): Observable<UiChange> {
-    val bpValidationResults = events
-        .ofType<BloodPressureBpValidated>()
-        .map { it.result }
-
-    return events
-        .ofType<BloodPressureNextArrowClicked>()
-        .withLatestFrom(bpValidationResults)
-        .filter { (_, result) -> result is Success }
-        .map { { ui: Ui -> ui.showDateEntryScreen() } }
-  }
 
   private fun showBpEntryWhenBackArrowIsPressed(events: Observable<UiEvent>): Observable<UiChange> {
     val previousArrowClicks = events

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
@@ -24,9 +24,10 @@ import org.simple.clinic.bp.entry.ScreenType.BP_ENTRY
 import org.simple.clinic.util.exhaustive
 import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result.DATE_IS_IN_FUTURE
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result.INVALID_PATTERN
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result.VALID
+import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Invalid
+import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Invalid.DateIsInFuture
+import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Invalid.InvalidPattern
 import org.threeten.bp.LocalDate
 import org.threeten.bp.ZoneOffset.UTC
 import org.threeten.bp.format.DateTimeFormatter
@@ -327,12 +328,11 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
   private fun showDateValidationErrors(events: Observable<UiEvent>): Observable<UiChange> {
     return events.ofType<BloodPressureDateValidated>()
         .map { it.result(dateValidator) }
-        .filter { it != VALID }
+        .ofType<Invalid>()
         .map<UiChange> {
           when (it) {
-            VALID -> throw AssertionError()
-            INVALID_PATTERN -> { ui: Ui -> ui.showInvalidDateError() }
-            DATE_IS_IN_FUTURE -> { ui: Ui -> ui.showDateIsInFutureError() }
+            is InvalidPattern -> { ui: Ui -> ui.showInvalidDateError() }
+            is DateIsInFuture -> { ui: Ui -> ui.showDateIsInFutureError() }
           }
         }
   }

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
@@ -144,14 +144,14 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
           .map {
             { ui: Ui ->
               when (it.result) {
-                ErrorSystolicLessThanDiastolic -> ui.showSystolicLessThanDiastolicError()
-                ErrorSystolicTooHigh -> ui.showSystolicHighError()
-                ErrorSystolicTooLow -> ui.showSystolicLowError()
-                ErrorDiastolicTooHigh -> ui.showDiastolicHighError()
-                ErrorDiastolicTooLow -> ui.showDiastolicLowError()
-                ErrorSystolicEmpty -> ui.showSystolicEmptyError()
-                ErrorDiastolicEmpty -> ui.showDiastolicEmptyError()
-                Success -> {
+                is ErrorSystolicLessThanDiastolic -> ui.showSystolicLessThanDiastolicError()
+                is ErrorSystolicTooHigh -> ui.showSystolicHighError()
+                is ErrorSystolicTooLow -> ui.showSystolicLowError()
+                is ErrorDiastolicTooHigh -> ui.showDiastolicHighError()
+                is ErrorDiastolicTooLow -> ui.showDiastolicLowError()
+                is ErrorSystolicEmpty -> ui.showSystolicEmptyError()
+                is ErrorDiastolicEmpty -> ui.showDiastolicEmptyError()
+                is Success -> {
                   // Nothing to do here, SUCCESS handled below separately!
                 }
               }.exhaustive()
@@ -221,12 +221,16 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
       diastolicNumber < 40 -> ErrorDiastolicTooLow
       diastolicNumber > 180 -> ErrorDiastolicTooHigh
       systolicNumber < diastolicNumber -> ErrorSystolicLessThanDiastolic
-      else -> Success
+      else -> Success(systolicNumber, diastolicNumber)
     }
   }
 
   sealed class Validation {
-    object Success : Validation()
+    data class Success(
+        val systolic: Int,
+        val diastolic: Int
+    ) : Validation()
+
     object ErrorSystolicEmpty : Validation()
     object ErrorDiastolicEmpty : Validation()
     object ErrorSystolicTooHigh : Validation()
@@ -362,19 +366,10 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
         .ofType<Valid>()
         .map { it.parsedDate }
 
-    data class BP(val systolic: Int, val diastolic: Int)
-
-    val systolicChanges = events
-        .ofType<BloodPressureSystolicTextChanged>()
-        .map { it.systolic }
-
-    val diastolicChanges = events
-        .ofType<BloodPressureDiastolicTextChanged>()
-        .map { it.diastolic }
-
-    val bpChanges = validDates
-        .withLatestFrom(systolicChanges, diastolicChanges)
-        .map { (_, systolic, diastolic) -> BP(systolic.toInt(), diastolic.toInt()) }
+    val validBps = events
+        .ofType<BloodPressureBpValidated>()
+        .map { it.result }
+        .ofType<Success>()
 
     val patientUuidStream = openAs
         .ofType<OpenAs.New>()
@@ -385,7 +380,7 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
         .map { it.bpUuid }
 
     val saveNewBp = validDates
-        .withLatestFrom(bpChanges, patientUuidStream)
+        .withLatestFrom(validBps, patientUuidStream)
         .flatMapSingle { (date, bp, patientUuid) ->
           val dateAsInstant = date.atStartOfDay(UTC).toInstant()
           bloodPressureRepository.saveMeasurement(patientUuid, bp.systolic, bp.diastolic, dateAsInstant)
@@ -393,7 +388,7 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
         .map { { ui: Ui -> ui.setBpSavedResultAndFinish() } }
 
     val updateExistingBp = validDates
-        .withLatestFrom(bpChanges, existingBpUuidStream)
+        .withLatestFrom(validBps, existingBpUuidStream)
         .flatMap { (date, newBp, existingBpUuid) ->
           bloodPressureRepository.measurement(existingBpUuid)
               .take(1)

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerV2.kt
@@ -12,14 +12,14 @@ import org.simple.clinic.ReplayUntilScreenIsDestroyed
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.bp.BloodPressureConfig
 import org.simple.clinic.bp.BloodPressureRepository
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ErrorDiastolicEmpty
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ErrorDiastolicTooHigh
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ErrorDiastolicTooLow
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ErrorSystolicEmpty
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ErrorSystolicLessThanDiastolic
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ErrorSystolicTooHigh
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.ErrorSystolicTooLow
-import org.simple.clinic.bp.entry.BloodPressureEntrySheetControllerV2.Validation.Success
+import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorDiastolicEmpty
+import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorDiastolicTooHigh
+import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorDiastolicTooLow
+import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorSystolicEmpty
+import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorSystolicLessThanDiastolic
+import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorSystolicTooHigh
+import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorSystolicTooLow
+import org.simple.clinic.bp.entry.BpValidator.Validation.Success
 import org.simple.clinic.bp.entry.ScreenType.BP_ENTRY
 import org.simple.clinic.bp.entry.ScreenType.DATE_ENTRY
 import org.simple.clinic.util.exhaustive
@@ -41,7 +41,8 @@ typealias UiChange = (Ui) -> Unit
 class BloodPressureEntrySheetControllerV2 @Inject constructor(
     private val bloodPressureRepository: BloodPressureRepository,
     private val configProvider: Single<BloodPressureConfig>,
-    private val dateValidator: DateOfBirthFormatValidator
+    private val dateValidator: DateOfBirthFormatValidator,
+    private val bpValidator: BpValidator
 ) : ObservableTransformer<UiEvent, UiChange> {
 
   override fun apply(events: Observable<UiEvent>): ObservableSource<UiChange> {
@@ -199,45 +200,10 @@ class BloodPressureEntrySheetControllerV2 @Inject constructor(
 
     val validations = saveBpClicks
         .withLatestFrom(systolicChanges, diastolicChanges)
-        .map { (_, systolic, diastolic) -> BloodPressureBpValidated(bpResult(systolic, diastolic)) }
+        .map { (_, systolic, diastolic) -> bpValidator.validate(systolic, diastolic) }
+        .map(::BloodPressureBpValidated)
 
     events.mergeWith(validations)
-  }
-
-  private fun bpResult(systolic: String, diastolic: String): Validation {
-    if (systolic.isBlank()) {
-      return ErrorSystolicEmpty
-    }
-    if (diastolic.isBlank()) {
-      return ErrorDiastolicEmpty
-    }
-
-    val systolicNumber = systolic.trim().toInt()
-    val diastolicNumber = diastolic.trim().toInt()
-
-    return when {
-      systolicNumber < 70 -> ErrorSystolicTooLow
-      systolicNumber > 300 -> ErrorSystolicTooHigh
-      diastolicNumber < 40 -> ErrorDiastolicTooLow
-      diastolicNumber > 180 -> ErrorDiastolicTooHigh
-      systolicNumber < diastolicNumber -> ErrorSystolicLessThanDiastolic
-      else -> Success(systolicNumber, diastolicNumber)
-    }
-  }
-
-  sealed class Validation {
-    data class Success(
-        val systolic: Int,
-        val diastolic: Int
-    ) : Validation()
-
-    object ErrorSystolicEmpty : Validation()
-    object ErrorDiastolicEmpty : Validation()
-    object ErrorSystolicTooHigh : Validation()
-    object ErrorSystolicTooLow : Validation()
-    object ErrorDiastolicTooHigh : Validation()
-    object ErrorDiastolicTooLow : Validation()
-    object ErrorSystolicLessThanDiastolic : Validation()
   }
 
   private fun toggleRemoveBloodPressureButton(events: Observable<UiEvent>): Observable<UiChange> {

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
@@ -4,11 +4,11 @@ import org.simple.clinic.widgets.UiEvent
 
 data class BloodPressureEntrySheetCreated(val openAs: OpenAs) : UiEvent
 
-class BloodPressureSystolicTextChanged(val systolic: String) : UiEvent {
+data class BloodPressureSystolicTextChanged(val systolic: String) : UiEvent {
   override val analyticsName = "Blood Pressure Entry:Systolic Text Changed"
 }
 
-class BloodPressureDiastolicTextChanged(val diastolic: String) : UiEvent {
+data class BloodPressureDiastolicTextChanged(val diastolic: String) : UiEvent {
   override val analyticsName = "Blood Pressure Entry:Diastolic Text Changed"
 }
 

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
@@ -41,6 +41,14 @@ data class BloodPressureMonthChanged(val month: String) : UiEvent
 data class BloodPressureYearChanged(val year: String) : UiEvent
 data class BloodPressureDateChanged(val date: String) : UiEvent
 
-object BloodPressureNextArrowClicked : UiEvent
-object BloodPressurePreviousArrowClicked : UiEvent
-object BloodPressureBackPressed : UiEvent
+object BloodPressureNextArrowClicked : UiEvent {
+  override val analyticsName = "Blood Pressure Entry:Next Arrow Clicked"
+}
+
+object BloodPressurePreviousArrowClicked : UiEvent {
+  override val analyticsName = "Blood Pressure Entry:Previous Arrow Clicked"
+}
+
+object BloodPressureBackPressed : UiEvent {
+  override val analyticsName = "Blood Pressure Entry:Hardware Back Pressed"
+}

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
@@ -43,3 +43,4 @@ data class BloodPressureDateChanged(val date: String) : UiEvent
 
 object BloodPressureNextArrowClicked : UiEvent
 object BloodPressurePreviousArrowClicked : UiEvent
+object BloodPressureBackPressed : UiEvent

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
@@ -1,7 +1,7 @@
 package org.simple.clinic.bp.entry
 
 import org.simple.clinic.widgets.UiEvent
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
 
 data class BloodPressureEntrySheetCreated(val openAs: OpenAs) : UiEvent
 
@@ -26,7 +26,7 @@ object BloodPressureDiastolicBackspaceClicked : UiEvent
 data class BloodPressureBpValidated(val result: BpValidator.Validation) : UiEvent
 
 data class BloodPressureDateValidated(val date: String) : UiEvent {
-  fun result(validator: DateOfBirthFormatValidator) = validator.validate2(date)
+  fun result(validator: UserInputDateValidator) = validator.validate2(date)
 }
 
 data class BloodPressureScreenChanged(val type: ScreenType) : UiEvent

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
@@ -25,7 +25,7 @@ object BloodPressureDiastolicBackspaceClicked : UiEvent
 
 // TODO: Find a better name or revert to using hardcoded values.
 data class BloodPressureDateValidated(val date: String) : UiEvent {
-  fun result(validator: DateOfBirthFormatValidator) = validator.validate(date)
+  fun result(validator: DateOfBirthFormatValidator) = validator.validate2(date)
 }
 
 data class BloodPressureScreenChanged(val type: ScreenType) : UiEvent

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
@@ -12,7 +12,7 @@ class BloodPressureDiastolicTextChanged(val diastolic: String) : UiEvent {
   override val analyticsName = "Blood Pressure Entry:Diastolic Text Changed"
 }
 
-class BloodPressureSaveClicked : UiEvent {
+object BloodPressureSaveClicked : UiEvent {
   override val analyticsName = "Blood Pressure Entry:Save Clicked"
 }
 

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
@@ -23,7 +23,7 @@ object BloodPressureRemoveClicked : UiEvent {
 
 object BloodPressureDiastolicBackspaceClicked : UiEvent
 
-data class BloodPressureBpValidated(val result: BloodPressureEntrySheetControllerV2.Validation) : UiEvent
+data class BloodPressureBpValidated(val result: BpValidator.Validation) : UiEvent
 
 data class BloodPressureDateValidated(val date: String) : UiEvent {
   fun result(validator: DateOfBirthFormatValidator) = validator.validate2(date)

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
@@ -23,7 +23,8 @@ object BloodPressureRemoveClicked : UiEvent {
 
 object BloodPressureDiastolicBackspaceClicked : UiEvent
 
-// TODO: Find a better name or revert to using hardcoded values.
+data class BloodPressureBpValidated(val result: BloodPressureEntrySheetControllerV2.Validation) : UiEvent
+
 data class BloodPressureDateValidated(val date: String) : UiEvent {
   fun result(validator: DateOfBirthFormatValidator) = validator.validate2(date)
 }

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
@@ -1,6 +1,7 @@
 package org.simple.clinic.bp.entry
 
 import org.simple.clinic.widgets.UiEvent
+import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
 
 data class BloodPressureEntrySheetCreated(val openAs: OpenAs) : UiEvent
 
@@ -22,9 +23,19 @@ object BloodPressureRemoveClicked : UiEvent {
 
 object BloodPressureDiastolicBackspaceClicked : UiEvent
 
+// TODO: Find a better name or revert to using hardcoded values.
+data class BloodPressureDateValidated(val date: String) : UiEvent {
+  fun result(validator: DateOfBirthFormatValidator) = validator.validate(date)
+}
+
 data class BloodPressureScreenChanged(val type: ScreenType) : UiEvent
 
 enum class ScreenType {
   BP_ENTRY,
   DATE_ENTRY
 }
+
+data class BloodPressureDayChanged(val day: String) : UiEvent
+data class BloodPressureMonthChanged(val month: String) : UiEvent
+data class BloodPressureYearChanged(val year: String) : UiEvent
+data class BloodPressureDateChanged(val date: String): UiEvent

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
@@ -39,4 +39,6 @@ enum class ScreenType {
 data class BloodPressureDayChanged(val day: String) : UiEvent
 data class BloodPressureMonthChanged(val month: String) : UiEvent
 data class BloodPressureYearChanged(val year: String) : UiEvent
-data class BloodPressureDateChanged(val date: String): UiEvent
+data class BloodPressureDateChanged(val date: String) : UiEvent
+
+object BloodPressureNextArrowClicked : UiEvent

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
@@ -42,3 +42,4 @@ data class BloodPressureYearChanged(val year: String) : UiEvent
 data class BloodPressureDateChanged(val date: String) : UiEvent
 
 object BloodPressureNextArrowClicked : UiEvent
+object BloodPressurePreviousArrowClicked : UiEvent

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetEvents.kt
@@ -21,3 +21,10 @@ object BloodPressureRemoveClicked : UiEvent {
 }
 
 object BloodPressureDiastolicBackspaceClicked : UiEvent
+
+data class BloodPressureScreenChanged(val type: ScreenType) : UiEvent
+
+enum class ScreenType {
+  BP_ENTRY,
+  DATE_ENTRY
+}

--- a/app/src/main/java/org/simple/clinic/bp/entry/BpValidator.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BpValidator.kt
@@ -1,0 +1,52 @@
+package org.simple.clinic.bp.entry
+
+import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorDiastolicEmpty
+import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorDiastolicTooHigh
+import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorDiastolicTooLow
+import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorSystolicEmpty
+import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorSystolicLessThanDiastolic
+import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorSystolicTooHigh
+import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorSystolicTooLow
+import org.simple.clinic.bp.entry.BpValidator.Validation.Success
+import javax.inject.Inject
+
+class BpValidator @Inject constructor() {
+
+  // TODO: Rename to "Result".
+  sealed class Validation {
+    // TODO: Rename to "Valid".
+    data class Success(
+        val systolic: Int,
+        val diastolic: Int
+    ) : Validation()
+
+    object ErrorSystolicEmpty : Validation()
+    object ErrorDiastolicEmpty : Validation()
+    object ErrorSystolicTooHigh : Validation()
+    object ErrorSystolicTooLow : Validation()
+    object ErrorDiastolicTooHigh : Validation()
+    object ErrorDiastolicTooLow : Validation()
+    object ErrorSystolicLessThanDiastolic : Validation()
+  }
+
+  fun validate(systolic: String, diastolic: String): Validation {
+    if (systolic.isBlank()) {
+      return ErrorSystolicEmpty
+    }
+    if (diastolic.isBlank()) {
+      return ErrorDiastolicEmpty
+    }
+
+    val systolicNumber = systolic.trim().toInt()
+    val diastolicNumber = diastolic.trim().toInt()
+
+    return when {
+      systolicNumber < 70 -> ErrorSystolicTooLow
+      systolicNumber > 300 -> ErrorSystolicTooHigh
+      diastolicNumber < 40 -> ErrorDiastolicTooLow
+      diastolicNumber > 180 -> ErrorDiastolicTooHigh
+      systolicNumber < diastolicNumber -> ErrorSystolicLessThanDiastolic
+      else -> Success(systolicNumber, diastolicNumber)
+    }
+  }
+}

--- a/app/src/main/java/org/simple/clinic/editpatient/PatientEditScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/PatientEditScreenController.kt
@@ -37,7 +37,7 @@ import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility.AGE_VISIBLE
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility.BOTH_VISIBLE
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility.DATE_OF_BIRTH_VISIBLE
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
 import org.threeten.bp.Clock
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
@@ -52,7 +52,7 @@ class PatientEditScreenController @Inject constructor(
     private val patientRepository: PatientRepository,
     private val numberValidator: PhoneNumberValidator,
     private val clock: Clock,
-    private val dateOfBirthFormatValidator: DateOfBirthFormatValidator,
+    private val dobValidator: UserInputDateValidator,
     @Named("date_for_user_input") private val dateOfBirthFormatter: DateTimeFormatter
 ) : ObservableTransformer<UiEvent, UiChange> {
 
@@ -215,7 +215,7 @@ class PatientEditScreenController @Inject constructor(
           ongoingEditPatientEntry to phoneNumber
         }
         .map { (ongoingEditPatientEntry, phoneNumber) ->
-          ongoingEditPatientEntry.validate(phoneNumber.toNullable(), numberValidator, dateOfBirthFormatValidator)
+          ongoingEditPatientEntry.validate(phoneNumber.toNullable(), numberValidator, dobValidator)
         }
         .filter { it.isNotEmpty() }
         .map { errors ->
@@ -260,7 +260,7 @@ class PatientEditScreenController @Inject constructor(
     val validEntry = saveClicks
         .withLatestFrom(entryChanges, savedNumbers)
         .filter { (_, entry, savedNumber) ->
-          val validationErrors = entry.validate(savedNumber.toNullable(), numberValidator, dateOfBirthFormatValidator)
+          val validationErrors = entry.validate(savedNumber.toNullable(), numberValidator, dobValidator)
           validationErrors.isEmpty()
         }
         .map { (_, entry) -> entry }

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreenController.kt
@@ -14,7 +14,7 @@ import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility.AGE_VISIBLE
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility.BOTH_VISIBLE
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility.DATE_OF_BIRTH_VISIBLE
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
 import org.simple.clinic.patient.OngoingNewPatientEntry
 import org.simple.clinic.patient.OngoingNewPatientEntry.Address
 import org.simple.clinic.patient.OngoingNewPatientEntry.PersonalDetails
@@ -51,7 +51,7 @@ class PatientEntryScreenController @Inject constructor(
     private val patientRepository: PatientRepository,
     private val facilityRepository: FacilityRepository,
     private val userSession: UserSession,
-    private val dobValidator: DateOfBirthFormatValidator,
+    private val dobValidator: UserInputDateValidator,
     private val numberValidator: PhoneNumberValidator
 ) : ObservableTransformer<UiEvent, UiChange> {
 

--- a/app/src/main/java/org/simple/clinic/patient/OngoingEditPatientEntry.kt
+++ b/app/src/main/java/org/simple/clinic/patient/OngoingEditPatientEntry.kt
@@ -14,7 +14,7 @@ import org.simple.clinic.editpatient.PatientEditValidationError.STATE_EMPTY
 import org.simple.clinic.registration.phone.PhoneNumberValidator
 import org.simple.clinic.registration.phone.PhoneNumberValidator.Result
 import org.simple.clinic.registration.phone.PhoneNumberValidator.Type
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
 
 data class OngoingEditPatientEntry(
     val name: String,
@@ -28,7 +28,7 @@ data class OngoingEditPatientEntry(
   fun validate(
       alreadySavedNumber: PatientPhoneNumber?,
       numberValidator: PhoneNumberValidator,
-      dateOfBirthFormatValidator: DateOfBirthFormatValidator
+      dobValidator: UserInputDateValidator
   ): Set<PatientEditValidationError> {
     val errors = mutableSetOf<PatientEditValidationError>()
 
@@ -63,16 +63,16 @@ data class OngoingEditPatientEntry(
     }
 
     if (ageOrDateOfBirth is EitherAgeOrDateOfBirth.EntryWithDateOfBirth) {
-      val validationResult = dateOfBirthFormatValidator.validate(ageOrDateOfBirth.dateOfBirth)
+      val validationResult = dobValidator.validate(ageOrDateOfBirth.dateOfBirth)
 
       when (validationResult) {
-        DateOfBirthFormatValidator.Result.INVALID_PATTERN -> {
+        UserInputDateValidator.Result.INVALID_PATTERN -> {
           errors.add(INVALID_DATE_OF_BIRTH)
         }
-        DateOfBirthFormatValidator.Result.DATE_IS_IN_FUTURE -> {
+        UserInputDateValidator.Result.DATE_IS_IN_FUTURE -> {
           errors.add(DATE_OF_BIRTH_IN_FUTURE)
         }
-        DateOfBirthFormatValidator.Result.VALID -> {
+        UserInputDateValidator.Result.VALID -> {
           // Nothing to do here.
         }
       }

--- a/app/src/main/java/org/simple/clinic/patient/OngoingNewPatientEntry.kt
+++ b/app/src/main/java/org/simple/clinic/patient/OngoingNewPatientEntry.kt
@@ -1,9 +1,9 @@
 package org.simple.clinic.patient
 
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result.DATE_IS_IN_FUTURE
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result.INVALID_PATTERN
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result.VALID
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result.DATE_IS_IN_FUTURE
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result.INVALID_PATTERN
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result.VALID
 import org.simple.clinic.patient.PatientEntryValidationError.BOTH_DATEOFBIRTH_AND_AGE_ABSENT
 import org.simple.clinic.patient.PatientEntryValidationError.BOTH_DATEOFBIRTH_AND_AGE_PRESENT
 import org.simple.clinic.patient.PatientEntryValidationError.COLONY_OR_VILLAGE_EMPTY
@@ -35,7 +35,7 @@ data class OngoingNewPatientEntry(
     val phoneNumber: PhoneNumber? = null
 ) {
 
-  fun validationErrors(dobValidator: DateOfBirthFormatValidator, numberValidator: PhoneNumberValidator): ArrayList<PatientEntryValidationError> {
+  fun validationErrors(dobValidator: UserInputDateValidator, numberValidator: PhoneNumberValidator): ArrayList<PatientEntryValidationError> {
     val errors = ArrayList<PatientEntryValidationError>()
 
     if (personalDetails == null) {

--- a/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
@@ -18,7 +18,7 @@ import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.Just
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
 import org.threeten.bp.Clock
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
@@ -34,7 +34,7 @@ typealias FacilityUuid = UUID
 @AppScope
 class PatientRepository @Inject constructor(
     private val database: AppDatabase,
-    private val dobValidator: DateOfBirthFormatValidator,
+    private val dobValidator: UserInputDateValidator,
     private val facilityRepository: FacilityRepository,
     private val userSession: UserSession,
     private val numberValidator: PhoneNumberValidator,

--- a/app/src/main/java/org/simple/clinic/util/KotlinFoo.kt
+++ b/app/src/main/java/org/simple/clinic/util/KotlinFoo.kt
@@ -1,5 +1,5 @@
 package org.simple.clinic.util
 
 // Forces when blocks to be exhaustive.
-fun Unit.exhaustive() {}
+fun Any?.exhaustive() {}
 

--- a/app/src/main/java/org/simple/clinic/widgets/BottomSheetActivity.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/BottomSheetActivity.kt
@@ -19,7 +19,7 @@ import org.simple.clinic.R
  * keyboard otherwise aligns itself just below text fields, overlapping everything else
  * present below them.
  *
- * TODO: BottomSheet behavior.
+ * TODO: Add BottomSheet behavior to dismiss the sheet by dragging it downwards.
  */
 abstract class BottomSheetActivity : AppCompatActivity() {
 

--- a/app/src/main/java/org/simple/clinic/widgets/ViewFlipperWithDebugPreview.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/ViewFlipperWithDebugPreview.kt
@@ -3,7 +3,9 @@ package org.simple.clinic.widgets
 import android.content.Context
 import android.util.AttributeSet
 import android.widget.ViewFlipper
-
+import io.reactivex.Observable
+import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.subjects.Subject
 import org.simple.clinic.R
 
 /** Exposes a way to set the displayed child in layout preview. */
@@ -11,12 +13,16 @@ class ViewFlipperWithDebugPreview(context: Context, attrs: AttributeSet) : ViewF
 
   private var childToDisplayPostInflate: Int = 0
 
+  private val displayedChildChangesSubject: Subject<Int> = BehaviorSubject.create()
+  val displayedChildChanges: Observable<Int> = displayedChildChangesSubject.hide()
+
   init {
     if (isInEditMode) {
       val attributes = context.obtainStyledAttributes(attrs, R.styleable.ViewFlipperWithDebugPreview)
       childToDisplayPostInflate = attributes.getInt(R.styleable.ViewFlipperWithDebugPreview_debug_displayedChild, 0)
       attributes.recycle()
     }
+    displayedChildChangesSubject.onNext(displayedChild)
   }
 
   override fun onFinishInflate() {
@@ -28,5 +34,10 @@ class ViewFlipperWithDebugPreview(context: Context, attrs: AttributeSet) : ViewF
       }
       displayedChild = childToDisplayPostInflate
     }
+  }
+
+  override fun setDisplayedChild(whichChild: Int) {
+    super.setDisplayedChild(whichChild)
+    displayedChildChangesSubject.onNext(whichChild)
   }
 }

--- a/app/src/main/java/org/simple/clinic/widgets/ageanddateofbirth/DateOfBirthFormatValidator.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/ageanddateofbirth/DateOfBirthFormatValidator.kt
@@ -36,4 +36,8 @@ class DateOfBirthFormatValidator @Inject constructor(
       }
     }
   }
+
+  fun validate(date: String): Result {
+    TODO()
+  }
 }

--- a/app/src/main/java/org/simple/clinic/widgets/ageanddateofbirth/DateOfBirthFormatValidator.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/ageanddateofbirth/DateOfBirthFormatValidator.kt
@@ -17,27 +17,42 @@ class DateOfBirthFormatValidator @Inject constructor(
     DATE_IS_IN_FUTURE,
   }
 
-  fun validate(dateText: String, nowDate: LocalDate = LocalDate.now(UTC)): Result {
-    return try {
-      if (dateText.isBlank()) {
-        Result.INVALID_PATTERN
-      }
-
-      val parsedDate = dateOfBirthFormat.parse(dateText, LocalDate::from)
-      when {
-        parsedDate > nowDate -> Result.DATE_IS_IN_FUTURE
-        else -> Result.VALID
-      }
-
-    } catch (e: Exception) {
-      when (e) {
-        is DateTimeParseException -> Result.INVALID_PATTERN
-        else -> throw e
-      }
+  sealed class Result2 {
+    data class Valid(val parsedDate: LocalDate) : Result2()
+    sealed class Invalid : Result2() {
+      object InvalidPattern : Invalid()
+      object DateIsInFuture : Invalid()
     }
   }
 
-  fun validate(date: String): Result {
-    TODO()
+  @Deprecated(
+      message = "use validate2 instead which uses sealed classes instead of enums",
+      replaceWith = ReplaceWith("validate2(dateText, nowDate)"))
+  fun validate(dateText: String, nowDate: LocalDate = LocalDate.now(UTC)): Result {
+    return when (validate2(dateText, nowDate)) {
+      is Result2.Valid -> Result.VALID
+      is Result2.Invalid.InvalidPattern -> Result.INVALID_PATTERN
+      is Result2.Invalid.DateIsInFuture -> Result.DATE_IS_IN_FUTURE
+    }
+  }
+
+  fun validate2(dateText: String, nowDate: LocalDate = LocalDate.now(UTC)): Result2 {
+    try {
+      if (dateText.isBlank()) {
+        return Result2.Invalid.InvalidPattern
+      }
+
+      val parsedDate = dateOfBirthFormat.parse(dateText, LocalDate::from)
+      return when {
+        parsedDate > nowDate -> Result2.Invalid.DateIsInFuture
+        else -> Result2.Valid(parsedDate)
+      }
+
+    } catch (e: Exception) {
+      return when (e) {
+        is DateTimeParseException -> Result2.Invalid.InvalidPattern
+        else -> throw e
+      }
+    }
   }
 }

--- a/app/src/main/java/org/simple/clinic/widgets/ageanddateofbirth/UserInputDateValidator.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/ageanddateofbirth/UserInputDateValidator.kt
@@ -7,10 +7,11 @@ import org.threeten.bp.format.DateTimeParseException
 import javax.inject.Inject
 import javax.inject.Named
 
-class DateOfBirthFormatValidator @Inject constructor(
+class UserInputDateValidator @Inject constructor(
     @Named("date_for_user_input") private val dateOfBirthFormat: DateTimeFormatter
 ) {
 
+  @Deprecated(message = "deprecated in favor of Result2")
   enum class Result {
     VALID,
     INVALID_PATTERN,

--- a/app/src/main/res/drawable/ic_round_arrow_forward_ios_24px.xml
+++ b/app/src/main/res/drawable/ic_round_arrow_forward_ios_24px.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M7.38,21.01c0.49,0.49 1.28,0.49 1.77,0l8.31,-8.31c0.39,-0.39 0.39,-1.02 0,-1.41L9.15,2.98c-0.49,-0.49 -1.28,-0.49 -1.77,0s-0.49,1.28 0,1.77L14.62,12l-7.25,7.25c-0.48,0.48 -0.48,1.28 0.01,1.76z"/>
+</vector>

--- a/app/src/main/res/layout/sheet_blood_pressure_entry.xml
+++ b/app/src/main/res/layout/sheet_blood_pressure_entry.xml
@@ -13,17 +13,16 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <Button
-      android:id="@+id/bloodpressureentry_remove"
-      style="@style/Widget.AppCompat.Button.Borderless"
+    <TextView
+      android:id="@+id/bloodpressureentry_enter_blood_pressure"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_alignParentEnd="true"
-      android:layout_marginEnd="@dimen/spacing_16"
-      android:text="@string/bloodpressureentry_remove"
-      android:textAppearance="@style/Clinic.V2.TextAppearance.Button2.Red1"
+      android:layout_centerHorizontal="true"
+      android:lines="1"
+      android:text="@string/bloodpressureentry_sheet_title_enter_blood_pressure"
+      android:textAppearance="@style/Clinic.V2.TextAppearance.H6.Grey0"
       android:visibility="gone"
-      tools:visibility="visible" />
+      tools:ignore="UnusedAttribute" />
 
     <TextView
       android:id="@+id/bloodpressureentry_edit_blood_pressure"
@@ -41,87 +40,85 @@
       tools:ignore="UnusedAttribute"
       tools:visibility="visible" />
 
-    <TextView
-      android:id="@+id/bloodpressureentry_enter_blood_pressure"
+    <Button
+      android:id="@+id/bloodpressureentry_remove"
+      style="@style/Widget.AppCompat.Button.Borderless"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_centerHorizontal="true"
-      android:lines="1"
-      android:text="@string/bloodpressureentry_sheet_title_enter_blood_pressure"
-      android:textAppearance="@style/Clinic.V2.TextAppearance.H6.Grey0"
+      android:layout_alignParentEnd="true"
+      android:layout_marginEnd="@dimen/spacing_16"
+      android:text="@string/bloodpressureentry_remove"
+      android:textAppearance="@style/Clinic.V2.TextAppearance.Button2.Red1"
       android:visibility="gone"
-      tools:ignore="UnusedAttribute" />
-
+      tools:visibility="visible" />
   </RelativeLayout>
 
-  <LinearLayout
+  <RelativeLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/spacing_16"
     android:gravity="center_horizontal">
 
-    <LinearLayout
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_weight="1"
-      android:orientation="vertical">
-
-      <!-- Contains an awkward bottom-padding to keep
+    <!-- Contains an awkward bottom-padding to keep
            the label visible even when the keyboard is up. -->
-      <EditText
-        android:id="@+id/bloodpressureentry_systolic"
-        style="@style/Clinic.BloodPressureInput"
-        android:importantForAutofill="no"
-        tools:ignore="UnusedAttribute"
-        tools:text="120" />
+    <EditText
+      android:id="@+id/bloodpressureentry_systolic"
+      style="@style/Clinic.V2.BloodPressureInput"
+      android:layout_toStartOf="@+id/bloodpressureentry_systolic_diastolic_separator"
+      android:importantForAutofill="no"
+      android:theme="@style/Clinic.V2.BloodPressureInputTheme"
+      tools:ignore="UnusedAttribute"
+      tools:text="120">
 
       <requestFocus />
-
-      <View
-        android:id="@+id/bloodpressureentry_systolic_underline"
-        style="@style/Clinic.BloodPressureInputUnderline" />
-
-      <TextView
-        android:id="@+id/bloodpressureentry_systolic_label"
-        style="@style/Clinic.BloodPressureInputLabel"
-        android:labelFor="@id/bloodpressureentry_systolic"
-        android:text="@string/bloodpressureentry_systolic"
-        android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1" />
-    </LinearLayout>
+    </EditText>
 
     <TextView
+      android:id="@+id/bloodpressureentry_systolic_label"
+      style="@style/Clinic.BloodPressureInputLabel"
+      android:layout_alignEnd="@+id/bloodpressureentry_systolic"
+      android:layout_alignStart="@+id/bloodpressureentry_systolic"
+      android:layout_below="@+id/bloodpressureentry_systolic"
+      android:gravity="center_horizontal"
+      android:labelFor="@id/bloodpressureentry_systolic"
+      android:text="@string/bloodpressureentry_systolic"
+      android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1" />
+
+    <TextView
+      android:id="@+id/bloodpressureentry_systolic_diastolic_separator"
       android:layout_width="wrap_content"
-      android:layout_height="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_alignBottom="@+id/bloodpressureentry_systolic"
+      android:layout_alignTop="@+id/bloodpressureentry_systolic"
+      android:layout_centerHorizontal="true"
+      android:layout_marginEnd="@dimen/spacing_12"
+      android:layout_marginStart="@dimen/spacing_12"
       android:fontFamily="sans-serif"
+      android:gravity="center_vertical"
       android:text="/"
       android:textColor="@color/grey2"
       android:textSize="40dp"
       tools:ignore="HardcodedText,SpUsage" />
 
-    <LinearLayout
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_weight="1"
-      android:orientation="vertical">
+    <org.simple.clinic.bp.entry.EditTextWithBackspaceListener
+      android:id="@+id/bloodpressureentry_diastolic"
+      style="@style/Clinic.V2.BloodPressureInput"
+      android:layout_toEndOf="@+id/bloodpressureentry_systolic_diastolic_separator"
+      android:importantForAutofill="no"
+      android:theme="@style/Clinic.V2.BloodPressureInputTheme"
+      tools:ignore="UnusedAttribute" />
 
-      <org.simple.clinic.bp.entry.EditTextWithBackspaceListener
-        android:id="@+id/bloodpressureentry_diastolic"
-        style="@style/Clinic.BloodPressureInput"
-        android:importantForAutofill="no"
-        tools:ignore="UnusedAttribute" />
-
-      <View
-        android:id="@+id/bloodpressureentry_diastolic_underline"
-        style="@style/Clinic.BloodPressureInputUnderline" />
-
-      <TextView
-        android:id="@+id/bloodpressureentry_diastolic_label"
-        style="@style/Clinic.BloodPressureInputLabel"
-        android:labelFor="@id/bloodpressureentry_diastolic"
-        android:text="@string/bloodpressureentry_diastolic"
-        android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1" />
-    </LinearLayout>
-  </LinearLayout>
+    <TextView
+      android:id="@+id/bloodpressureentry_diastolic_label"
+      style="@style/Clinic.BloodPressureInputLabel"
+      android:layout_alignEnd="@+id/bloodpressureentry_diastolic"
+      android:layout_alignStart="@+id/bloodpressureentry_diastolic"
+      android:layout_below="@+id/bloodpressureentry_diastolic"
+      android:gravity="center_horizontal"
+      android:labelFor="@id/bloodpressureentry_diastolic"
+      android:text="@string/bloodpressureentry_diastolic"
+      android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1" />
+  </RelativeLayout>
 
   <TextView
     android:id="@+id/bloodpressureentry_error"
@@ -131,5 +128,4 @@
     android:layout_marginTop="@dimen/spacing_8"
     android:gravity="center_horizontal"
     android:visibility="gone" />
-
 </org.simple.clinic.bp.entry.LinearLayoutWithPreImeKeyEventListener>

--- a/app/src/main/res/layout/sheet_blood_pressure_entry.xml
+++ b/app/src/main/res/layout/sheet_blood_pressure_entry.xml
@@ -10,126 +10,232 @@
   android:paddingBottom="@dimen/spacing_24"
   android:paddingTop="@dimen/spacing_16">
 
-  <RelativeLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content">
-
-    <TextView
-      android:id="@+id/bloodpressureentry_enter_blood_pressure"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_centerHorizontal="true"
-      android:lines="1"
-      android:text="@string/bloodpressureentry_sheet_title_enter_blood_pressure"
-      android:textAppearance="@style/Clinic.V2.TextAppearance.H6.Grey0"
-      android:visibility="gone"
-      tools:ignore="UnusedAttribute" />
-
-    <TextView
-      android:id="@+id/bloodpressureentry_edit_blood_pressure"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentStart="true"
-      android:layout_centerVertical="true"
-      android:layout_marginStart="@dimen/spacing_24"
-      android:layout_toStartOf="@id/bloodpressureentry_remove"
-      android:ellipsize="end"
-      android:lines="1"
-      android:text="@string/bloodpressureentry_sheet_title_edit_blood_pressure"
-      android:textAppearance="@style/Clinic.V2.TextAppearance.H6.Grey0"
-      android:visibility="gone"
-      tools:ignore="UnusedAttribute"
-      tools:visibility="visible" />
-
-    <Button
-      android:id="@+id/bloodpressureentry_remove"
-      style="@style/Widget.AppCompat.Button.Borderless"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_alignParentEnd="true"
-      android:layout_marginEnd="@dimen/spacing_16"
-      android:text="@string/bloodpressureentry_remove"
-      android:textAppearance="@style/Clinic.V2.TextAppearance.Button2.Red1"
-      android:visibility="gone"
-      tools:visibility="visible" />
-  </RelativeLayout>
-
-  <android.support.constraint.ConstraintLayout
+  <org.simple.clinic.widgets.ViewFlipperWithDebugPreview
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="@dimen/spacing_16"
-    android:gravity="center_horizontal">
+    app:debug_displayedChild="1">
 
-    <!-- Contains an awkward bottom-padding to keep
-           the label visible even when the keyboard is up. -->
-    <EditText
-      android:id="@+id/bloodpressureentry_systolic"
-      style="@style/Clinic.V2.BloodPressureInput"
-      android:layout_marginEnd="@dimen/spacing_12"
-      android:importantForAutofill="no"
-      android:theme="@style/Clinic.V2.BloodPressureInputTheme"
-      app:layout_constraintEnd_toStartOf="@+id/bloodpressureentry_systolic_diastolic_separator"
-      tools:ignore="UnusedAttribute"
-      tools:text="120">
-
-      <requestFocus />
-    </EditText>
-
-    <TextView
-      android:id="@+id/bloodpressureentry_systolic_label"
-      style="@style/Clinic.BloodPressureInputLabel"
-      android:gravity="center_horizontal"
-      android:labelFor="@id/bloodpressureentry_systolic"
-      android:text="@string/bloodpressureentry_systolic"
-      android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1"
-      app:layout_constraintEnd_toEndOf="@+id/bloodpressureentry_systolic"
-      app:layout_constraintStart_toStartOf="@+id/bloodpressureentry_systolic"
-      app:layout_constraintTop_toBottomOf="@+id/bloodpressureentry_systolic" />
-
-    <TextView
-      android:id="@+id/bloodpressureentry_systolic_diastolic_separator"
-      android:layout_width="wrap_content"
+    <LinearLayout
+      android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_marginEnd="@dimen/spacing_12"
-      android:layout_marginStart="@dimen/spacing_12"
-      android:fontFamily="sans-serif"
-      android:gravity="center_vertical"
-      android:text="/"
-      android:textColor="@color/grey2"
-      android:textSize="40dp"
-      app:layout_constraintBottom_toBottomOf="@+id/bloodpressureentry_systolic"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintTop_toTopOf="@+id/bloodpressureentry_systolic"
-      tools:ignore="HardcodedText,SpUsage" />
+      android:orientation="vertical">
 
-    <org.simple.clinic.bp.entry.EditTextWithBackspaceListener
-      android:id="@+id/bloodpressureentry_diastolic"
-      style="@style/Clinic.V2.BloodPressureInput"
-      android:layout_marginStart="@dimen/spacing_12"
-      android:importantForAutofill="no"
-      android:theme="@style/Clinic.V2.BloodPressureInputTheme"
-      app:layout_constraintStart_toEndOf="@+id/bloodpressureentry_systolic_diastolic_separator"
-      tools:ignore="UnusedAttribute" />
+      <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-    <TextView
-      android:id="@+id/bloodpressureentry_diastolic_label"
-      style="@style/Clinic.BloodPressureInputLabel"
-      android:gravity="center_horizontal"
-      android:labelFor="@id/bloodpressureentry_diastolic"
-      android:text="@string/bloodpressureentry_diastolic"
-      android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1"
-      app:layout_constraintEnd_toEndOf="@+id/bloodpressureentry_diastolic"
-      app:layout_constraintStart_toStartOf="@+id/bloodpressureentry_diastolic"
-      app:layout_constraintTop_toBottomOf="@+id/bloodpressureentry_diastolic" />
-  </android.support.constraint.ConstraintLayout>
+        <TextView
+          android:id="@+id/bloodpressureentry_enter_blood_pressure"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_centerHorizontal="true"
+          android:lines="1"
+          android:text="@string/bloodpressureentry_sheet_title_enter_blood_pressure"
+          android:textAppearance="@style/Clinic.V2.TextAppearance.H6.Grey0"
+          android:visibility="gone"
+          tools:ignore="UnusedAttribute" />
 
-  <TextView
-    android:id="@+id/bloodpressureentry_error"
-    style="@style/Clinic.V2.TextAppearance.TextInputLayoutError"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_marginTop="@dimen/spacing_8"
-    android:gravity="center_horizontal"
-    android:visibility="gone" />
+        <TextView
+          android:id="@+id/bloodpressureentry_edit_blood_pressure"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_alignParentStart="true"
+          android:layout_centerVertical="true"
+          android:layout_marginStart="@dimen/spacing_24"
+          android:layout_toStartOf="@id/bloodpressureentry_remove"
+          android:ellipsize="end"
+          android:lines="1"
+          android:text="@string/bloodpressureentry_sheet_title_edit_blood_pressure"
+          android:textAppearance="@style/Clinic.V2.TextAppearance.H6.Grey0"
+          android:visibility="gone"
+          tools:ignore="UnusedAttribute"
+          tools:visibility="visible" />
+
+        <Button
+          android:id="@+id/bloodpressureentry_remove"
+          style="@style/Widget.AppCompat.Button.Borderless"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_alignParentEnd="true"
+          android:layout_marginEnd="@dimen/spacing_16"
+          android:text="@string/bloodpressureentry_remove"
+          android:textAppearance="@style/Clinic.V2.TextAppearance.Button2.Red1"
+          android:visibility="gone"
+          tools:visibility="visible" />
+      </RelativeLayout>
+
+      <android.support.constraint.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_16"
+        android:gravity="center_horizontal">
+
+        <!-- Contains an awkward bottom-padding to keep
+               the label visible even when the keyboard is up. -->
+        <EditText
+          android:id="@+id/bloodpressureentry_systolic"
+          style="@style/Clinic.V2.BloodPressureInput.BpReading"
+          android:layout_marginEnd="@dimen/spacing_12"
+          android:importantForAutofill="no"
+          android:theme="@style/Clinic.V2.BloodPressureInputTheme"
+          app:layout_constraintEnd_toStartOf="@+id/bloodpressureentry_systolic_diastolic_separator"
+          tools:ignore="UnusedAttribute"
+          tools:text="120">
+
+          <requestFocus />
+        </EditText>
+
+        <TextView
+          android:id="@+id/bloodpressureentry_systolic_label"
+          style="@style/Clinic.BloodPressureInputLabel"
+          android:gravity="center_horizontal"
+          android:labelFor="@+id/bloodpressureentry_systolic"
+          android:text="@string/bloodpressureentry_systolic"
+          android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1"
+          app:layout_constraintEnd_toEndOf="@+id/bloodpressureentry_systolic"
+          app:layout_constraintStart_toStartOf="@+id/bloodpressureentry_systolic"
+          app:layout_constraintTop_toBottomOf="@+id/bloodpressureentry_systolic" />
+
+        <TextView
+          android:id="@+id/bloodpressureentry_systolic_diastolic_separator"
+          style="@style/Clinic.V2.BloodPressureInputSeparator"
+          android:layout_marginEnd="@dimen/spacing_12"
+          android:layout_marginStart="@dimen/spacing_12"
+          app:layout_constraintBottom_toBottomOf="@+id/bloodpressureentry_systolic"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="@+id/bloodpressureentry_systolic" />
+
+        <org.simple.clinic.bp.entry.EditTextWithBackspaceListener
+          android:id="@+id/bloodpressureentry_diastolic"
+          style="@style/Clinic.V2.BloodPressureInput.BpReading"
+          android:layout_marginStart="@dimen/spacing_12"
+          android:importantForAutofill="no"
+          android:theme="@style/Clinic.V2.BloodPressureInputTheme"
+          app:layout_constraintStart_toEndOf="@+id/bloodpressureentry_systolic_diastolic_separator"
+          tools:ignore="UnusedAttribute" />
+
+        <TextView
+          android:id="@+id/bloodpressureentry_diastolic_label"
+          style="@style/Clinic.BloodPressureInputLabel"
+          android:gravity="center_horizontal"
+          android:labelFor="@id/bloodpressureentry_diastolic"
+          android:text="@string/bloodpressureentry_diastolic"
+          android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1"
+          app:layout_constraintEnd_toEndOf="@+id/bloodpressureentry_diastolic"
+          app:layout_constraintStart_toStartOf="@+id/bloodpressureentry_diastolic"
+          app:layout_constraintTop_toBottomOf="@+id/bloodpressureentry_diastolic" />
+      </android.support.constraint.ConstraintLayout>
+
+      <TextView
+        android:id="@+id/bloodpressureentry_error"
+        style="@style/Clinic.V2.TextAppearance.TextInputLayoutError"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_8"
+        android:gravity="center_horizontal"
+        android:visibility="gone" />
+    </LinearLayout>
+
+    <LinearLayout
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical">
+
+      <TextView
+        android:id="@+id/bloodpressureentry_enter_date"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="20dp"
+        android:gravity="center_horizontal"
+        android:text="@string/bloodpressureentry_sheet_title_enter_date"
+        android:textAppearance="@style/Clinic.V2.TextAppearance.H6.Grey0" />
+
+      <android.support.constraint.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <EditText
+          android:id="@+id/bloodpressureentry_day"
+          style="@style/Clinic.V2.BloodPressureInput.Date"
+          android:importantForAutofill="no"
+          android:theme="@style/Clinic.V2.BloodPressureInputTheme"
+          app:layout_constraintEnd_toStartOf="@+id/bloodpressureentry_day_month_separator"
+          app:layout_constraintHorizontal_chainStyle="packed"
+          app:layout_constraintStart_toStartOf="parent"
+          tools:ignore="UnusedAttribute" />
+
+        <TextView
+          android:id="@+id/bloodpressureentry_day_label"
+          style="@style/Clinic.BloodPressureInputLabel"
+          android:gravity="center_horizontal"
+          android:labelFor="@id/bloodpressureentry_day"
+          android:text="@string/bloodpressureentry_day"
+          android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1"
+          app:layout_constraintEnd_toEndOf="@+id/bloodpressureentry_day"
+          app:layout_constraintStart_toStartOf="@+id/bloodpressureentry_day"
+          app:layout_constraintTop_toBottomOf="@+id/bloodpressureentry_day" />
+
+        <TextView
+          android:id="@+id/bloodpressureentry_day_month_separator"
+          style="@style/Clinic.V2.BloodPressureInputSeparator"
+          android:layout_marginEnd="@dimen/spacing_12"
+          android:layout_marginStart="@dimen/spacing_12"
+          app:layout_constraintBottom_toBottomOf="@+id/bloodpressureentry_day"
+          app:layout_constraintEnd_toStartOf="@+id/bloodpressureentry_month"
+          app:layout_constraintStart_toEndOf="@+id/bloodpressureentry_day"
+          app:layout_constraintTop_toTopOf="@+id/bloodpressureentry_day" />
+
+        <EditText
+          android:id="@+id/bloodpressureentry_month"
+          style="@style/Clinic.V2.BloodPressureInput.Date"
+          android:importantForAutofill="no"
+          android:theme="@style/Clinic.V2.BloodPressureInputTheme"
+          app:layout_constraintEnd_toStartOf="@+id/bloodpressureentry_month_year_separator"
+          app:layout_constraintStart_toEndOf="@+id/bloodpressureentry_day_month_separator"
+          tools:ignore="UnusedAttribute" />
+
+        <TextView
+          android:id="@+id/bloodpressureentry_month_label"
+          style="@style/Clinic.BloodPressureInputLabel"
+          android:gravity="center_horizontal"
+          android:labelFor="@id/bloodpressureentry_month"
+          android:text="@string/bloodpressureentry_month"
+          android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1"
+          app:layout_constraintEnd_toEndOf="@+id/bloodpressureentry_month"
+          app:layout_constraintStart_toStartOf="@+id/bloodpressureentry_month"
+          app:layout_constraintTop_toBottomOf="@+id/bloodpressureentry_month" />
+
+        <TextView
+          android:id="@+id/bloodpressureentry_month_year_separator"
+          style="@style/Clinic.V2.BloodPressureInputSeparator"
+          android:layout_marginEnd="@dimen/spacing_12"
+          android:layout_marginStart="@dimen/spacing_12"
+          app:layout_constraintBottom_toBottomOf="@+id/bloodpressureentry_month"
+          app:layout_constraintEnd_toStartOf="@+id/bloodpressureentry_year"
+          app:layout_constraintStart_toEndOf="@+id/bloodpressureentry_month"
+          app:layout_constraintTop_toTopOf="@+id/bloodpressureentry_month" />
+
+        <EditText
+          android:id="@+id/bloodpressureentry_year"
+          style="@style/Clinic.V2.BloodPressureInput.Date"
+          android:importantForAutofill="no"
+          android:theme="@style/Clinic.V2.BloodPressureInputTheme"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toEndOf="@+id/bloodpressureentry_month_year_separator"
+          tools:ignore="UnusedAttribute" />
+
+        <TextView
+          android:id="@+id/bloodpressureentry_year_label"
+          style="@style/Clinic.BloodPressureInputLabel"
+          android:gravity="center_horizontal"
+          android:labelFor="@id/bloodpressureentry_year"
+          android:text="@string/bloodpressureentry_year"
+          android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1"
+          app:layout_constraintEnd_toEndOf="@+id/bloodpressureentry_year"
+          app:layout_constraintStart_toStartOf="@+id/bloodpressureentry_year"
+          app:layout_constraintTop_toBottomOf="@+id/bloodpressureentry_year" />
+      </android.support.constraint.ConstraintLayout>
+    </LinearLayout>
+  </org.simple.clinic.widgets.ViewFlipperWithDebugPreview>
 </org.simple.clinic.bp.entry.LinearLayoutWithPreImeKeyEventListener>

--- a/app/src/main/res/layout/sheet_blood_pressure_entry.xml
+++ b/app/src/main/res/layout/sheet_blood_pressure_entry.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <org.simple.clinic.bp.entry.LinearLayoutWithPreImeKeyEventListener android:id="@+id/bloodpressureentry_root"
   xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
@@ -53,7 +54,7 @@
       tools:visibility="visible" />
   </RelativeLayout>
 
-  <RelativeLayout
+  <android.support.constraint.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/spacing_16"
@@ -64,9 +65,10 @@
     <EditText
       android:id="@+id/bloodpressureentry_systolic"
       style="@style/Clinic.V2.BloodPressureInput"
-      android:layout_toStartOf="@+id/bloodpressureentry_systolic_diastolic_separator"
+      android:layout_marginEnd="@dimen/spacing_12"
       android:importantForAutofill="no"
       android:theme="@style/Clinic.V2.BloodPressureInputTheme"
+      app:layout_constraintEnd_toStartOf="@+id/bloodpressureentry_systolic_diastolic_separator"
       tools:ignore="UnusedAttribute"
       tools:text="120">
 
@@ -76,21 +78,18 @@
     <TextView
       android:id="@+id/bloodpressureentry_systolic_label"
       style="@style/Clinic.BloodPressureInputLabel"
-      android:layout_alignEnd="@+id/bloodpressureentry_systolic"
-      android:layout_alignStart="@+id/bloodpressureentry_systolic"
-      android:layout_below="@+id/bloodpressureentry_systolic"
       android:gravity="center_horizontal"
       android:labelFor="@id/bloodpressureentry_systolic"
       android:text="@string/bloodpressureentry_systolic"
-      android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1" />
+      android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1"
+      app:layout_constraintEnd_toEndOf="@+id/bloodpressureentry_systolic"
+      app:layout_constraintStart_toStartOf="@+id/bloodpressureentry_systolic"
+      app:layout_constraintTop_toBottomOf="@+id/bloodpressureentry_systolic" />
 
     <TextView
       android:id="@+id/bloodpressureentry_systolic_diastolic_separator"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_alignBottom="@+id/bloodpressureentry_systolic"
-      android:layout_alignTop="@+id/bloodpressureentry_systolic"
-      android:layout_centerHorizontal="true"
       android:layout_marginEnd="@dimen/spacing_12"
       android:layout_marginStart="@dimen/spacing_12"
       android:fontFamily="sans-serif"
@@ -98,27 +97,32 @@
       android:text="/"
       android:textColor="@color/grey2"
       android:textSize="40dp"
+      app:layout_constraintBottom_toBottomOf="@+id/bloodpressureentry_systolic"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintTop_toTopOf="@+id/bloodpressureentry_systolic"
       tools:ignore="HardcodedText,SpUsage" />
 
     <org.simple.clinic.bp.entry.EditTextWithBackspaceListener
       android:id="@+id/bloodpressureentry_diastolic"
       style="@style/Clinic.V2.BloodPressureInput"
-      android:layout_toEndOf="@+id/bloodpressureentry_systolic_diastolic_separator"
+      android:layout_marginStart="@dimen/spacing_12"
       android:importantForAutofill="no"
       android:theme="@style/Clinic.V2.BloodPressureInputTheme"
+      app:layout_constraintStart_toEndOf="@+id/bloodpressureentry_systolic_diastolic_separator"
       tools:ignore="UnusedAttribute" />
 
     <TextView
       android:id="@+id/bloodpressureentry_diastolic_label"
       style="@style/Clinic.BloodPressureInputLabel"
-      android:layout_alignEnd="@+id/bloodpressureentry_diastolic"
-      android:layout_alignStart="@+id/bloodpressureentry_diastolic"
-      android:layout_below="@+id/bloodpressureentry_diastolic"
       android:gravity="center_horizontal"
       android:labelFor="@id/bloodpressureentry_diastolic"
       android:text="@string/bloodpressureentry_diastolic"
-      android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1" />
-  </RelativeLayout>
+      android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Grey1"
+      app:layout_constraintEnd_toEndOf="@+id/bloodpressureentry_diastolic"
+      app:layout_constraintStart_toStartOf="@+id/bloodpressureentry_diastolic"
+      app:layout_constraintTop_toBottomOf="@+id/bloodpressureentry_diastolic" />
+  </android.support.constraint.ConstraintLayout>
 
   <TextView
     android:id="@+id/bloodpressureentry_error"

--- a/app/src/main/res/layout/sheet_blood_pressure_entry.xml
+++ b/app/src/main/res/layout/sheet_blood_pressure_entry.xml
@@ -17,6 +17,7 @@
     app:debug_displayedChild="1">
 
     <LinearLayout
+      android:id="@+id/bloodpressureentry_flipper_bp_entry"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:orientation="vertical">
@@ -151,6 +152,7 @@
     </LinearLayout>
 
     <LinearLayout
+      android:id="@+id/bloodpressureentry_flipper_date_entry"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:orientation="vertical">

--- a/app/src/main/res/layout/sheet_blood_pressure_entry.xml
+++ b/app/src/main/res/layout/sheet_blood_pressure_entry.xml
@@ -11,6 +11,7 @@
   android:paddingTop="@dimen/spacing_16">
 
   <org.simple.clinic.widgets.ViewFlipperWithDebugPreview
+    android:id="@+id/bloodpressureentry_view_flipper"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     app:debug_displayedChild="1">
@@ -125,6 +126,18 @@
           app:layout_constraintEnd_toEndOf="@+id/bloodpressureentry_diastolic"
           app:layout_constraintStart_toStartOf="@+id/bloodpressureentry_diastolic"
           app:layout_constraintTop_toBottomOf="@+id/bloodpressureentry_diastolic" />
+
+        <ImageView
+          android:id="@+id/bloodpressureentry_next_arrow"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginEnd="16dp"
+          android:background="?selectableItemBackgroundBorderless"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintTop_toTopOf="parent"
+          app:srcCompat="@drawable/ic_round_arrow_forward_ios_24px"
+          tools:ignore="ContentDescription" />
       </android.support.constraint.ConstraintLayout>
 
       <TextView
@@ -154,6 +167,19 @@
       <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
+
+        <ImageView
+          android:id="@+id/bloodpressureentry_previous_arrow"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginStart="16dp"
+          android:background="?selectableItemBackgroundBorderless"
+          android:rotation="180"
+          app:layout_constraintBottom_toBottomOf="parent"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toTopOf="parent"
+          app:srcCompat="@drawable/ic_round_arrow_forward_ios_24px"
+          tools:ignore="ContentDescription" />
 
         <EditText
           android:id="@+id/bloodpressureentry_day"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,9 +117,13 @@
   <!-- Blood pressure entry -->
   <string name="bloodpressureentry_sheet_title_enter_blood_pressure">Enter blood pressure</string>
   <string name="bloodpressureentry_sheet_title_edit_blood_pressure">Edit blood pressure</string>
+  <string name="bloodpressureentry_sheet_title_enter_date">Date of visit</string>
   <string name="bloodpressureentry_remove">Remove</string>
   <string name="bloodpressureentry_systolic">Systolic</string>
   <string name="bloodpressureentry_diastolic">Diastolic</string>
+  <string name="bloodpressureentry_day">Day</string>
+  <string name="bloodpressureentry_month">Month</string>
+  <string name="bloodpressureentry_year">Year</string>
   <string name="bloodpressureentry_error_systolic_more">Systolic should be more than diastolic</string>
   <string name="bloodpressureentry_error_systolic_70">Systolic cannot be less than 70</string>
   <string name="bloodpressureentry_error_systolic_300">Systolic cannot be more than 300</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -245,4 +245,14 @@
     <item name="android:paddingStart">@dimen/spacing_24</item>
     <item name="android:paddingTop">@dimen/spacing_16</item>
   </style>
+
+  <style name="Clinic.V2.BloodPressureInputSeparator">
+    <item name="android:text">/</item>
+    <item name="android:layout_width">wrap_content</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:fontFamily">sans-serif</item>
+    <item name="android:gravity">center_vertical</item>
+    <item name="android:textColor">@color/grey2</item>
+    <item name="android:textSize">40sp</item>
+  </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -12,30 +12,6 @@
     <item name="android:src">@drawable/ic_clear_circular_16dp</item>
   </style>
 
-  <style name="Clinic.BloodPressureInput">
-    <item name="android:layout_width">wrap_content</item>
-    <item name="android:layout_height">wrap_content</item>
-    <item name="android:background">@null</item>
-    <item name="android:fontFamily">sans-serif</item>
-    <item name="android:gravity">center|top</item>
-    <item name="android:inputType">number</item>
-    <item name="android:maxEms">3</item>
-    <item name="android:maxLength">3</item>
-    <item name="android:minEms">3</item>
-    <item name="android:textSize">40sp</item>
-    <item name="android:textColor">@color/grey0</item>
-    <item name="android:lineSpacingExtra">16sp</item>
-  </style>
-
-  <style name="Clinic.BloodPressureInputUnderline">
-    <item name="android:layout_width">match_parent</item>
-    <item name="android:layout_height">1dp</item>
-    <item name="android:layout_marginEnd">24dp</item>
-    <item name="android:layout_marginStart">24dp</item>
-    <item name="android:background">@color/grey2</item>
-    <item name="android:layout_marginBottom">@dimen/spacing_8</item>
-  </style>
-
   <style name="Clinic.BloodPressureInputLabel">
     <item name="android:layout_width">wrap_content</item>
     <item name="android:layout_height">wrap_content</item>

--- a/app/src/main/res/values/styles_v2.xml
+++ b/app/src/main/res/values/styles_v2.xml
@@ -496,4 +496,23 @@
     <item name="android:drawableStart">@drawable/ic_location_20dp</item>
     <item name="android:drawablePadding">6dp</item>
   </style>
+
+  <style name="Clinic.V2.BloodPressureInput">
+    <item name="android:layout_width">wrap_content</item>
+    <item name="android:layout_height">wrap_content</item>
+    <item name="android:fontFamily">sans-serif</item>
+    <item name="android:gravity">center|top</item>
+    <item name="android:inputType">number</item>
+    <item name="android:minEms">2</item>
+    <item name="android:maxLength">3</item>
+    <item name="android:textSize">40sp</item>
+    <item name="android:textColor">@color/grey0</item>
+    <item name="android:lineSpacingExtra">16sp</item>
+    <item name="android:paddingStart">@dimen/spacing_12</item>
+    <item name="android:paddingEnd">@dimen/spacing_12</item>
+  </style>
+
+  <style name="Clinic.V2.BloodPressureInputTheme">
+    <item name="colorControlNormal">@color/grey2</item>
+  </style>
 </resources>

--- a/app/src/main/res/values/styles_v2.xml
+++ b/app/src/main/res/values/styles_v2.xml
@@ -503,13 +503,21 @@
     <item name="android:fontFamily">sans-serif</item>
     <item name="android:gravity">center|top</item>
     <item name="android:inputType">number</item>
-    <item name="android:minEms">2</item>
-    <item name="android:maxLength">3</item>
     <item name="android:textSize">40sp</item>
     <item name="android:textColor">@color/grey0</item>
     <item name="android:lineSpacingExtra">16sp</item>
     <item name="android:paddingStart">@dimen/spacing_12</item>
     <item name="android:paddingEnd">@dimen/spacing_12</item>
+  </style>
+
+  <style name="Clinic.V2.BloodPressureInput.BpReading">
+    <item name="android:minEms">2</item>
+    <item name="android:maxLength">3</item>
+  </style>
+
+  <style name="Clinic.V2.BloodPressureInput.Date">
+    <item name="android:minEms">1</item>
+    <item name="android:maxLength">2</item>
   </style>
 
   <style name="Clinic.V2.BloodPressureInputTheme">

--- a/app/src/sharedTest/java/org/simple/clinic/util/RxErrorsRule.kt
+++ b/app/src/sharedTest/java/org/simple/clinic/util/RxErrorsRule.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.util
 
+import com.tspoon.traceur.Traceur
 import io.reactivex.plugins.RxJavaPlugins
 import org.junit.rules.TestRule
 import org.junit.runner.Description
@@ -24,12 +25,14 @@ class RxErrorsRule : TestRule {
   override fun apply(base: Statement, description: Description): Statement {
     return object : Statement() {
       override fun evaluate() {
+        Traceur.enableLogging()
         RxJavaPlugins.setErrorHandler { t -> errors.add(t) }
 
         try {
           base.evaluate()
 
         } finally {
+          Traceur.disableLogging()
           RxJavaPlugins.setErrorHandler(null)
           assertNoErrors()
         }

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -105,7 +105,7 @@ class BloodPressureEntrySheetControllerTest {
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged("90"))
     uiEvents.onNext(BloodPressureDiastolicTextChanged("140"))
-    uiEvents.onNext(BloodPressureSaveClicked())
+    uiEvents.onNext(BloodPressureSaveClicked)
 
     verify(bloodPressureRepository, never()).saveMeasurement(any(), any(), any())
     verify(sheet).showSystolicLessThanDiastolicError()
@@ -116,7 +116,7 @@ class BloodPressureEntrySheetControllerTest {
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged("55"))
     uiEvents.onNext(BloodPressureDiastolicTextChanged("55"))
-    uiEvents.onNext(BloodPressureSaveClicked())
+    uiEvents.onNext(BloodPressureSaveClicked)
 
     verify(bloodPressureRepository, never()).saveMeasurement(any(), any(), any())
     verify(sheet).showSystolicLowError()
@@ -127,7 +127,7 @@ class BloodPressureEntrySheetControllerTest {
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged("333"))
     uiEvents.onNext(BloodPressureDiastolicTextChanged("88"))
-    uiEvents.onNext(BloodPressureSaveClicked())
+    uiEvents.onNext(BloodPressureSaveClicked)
 
     verify(bloodPressureRepository, never()).saveMeasurement(any(), any(), any())
     verify(sheet).showSystolicHighError()
@@ -138,7 +138,7 @@ class BloodPressureEntrySheetControllerTest {
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged("110"))
     uiEvents.onNext(BloodPressureDiastolicTextChanged("33"))
-    uiEvents.onNext(BloodPressureSaveClicked())
+    uiEvents.onNext(BloodPressureSaveClicked)
 
     verify(bloodPressureRepository, never()).saveMeasurement(any(), any(), any())
     verify(sheet).showDiastolicLowError()
@@ -149,7 +149,7 @@ class BloodPressureEntrySheetControllerTest {
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged("233"))
     uiEvents.onNext(BloodPressureDiastolicTextChanged("190"))
-    uiEvents.onNext(BloodPressureSaveClicked())
+    uiEvents.onNext(BloodPressureSaveClicked)
 
     verify(bloodPressureRepository, never()).saveMeasurement(any(), any(), any())
     verify(sheet).showDiastolicHighError()
@@ -160,7 +160,7 @@ class BloodPressureEntrySheetControllerTest {
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged(""))
     uiEvents.onNext(BloodPressureDiastolicTextChanged("190"))
-    uiEvents.onNext(BloodPressureSaveClicked())
+    uiEvents.onNext(BloodPressureSaveClicked)
 
     verify(bloodPressureRepository, never()).saveMeasurement(any(), any(), any())
     verify(sheet).showSystolicEmptyError()
@@ -171,7 +171,7 @@ class BloodPressureEntrySheetControllerTest {
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged("120"))
     uiEvents.onNext(BloodPressureDiastolicTextChanged(""))
-    uiEvents.onNext(BloodPressureSaveClicked())
+    uiEvents.onNext(BloodPressureSaveClicked)
 
     verify(bloodPressureRepository, never()).saveMeasurement(any(), any(), any())
     verify(sheet).showDiastolicEmptyError()
@@ -201,7 +201,7 @@ class BloodPressureEntrySheetControllerTest {
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged(systolic))
     uiEvents.onNext(BloodPressureDiastolicTextChanged(diastolic))
-    uiEvents.onNext(BloodPressureSaveClicked())
+    uiEvents.onNext(BloodPressureSaveClicked)
 
     verify(bloodPressureRepository, never()).saveMeasurement(any(), any(), any())
     verify(sheet, never()).setBPSavedResultAndFinish()
@@ -226,9 +226,9 @@ class BloodPressureEntrySheetControllerTest {
     uiEvents.onNext(BloodPressureEntrySheetCreated(openAs))
     uiEvents.onNext(BloodPressureSystolicTextChanged("142"))
     uiEvents.onNext(BloodPressureDiastolicTextChanged("80"))
-    uiEvents.onNext(BloodPressureSaveClicked())
-    uiEvents.onNext(BloodPressureSaveClicked())
-    uiEvents.onNext(BloodPressureSaveClicked())
+    uiEvents.onNext(BloodPressureSaveClicked)
+    uiEvents.onNext(BloodPressureSaveClicked)
+    uiEvents.onNext(BloodPressureSaveClicked)
 
     if (openAs is OpenAs.New) {
       verify(bloodPressureRepository).saveMeasurement(openAs.patientUuid, 142, 80)

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
@@ -409,7 +409,7 @@ class BloodPressureEntrySheetControllerTestV2 {
     }.exhaustive()
 
     verify(sheet, never()).setBpSavedResultAndFinish()
-    verify(dateValidator, times(5)).validate2("dummy/dummy/dummy")
+    verify(dateValidator, times(3)).validate2("dummy/dummy/dummy")
   }
 
   /**
@@ -439,8 +439,10 @@ class BloodPressureEntrySheetControllerTestV2 {
 
     uiEvents.run {
       onNext(BloodPressureEntrySheetCreated(openAs = OpenAs.New(patientUuid)))
+      onNext(BloodPressureScreenChanged(BP_ENTRY))
       onNext(BloodPressureSystolicTextChanged("120"))
       onNext(BloodPressureDiastolicTextChanged("110"))
+      onNext(BloodPressureSaveClicked)
       onNext(BloodPressureScreenChanged(DATE_ENTRY))
       onNext(BloodPressureDayChanged("13"))
       onNext(BloodPressureMonthChanged("01"))
@@ -473,8 +475,10 @@ class BloodPressureEntrySheetControllerTestV2 {
 
     uiEvents.run {
       onNext(BloodPressureEntrySheetCreated(openAs = OpenAs.Update(existingBp.uuid)))
+      onNext(BloodPressureScreenChanged(BP_ENTRY))
       onNext(BloodPressureSystolicTextChanged("120"))
       onNext(BloodPressureDiastolicTextChanged("110"))
+      onNext(BloodPressureSaveClicked)
       onNext(BloodPressureScreenChanged(DATE_ENTRY))
       onNext(BloodPressureDayChanged("14"))
       onNext(BloodPressureMonthChanged("02"))

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
@@ -37,10 +37,10 @@ import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestClock
 import org.simple.clinic.util.exhaustive
 import org.simple.clinic.widgets.UiEvent
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Invalid.DateIsInFuture
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Invalid.InvalidPattern
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Valid
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result2.Invalid.DateIsInFuture
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result2.Invalid.InvalidPattern
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result2.Valid
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
 import org.threeten.bp.ZoneOffset.UTC
@@ -54,7 +54,7 @@ class BloodPressureEntrySheetControllerTestV2 {
 
   private val sheet = mock<BloodPressureEntrySheet>()
   private val bloodPressureRepository = mock<BloodPressureRepository>()
-  private val dateValidator = mock<DateOfBirthFormatValidator>()
+  private val dateValidator = mock<UserInputDateValidator>()
   private val bpValidator = mock<BpValidator>()
 
   private val uiEvents = PublishSubject.create<UiEvent>()
@@ -355,7 +355,7 @@ class BloodPressureEntrySheetControllerTestV2 {
   @Parameters(method = "params for checking valid date input")
   fun `when save is clicked, date entry is active, but input is invalid then BP measurement should not be saved`(
       openAs: OpenAs,
-      result: DateOfBirthFormatValidator.Result2
+      result: UserInputDateValidator.Result2
   ) {
     whenever(bloodPressureRepository.measurement(any())).thenReturn(Observable.never())
     whenever(dateValidator.validate2("dummy/dummy/dummy")).thenReturn(result)
@@ -387,9 +387,9 @@ class BloodPressureEntrySheetControllerTestV2 {
         listOf(OpenAs.Update(UUID.randomUUID()), InvalidPattern),
         listOf(OpenAs.Update(UUID.randomUUID()), DateIsInFuture))
 
-    //    return DateOfBirthFormatValidator.Result
+    //    return UserInputDateValidator.Result
     //        .values()
-    //        .filter { it != DateOfBirthFormatValidator.Result.VALID }
+    //        .filter { it != UserInputDateValidator.Result.VALID }
     //        .flatMap { result ->
     //          listOf(OpenAs.New(patientUuid), result) + listOf(OpenAs.Update(UUID.randomUUID()), result)
     //        }
@@ -465,7 +465,7 @@ class BloodPressureEntrySheetControllerTestV2 {
   @Parameters(method = "params for showing date validation errors")
   fun `when save is clicked, date entry is active and input is invalid then validation errors should be shown`(
       openAs: OpenAs,
-      errorResult: DateOfBirthFormatValidator.Result2,
+      errorResult: UserInputDateValidator.Result2,
       uiChangeVerification: UiChange
   ) {
     whenever(dateValidator.validate2(any(), any())).thenReturn(errorResult)

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
@@ -568,7 +568,12 @@ class BloodPressureEntrySheetControllerTestV2 {
 
   @Test
   fun `when date entry is active and back is pressed then BP entry should be shown`() {
-    // TODO
+    uiEvents.run {
+      onNext(BloodPressureScreenChanged(DATE_ENTRY))
+      onNext(BloodPressureBackPressed)
+    }
+
+    verify(sheet).showBpEntryScreen()
   }
 
   @Test

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
@@ -528,8 +528,26 @@ class BloodPressureEntrySheetControllerTestV2 {
   }
 
   @Test
-  fun `when BP entry is active, BP readings are valid and next arrow is pressed then date entry should be shown`() {
-    // TODO
+  @Parameters(method = "params for OpenAs types")
+  fun `when BP entry is active, BP readings are valid and next arrow is pressed then date entry should be shown`(
+      openAs: OpenAs
+  ) {
+    whenever(bloodPressureRepository.measurement(any())).thenReturn(Observable.never())
+
+    uiEvents.run {
+      onNext(BloodPressureEntrySheetCreated(openAs = openAs))
+      onNext(BloodPressureScreenChanged(BP_ENTRY))
+      onNext(BloodPressureSystolicTextChanged("120"))
+      onNext(BloodPressureDiastolicTextChanged("110"))
+      onNext(BloodPressureNextArrowClicked)
+    }
+
+    verify(sheet).showDateEntryScreen()
+  }
+
+  @Suppress("Unused")
+  private fun `params for OpenAs types`(): List<Any> {
+    return listOf(OpenAs.New(patientUuid), OpenAs.Update(UUID.randomUUID()))
   }
 
   @Test

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
@@ -513,11 +513,6 @@ class BloodPressureEntrySheetControllerTestV2 {
     verify(sheet).showDateEntryScreen()
   }
 
-  @Suppress("Unused")
-  private fun `params for OpenAs types`(): List<Any> {
-    return listOf(OpenAs.New(patientUuid), OpenAs.Update(UUID.randomUUID()))
-  }
-
   @Test
   @Parameters(method = "params for OpenAs and bp validation errors")
   fun `when BP entry is active, BP readings are invalid and next arrow is pressed then date entry should not be shown`(
@@ -559,8 +554,16 @@ class BloodPressureEntrySheetControllerTestV2 {
   }
 
   @Test
-  fun `when BP entry is active and previous arrow is pressed then date entry should be shown`() {
-    // TODO
+  @Parameters(method = "params for OpenAs types")
+  fun `when date entry is active and previous arrow is pressed then BP entry should be shown`(
+      openAs: OpenAs
+  ) {
+    uiEvents.run {
+      onNext(BloodPressureScreenChanged(DATE_ENTRY))
+      onNext(BloodPressurePreviousArrowClicked)
+    }
+
+    verify(sheet).showBpEntryScreen()
   }
 
   @Test
@@ -571,5 +574,10 @@ class BloodPressureEntrySheetControllerTestV2 {
   @Test
   fun `when screen is opened for a new BP, then the date should be prefilled with the current date`() {
     // TODO
+  }
+
+  @Suppress("Unused")
+  private fun `params for OpenAs types`(): List<Any> {
+    return listOf(OpenAs.New(patientUuid), OpenAs.Update(UUID.randomUUID()))
   }
 }

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
@@ -482,4 +482,66 @@ class BloodPressureEntrySheetControllerTestV2 {
     verify(bloodPressureRepository, never()).saveMeasurement(any(), any(), any(), any())
     verify(sheet).setBpSavedResultAndFinish()
   }
+
+  @Test
+  @Suppress("IMPLICIT_CAST_TO_ANY")
+  @Parameters(method = "params for showing date validation errors")
+  fun `when save is clicked, date entry is active and input is invalid then validation errors should be shown`(
+      openAs: OpenAs,
+      errorResult: DateOfBirthFormatValidator.Result2,
+      errorUiChangeVerifications: UiChange
+  ) {
+    whenever(dateValidator.validate2(any(), any())).thenReturn(errorResult)
+    whenever(bloodPressureRepository.measurement(any())).thenReturn(Observable.never())
+
+    uiEvents.run {
+      onNext(BloodPressureEntrySheetCreated(openAs = openAs))
+      onNext(BloodPressureScreenChanged(DATE_ENTRY))
+      onNext(BloodPressureDayChanged("14"))
+      onNext(BloodPressureMonthChanged("02"))
+      onNext(BloodPressureYearChanged("1991"))
+      onNext(BloodPressureSaveClicked)
+    }
+
+    verify(bloodPressureRepository, never()).saveMeasurement(any(), any(), any(), any())
+    verify(bloodPressureRepository, never()).updateMeasurement(any())
+    verify(sheet, never()).setBpSavedResultAndFinish()
+
+    errorUiChangeVerifications(sheet)
+  }
+
+  @Suppress("unused")
+  fun `params for showing date validation errors`(): List<Any> {
+    val existingBpUuid = UUID.randomUUID()
+    return listOf(
+        listOf(OpenAs.New(patientUuid), InvalidPattern, { ui: Ui -> verify(ui).showInvalidDateError() }),
+        listOf(OpenAs.Update(existingBpUuid), InvalidPattern, { ui: Ui -> verify(ui).showInvalidDateError() }),
+        listOf(OpenAs.New(patientUuid), DateIsInFuture, { ui: Ui -> verify(ui).showDateIsInFutureError() }),
+        listOf(OpenAs.Update(existingBpUuid), DateIsInFuture, { ui: Ui -> verify(ui).showDateIsInFutureError() }))
+  }
+
+  @Test
+  fun `when BP entry is active, BP readings are valid and next arrow is pressed then date entry should be shown`() {
+    // TODO
+  }
+
+  @Test
+  fun `when BP entry is active, BP readings are invalid and next arrow is pressed then date entry should not be shown`() {
+    // TODO
+  }
+
+  @Test
+  fun `when BP entry is active and previous arrow is pressed then date entry should be shown`() {
+    // TODO
+  }
+
+  @Test
+  fun `when date entry is active and back is pressed then BP entry should be shown`() {
+    // TODO
+  }
+
+  @Test
+  fun `when screen is opened for a new BP, then the date should be prefilled with the current date`() {
+    // TODO
+  }
 }

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
@@ -116,7 +116,8 @@ class BloodPressureEntrySheetControllerTestV2 {
   }
 
   @Test
-  fun `when systolic is less than diastolic, show error`() {
+  fun `when in BP entry screen, and systolic is less than diastolic, show error`() {
+    uiEvents.onNext(BloodPressureScreenChanged(BP_ENTRY))
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged("90"))
     uiEvents.onNext(BloodPressureDiastolicTextChanged("140"))
@@ -127,7 +128,8 @@ class BloodPressureEntrySheetControllerTestV2 {
   }
 
   @Test
-  fun `when systolic is less than minimum possible, show error`() {
+  fun `when in BP entry screen, and systolic is less than minimum possible, show error`() {
+    uiEvents.onNext(BloodPressureScreenChanged(BP_ENTRY))
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged("55"))
     uiEvents.onNext(BloodPressureDiastolicTextChanged("55"))
@@ -138,7 +140,8 @@ class BloodPressureEntrySheetControllerTestV2 {
   }
 
   @Test
-  fun `when systolic is more than maximum possible, show error`() {
+  fun `when in BP entry screen, and systolic is more than maximum possible, show error`() {
+    uiEvents.onNext(BloodPressureScreenChanged(BP_ENTRY))
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged("333"))
     uiEvents.onNext(BloodPressureDiastolicTextChanged("88"))
@@ -149,7 +152,8 @@ class BloodPressureEntrySheetControllerTestV2 {
   }
 
   @Test
-  fun `when diastolic is less than minimum possible, show error`() {
+  fun `when in BP entry screen, and diastolic is less than minimum possible, show error`() {
+    uiEvents.onNext(BloodPressureScreenChanged(BP_ENTRY))
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged("110"))
     uiEvents.onNext(BloodPressureDiastolicTextChanged("33"))
@@ -160,7 +164,8 @@ class BloodPressureEntrySheetControllerTestV2 {
   }
 
   @Test
-  fun `when diastolic is more than maximum possible, show error`() {
+  fun `when in BP entry screen, and diastolic is more than maximum possible, show error`() {
+    uiEvents.onNext(BloodPressureScreenChanged(BP_ENTRY))
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged("233"))
     uiEvents.onNext(BloodPressureDiastolicTextChanged("190"))
@@ -171,7 +176,8 @@ class BloodPressureEntrySheetControllerTestV2 {
   }
 
   @Test
-  fun `when systolic is empty, show error`() {
+  fun `when in BP entry screen, and systolic is empty, show error`() {
+    uiEvents.onNext(BloodPressureScreenChanged(BP_ENTRY))
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged(""))
     uiEvents.onNext(BloodPressureDiastolicTextChanged("190"))
@@ -182,7 +188,8 @@ class BloodPressureEntrySheetControllerTestV2 {
   }
 
   @Test
-  fun `when diastolic is empty, show error`() {
+  fun `when in BP entry screen, and diastolic is empty, show error`() {
+    uiEvents.onNext(BloodPressureScreenChanged(BP_ENTRY))
     uiEvents.onNext(BloodPressureEntrySheetCreated(OpenAs.New(patientUuid)))
     uiEvents.onNext(BloodPressureSystolicTextChanged("120"))
     uiEvents.onNext(BloodPressureDiastolicTextChanged(""))

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
@@ -126,7 +126,7 @@ class BloodPressureEntrySheetControllerTestV2 {
   }
 
   @Test
-  @Parameters(method = "params for bp validation errors")
+  @Parameters(method = "params for bp validation errors and expected ui changes")
   fun `when BP entry is active, and BP readings are invalid then show error`(
       error: BpValidator.Validation,
       uiChangeVerification: UiChange
@@ -146,7 +146,7 @@ class BloodPressureEntrySheetControllerTestV2 {
   }
 
   @Suppress("unused")
-  fun `params for bp validation errors`(): List<Any> {
+  fun `params for bp validation errors and expected ui changes`(): List<Any> {
     return listOf(
         listOf<Any>(ErrorSystolicEmpty, { ui: Ui -> verify(ui).showSystolicEmptyError() }),
         listOf<Any>(ErrorDiastolicEmpty, { ui: Ui -> verify(ui).showDiastolicEmptyError() }),
@@ -519,8 +519,43 @@ class BloodPressureEntrySheetControllerTestV2 {
   }
 
   @Test
-  fun `when BP entry is active, BP readings are invalid and next arrow is pressed then date entry should not be shown`() {
-    // TODO
+  @Parameters(method = "params for OpenAs and bp validation errors")
+  fun `when BP entry is active, BP readings are invalid and next arrow is pressed then date entry should not be shown`(
+      openAs: OpenAs,
+      error: BpValidator.Validation
+  ) {
+    whenever(bpValidator.validate(any(), any())).thenReturn(error)
+    whenever(bloodPressureRepository.measurement(any())).thenReturn(Observable.never())
+
+    uiEvents.run {
+      onNext(BloodPressureEntrySheetCreated(openAs = openAs))
+      onNext(BloodPressureScreenChanged(BP_ENTRY))
+      onNext(BloodPressureSystolicTextChanged("-"))
+      onNext(BloodPressureDiastolicTextChanged("-"))
+      onNext(BloodPressureNextArrowClicked)
+    }
+
+    verify(sheet, never()).showDateEntryScreen()
+  }
+
+  @Suppress("unused")
+  fun `params for OpenAs and bp validation errors`(): List<Any> {
+    val bpUuid = UUID.randomUUID()
+    return listOf(
+        listOf(OpenAs.New(patientUuid), ErrorSystolicEmpty),
+        listOf(OpenAs.New(patientUuid), ErrorDiastolicEmpty),
+        listOf(OpenAs.New(patientUuid), ErrorSystolicTooHigh),
+        listOf(OpenAs.New(patientUuid), ErrorSystolicTooLow),
+        listOf(OpenAs.New(patientUuid), ErrorDiastolicTooHigh),
+        listOf(OpenAs.New(patientUuid), ErrorDiastolicTooLow),
+        listOf(OpenAs.New(patientUuid), ErrorSystolicLessThanDiastolic),
+        listOf(OpenAs.Update(bpUuid), ErrorSystolicEmpty),
+        listOf(OpenAs.Update(bpUuid), ErrorDiastolicEmpty),
+        listOf(OpenAs.Update(bpUuid), ErrorSystolicTooHigh),
+        listOf(OpenAs.Update(bpUuid), ErrorSystolicTooLow),
+        listOf(OpenAs.Update(bpUuid), ErrorDiastolicTooHigh),
+        listOf(OpenAs.Update(bpUuid), ErrorDiastolicTooLow),
+        listOf(OpenAs.Update(bpUuid), ErrorSystolicLessThanDiastolic))
   }
 
   @Test

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
+import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.plugins.RxJavaPlugins
@@ -401,7 +402,7 @@ class BloodPressureEntrySheetControllerTestV2 {
     }.exhaustive()
 
     verify(sheet, never()).setBpSavedResultAndFinish()
-    verify(dateValidator, times(3)).validate2("dummy/dummy/dummy")
+    verify(dateValidator, times(5)).validate2("dummy/dummy/dummy")
   }
 
   /**
@@ -433,10 +434,10 @@ class BloodPressureEntrySheetControllerTestV2 {
       onNext(BloodPressureEntrySheetCreated(openAs = OpenAs.New(patientUuid)))
       onNext(BloodPressureSystolicTextChanged("120"))
       onNext(BloodPressureDiastolicTextChanged("110"))
+      onNext(BloodPressureScreenChanged(DATE_ENTRY))
       onNext(BloodPressureDayChanged("13"))
       onNext(BloodPressureMonthChanged("01"))
       onNext(BloodPressureYearChanged("1990"))
-      onNext(BloodPressureScreenChanged(DATE_ENTRY))
       onNext(BloodPressureSaveClicked)
     }
 
@@ -453,14 +454,32 @@ class BloodPressureEntrySheetControllerTestV2 {
   }
 
   @Test
-  fun `when save is clicked while updating a BP, date entry is active and input is valid then a BP measurement should be saved`() {
-    // TODO
-  }
+  fun `when save is clicked while updating a BP, date entry is active and input is valid then the updated BP measurement should be saved`() {
+    val oldCreatedAt = LocalDate.of(1990, 1, 13).atStartOfDay(UTC).toInstant()
+    val existingBp = PatientMocker.bp(systolic = 9000, diastolic = 8999, createdAt = oldCreatedAt, updatedAt = oldCreatedAt)
 
-  @Test
-  fun `when date entry is active and back is pressed then BP entry should be shown`() {
-    // TODO
-  }
+    val newInputDate = LocalDate.of(1991, 2, 14)
+    whenever(dateValidator.validate2(any(), any())).thenReturn(Valid(newInputDate))
+    whenever(bloodPressureRepository.saveMeasurement(any(), any(), any(), any())).thenReturn(Single.just(PatientMocker.bp()))
+    whenever(bloodPressureRepository.measurement(existingBp.uuid)).thenReturn(Observable.just(existingBp))
+    whenever(bloodPressureRepository.updateMeasurement(any())).thenReturn(Completable.complete())
 
-  // TODO: Date validation tests.
+    uiEvents.run {
+      onNext(BloodPressureEntrySheetCreated(openAs = OpenAs.Update(existingBp.uuid)))
+      onNext(BloodPressureSystolicTextChanged("120"))
+      onNext(BloodPressureDiastolicTextChanged("110"))
+      onNext(BloodPressureScreenChanged(DATE_ENTRY))
+      onNext(BloodPressureDayChanged("14"))
+      onNext(BloodPressureMonthChanged("02"))
+      onNext(BloodPressureYearChanged("1991"))
+      onNext(BloodPressureSaveClicked)
+    }
+
+    val newInputDateAsInstant = newInputDate.atStartOfDay(UTC).toInstant()
+    val updatedBp = existingBp.copy(systolic = 120, diastolic = 110, createdAt = newInputDateAsInstant, updatedAt = newInputDateAsInstant)
+    verify(bloodPressureRepository).updateMeasurement(updatedBp)
+
+    verify(bloodPressureRepository, never()).saveMeasurement(any(), any(), any(), any())
+    verify(sheet).setBpSavedResultAndFinish()
+  }
 }

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
@@ -28,9 +28,9 @@ import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.exhaustive
 import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result.DATE_IS_IN_FUTURE
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result.INVALID_PATTERN
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result.VALID
+import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Invalid.DateIsInFuture
+import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Invalid.InvalidPattern
+import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Valid
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
 import org.threeten.bp.ZoneOffset.UTC
@@ -383,10 +383,10 @@ class BloodPressureEntrySheetControllerTestV2 {
   @Parameters(method = "params for checking valid date input")
   fun `when save is clicked, date entry is active, but input is invalid then BP measurement should not be saved`(
       openAs: OpenAs,
-      result: DateOfBirthFormatValidator.Result
+      result: DateOfBirthFormatValidator.Result2
   ) {
     whenever(bloodPressureRepository.measurement(any())).thenReturn(Observable.never())
-    whenever(dateValidator.validate("dummy/dummy/dummy")).thenReturn(result)
+    whenever(dateValidator.validate2("dummy/dummy/dummy")).thenReturn(result)
 
     uiEvents.onNext(BloodPressureEntrySheetCreated(openAs))
     uiEvents.onNext(BloodPressureScreenChanged(DATE_ENTRY))
@@ -401,7 +401,7 @@ class BloodPressureEntrySheetControllerTestV2 {
     }.exhaustive()
 
     verify(sheet, never()).setBpSavedResultAndFinish()
-    verify(dateValidator, times(3)).validate("dummy/dummy/dummy")
+    verify(dateValidator, times(3)).validate2("dummy/dummy/dummy")
   }
 
   /**
@@ -410,10 +410,10 @@ class BloodPressureEntrySheetControllerTestV2 {
   @Suppress("Unused")
   private fun `params for checking valid date input`(): List<Any> {
     return listOf(
-        listOf(OpenAs.New(patientUuid), INVALID_PATTERN),
-        listOf(OpenAs.New(patientUuid), DATE_IS_IN_FUTURE),
-        listOf(OpenAs.Update(UUID.randomUUID()), INVALID_PATTERN),
-        listOf(OpenAs.Update(UUID.randomUUID()), DATE_IS_IN_FUTURE))
+        listOf(OpenAs.New(patientUuid), InvalidPattern),
+        listOf(OpenAs.New(patientUuid), DateIsInFuture),
+        listOf(OpenAs.Update(UUID.randomUUID()), InvalidPattern),
+        listOf(OpenAs.Update(UUID.randomUUID()), DateIsInFuture))
 
     //    return DateOfBirthFormatValidator.Result
     //        .values()
@@ -425,8 +425,9 @@ class BloodPressureEntrySheetControllerTestV2 {
 
   @Test
   fun `when save is clicked for a new BP, date entry is active and input is valid then a BP measurement should be saved`() {
+    val inputDate = LocalDate.of(1990, 1, 13)
+    whenever(dateValidator.validate2(any(), any())).thenReturn(Valid(inputDate))
     whenever(bloodPressureRepository.saveMeasurement(any(), any(), any(), any())).thenReturn(Single.just(PatientMocker.bp()))
-    whenever(dateValidator.validate(any())).thenReturn(VALID)
 
     uiEvents.run {
       onNext(BloodPressureEntrySheetCreated(openAs = OpenAs.New(patientUuid)))
@@ -439,7 +440,7 @@ class BloodPressureEntrySheetControllerTestV2 {
       onNext(BloodPressureSaveClicked)
     }
 
-    val entryDateAsInstant = LocalDate.of(1990, 1, 13).atStartOfDay(UTC).toInstant()
+    val entryDateAsInstant = inputDate.atStartOfDay(UTC).toInstant()
 
     verify(bloodPressureRepository, never()).updateMeasurement(any())
 

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTestV2.kt
@@ -52,6 +52,7 @@ class BloodPressureEntrySheetControllerTestV2 {
   private lateinit var controller: BloodPressureEntrySheetControllerV2
 
   private val dateValidator = mock<DateOfBirthFormatValidator>()
+  private val bpValidator = BpValidator()
 
   @Before
   fun setUp() {
@@ -60,7 +61,8 @@ class BloodPressureEntrySheetControllerTestV2 {
     controller = BloodPressureEntrySheetControllerV2(
         bloodPressureRepository = bloodPressureRepository,
         configProvider = configEmitter.firstOrError(),
-        dateValidator = dateValidator)
+        dateValidator = dateValidator,
+        bpValidator = bpValidator)
 
     uiEvents
         .compose(controller)

--- a/app/src/test/java/org/simple/clinic/bp/entry/BpValidatorTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BpValidatorTest.kt
@@ -1,0 +1,72 @@
+package org.simple.clinic.bp.entry
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class BpValidatorTest {
+
+  private val bpValidator = BpValidator()
+
+  @Test
+  fun `when systolic is less than diastolic, return error`() {
+    val systolic = "90"
+    val diastolic = "140"
+    val result = bpValidator.validate(systolic, diastolic)
+
+    assertThat(result).isEqualTo(BpValidator.Validation.ErrorSystolicLessThanDiastolic)
+  }
+
+  @Test
+  fun `when systolic is less than minimum possible, return error`() {
+    val systolic = "55"
+    val diastolic = "55"
+    val result = bpValidator.validate(systolic, diastolic)
+
+    assertThat(result).isEqualTo(BpValidator.Validation.ErrorSystolicTooLow)
+  }
+
+  @Test
+  fun `when systolic is more than maximum possible, return error`() {
+    val systolic = "333"
+    val diastolic = "88"
+    val result = bpValidator.validate(systolic, diastolic)
+
+    assertThat(result).isEqualTo(BpValidator.Validation.ErrorSystolicTooHigh)
+  }
+
+  @Test
+  fun `when diastolic is less than minimum possible, return error`() {
+    val systolic = "110"
+    val diastolic = "33"
+    val result = bpValidator.validate(systolic, diastolic)
+
+    assertThat(result).isEqualTo(BpValidator.Validation.ErrorDiastolicTooLow)
+  }
+
+  @Test
+  fun `when diastolic is more than maximum possible, return error`() {
+    val systolic = "233"
+    val diastolic = "190"
+    val result = bpValidator.validate(systolic, diastolic)
+
+    assertThat(result).isEqualTo(BpValidator.Validation.ErrorDiastolicTooHigh)
+  }
+
+  @Test
+  fun `when systolic is empty, return error`() {
+    val systolic = ""
+    val diastolic = "190"
+    val result = bpValidator.validate(systolic, diastolic)
+
+    assertThat(result).isEqualTo(BpValidator.Validation.ErrorSystolicEmpty)
+  }
+
+  @Test
+  fun `when diastolic is empty, return error`() {
+    val systolic = "120"
+    val diastolic = ""
+    val result = bpValidator.validate(systolic, diastolic)
+
+    assertThat(result).isEqualTo(BpValidator.Validation.ErrorDiastolicEmpty)
+  }
+}

--- a/app/src/test/java/org/simple/clinic/editpatient/PatientEditScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/PatientEditScreenControllerTest.kt
@@ -1143,7 +1143,6 @@ class PatientEditScreenControllerTest {
 
   @Suppress("Unused")
   private fun `params for confirming discard changes`(): List<List<Any?>> {
-
     fun generatePatientProfile(
         name: String? = null,
         phoneNumber: String? = null,

--- a/app/src/test/java/org/simple/clinic/newentry/DateOfBirthFormatValidatorTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/DateOfBirthFormatValidatorTest.kt
@@ -7,6 +7,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result
+import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Invalid
+import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Valid
 import org.threeten.bp.LocalDate
 import org.threeten.bp.format.DateTimeFormatter
 import java.util.Locale
@@ -23,18 +25,46 @@ class DateOfBirthFormatValidatorTest {
     "24/04, INVALID_PATTERN",
     " , INVALID_PATTERN"
   ])
-  fun validate(date: String, expectedResult: Result) {
+  fun `validate (v1)`(date: String, expectedResult: Result) {
     val format = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH)
 
     assertThat(DateOfBirthFormatValidator(format).validate(date)).isEqualTo(expectedResult)
   }
 
   @Test
-  fun `validate future date`() {
+  @Parameters(method = "params for v2 validation")
+  fun `validate (v2)`(date: String, expectedResult: DateOfBirthFormatValidator.Result2) {
+    val format = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH)
+
+    assertThat(DateOfBirthFormatValidator(format).validate2(date)).isEqualTo(expectedResult)
+  }
+
+  @Suppress("unused")
+  fun `params for v2 validation`(): List<Any> {
+    return listOf(
+        listOf("24/04/1971", Valid(LocalDate.of(1971, 4, 24))),
+        listOf("24-04-1971", Invalid.InvalidPattern),
+        listOf("1971-04-24", Invalid.InvalidPattern),
+        listOf("1971-24-04", Invalid.InvalidPattern),
+        listOf("24/04", Invalid.InvalidPattern),
+        listOf(" ", Invalid.InvalidPattern))
+  }
+
+  @Test
+  fun `validate future date (v1)`() {
     val format = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH)
     val dobValidator = DateOfBirthFormatValidator(format)
     val futureDateResult = dobValidator.validate("01/01/3000", nowDate = LocalDate.parse("2018-07-16"))
 
     assertThat(futureDateResult).isEqualTo(Result.DATE_IS_IN_FUTURE)
+  }
+
+  @Test
+  fun `validate future date (v2)`() {
+    val format = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH)
+    val dobValidator = DateOfBirthFormatValidator(format)
+    val futureDateResult = dobValidator.validate2("01/01/3000", nowDate = LocalDate.parse("2018-07-16"))
+
+    assertThat(futureDateResult).isEqualTo(Invalid.DateIsInFuture)
   }
 }

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
@@ -40,8 +40,8 @@ import org.simple.clinic.widgets.ScreenCreated
 import org.simple.clinic.widgets.TheActivityLifecycle
 import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result
 
 @RunWith(JUnitParamsRunner::class)
 class PatientEntryScreenControllerTest {
@@ -53,7 +53,7 @@ class PatientEntryScreenControllerTest {
   private val patientRepository = mock<PatientRepository>()
   private val facilityRepository = mock<FacilityRepository>()
   private val userSession = mock<UserSession>()
-  private val dobValidator = mock<DateOfBirthFormatValidator>()
+  private val dobValidator = mock<UserInputDateValidator>()
   private val numberValidator = mock<PhoneNumberValidator>()
 
   private val uiEvents = PublishSubject.create<UiEvent>()

--- a/app/src/test/java/org/simple/clinic/newentry/UserInputDateValidatorTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/UserInputDateValidatorTest.kt
@@ -5,16 +5,16 @@ import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Invalid
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result2.Valid
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result2.Invalid
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result2.Valid
 import org.threeten.bp.LocalDate
 import org.threeten.bp.format.DateTimeFormatter
 import java.util.Locale
 
 @RunWith(JUnitParamsRunner::class)
-class DateOfBirthFormatValidatorTest {
+class UserInputDateValidatorTest {
 
   @Test
   @Parameters(value = [
@@ -28,15 +28,15 @@ class DateOfBirthFormatValidatorTest {
   fun `validate (v1)`(date: String, expectedResult: Result) {
     val format = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH)
 
-    assertThat(DateOfBirthFormatValidator(format).validate(date)).isEqualTo(expectedResult)
+    assertThat(UserInputDateValidator(format).validate(date)).isEqualTo(expectedResult)
   }
 
   @Test
   @Parameters(method = "params for v2 validation")
-  fun `validate (v2)`(date: String, expectedResult: DateOfBirthFormatValidator.Result2) {
+  fun `validate (v2)`(date: String, expectedResult: UserInputDateValidator.Result2) {
     val format = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH)
 
-    assertThat(DateOfBirthFormatValidator(format).validate2(date)).isEqualTo(expectedResult)
+    assertThat(UserInputDateValidator(format).validate2(date)).isEqualTo(expectedResult)
   }
 
   @Suppress("unused")
@@ -53,7 +53,7 @@ class DateOfBirthFormatValidatorTest {
   @Test
   fun `validate future date (v1)`() {
     val format = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH)
-    val dobValidator = DateOfBirthFormatValidator(format)
+    val dobValidator = UserInputDateValidator(format)
     val futureDateResult = dobValidator.validate("01/01/3000", nowDate = LocalDate.parse("2018-07-16"))
 
     assertThat(futureDateResult).isEqualTo(Result.DATE_IS_IN_FUTURE)
@@ -62,7 +62,7 @@ class DateOfBirthFormatValidatorTest {
   @Test
   fun `validate future date (v2)`() {
     val format = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH)
-    val dobValidator = DateOfBirthFormatValidator(format)
+    val dobValidator = UserInputDateValidator(format)
     val futureDateResult = dobValidator.validate2("01/01/3000", nowDate = LocalDate.parse("2018-07-16"))
 
     assertThat(futureDateResult).isEqualTo(Invalid.DateIsInFuture)

--- a/app/src/test/java/org/simple/clinic/patient/OngoingNewPatientEntryTest.kt
+++ b/app/src/test/java/org/simple/clinic/patient/OngoingNewPatientEntryTest.kt
@@ -7,8 +7,8 @@ import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator.Result
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result
 import org.simple.clinic.patient.OngoingNewPatientEntry.Address
 import org.simple.clinic.patient.OngoingNewPatientEntry.PersonalDetails
 import org.simple.clinic.patient.OngoingNewPatientEntry.PhoneNumber
@@ -38,7 +38,7 @@ class OngoingNewPatientEntryTest {
         address = Address(colonyOrVillage, district, state),
         phoneNumber = PhoneNumber(""))
 
-    val dobValidator = DateOfBirthFormatValidator(DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH))
+    val dobValidator = UserInputDateValidator(DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH))
     val numValidator = mock<PhoneNumberValidator>()
     whenever(numValidator.validate("", LANDLINE_OR_MOBILE)).thenReturn(phoneValidationResult)
 
@@ -70,7 +70,7 @@ class OngoingNewPatientEntryTest {
         address = Address("colony", "district", "state"),
         phoneNumber = PhoneNumber("phone-number"))
 
-    val mockDobValidator = mock<DateOfBirthFormatValidator>()
+    val mockDobValidator = mock<UserInputDateValidator>()
     whenever(mockDobValidator.validate("01/01/3000")).thenReturn(Result.DATE_IS_IN_FUTURE)
 
     val mockNumValidator = mock<PhoneNumberValidator>()

--- a/app/src/test/java/org/simple/clinic/patient/PatientRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/patient/PatientRepositoryTest.kt
@@ -27,7 +27,7 @@ import org.simple.clinic.registration.phone.PhoneNumberValidator
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestClock
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthFormatValidator
+import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
 import org.threeten.bp.format.DateTimeFormatter
 import java.util.UUID
 
@@ -45,7 +45,7 @@ class PatientRepositoryTest {
   private lateinit var patientAddressDao: PatientAddress.RoomDao
   private lateinit var patientPhoneNumberDao: PatientPhoneNumber.RoomDao
   private lateinit var fuzzyPatientSearchDao: PatientFuzzySearch.PatientFuzzySearchDao
-  private lateinit var dobValidator: DateOfBirthFormatValidator
+  private lateinit var dobValidator: UserInputDateValidator
   private lateinit var userSession: UserSession
   private lateinit var facilityRepository: FacilityRepository
   private lateinit var numberValidator: PhoneNumberValidator

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ buildscript {
       javaStringSimilarity: '1.1.0',
       espresso            : '3.0.2',
       leakCanary          : '1.6.2',
+      constraintLayout    : '1.1.2',
   ]
 
   repositories {


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2184102/stories/163052502

- [ ] Avoid hardcoding date pattern
- [x] Explore having a super type for incorrect dates to leverage `Observable#ofType()`.
- [x] Tests for validate2()
- [ ] Find a better name for `BloodPressureDateValidated` or revert to storing result as constructor param
- [x] Consider adding a `BpValidated` event
- [x] Rename `DateOfBirthFormatValidator` -> `UserInputDateValidator`
- [ ] Add a Pivotal story for displaying granular date errors (e.g., Day cannot be greater than 28 for February, Month cannot be greater than 12, etc.)
- [ ] Copy changes made in https://github.com/simpledotorg/simple-android/pull/446/commits/fccc709d7145a4cee5b18e63cb64098cc7e29b0d