### PR TITLE
Facility selection: discard stale location updates

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/TestClinicApp.kt
+++ b/app/src/androidTest/java/org/simple/clinic/TestClinicApp.kt
@@ -33,6 +33,8 @@ import org.simple.clinic.storage.StorageModule
 import org.simple.clinic.sync.SyncScheduler
 import org.simple.clinic.user.LoggedInUserHttpInterceptor
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.ElapsedRealtimeClock
+import org.simple.clinic.util.TestElapsedRealtimeClock
 import org.simple.clinic.util.TestUserClock
 import org.simple.clinic.util.TestUtcClock
 import org.simple.clinic.util.UserClock
@@ -75,6 +77,8 @@ class TestClinicApp : ClinicApp() {
           override fun utcClock(): UtcClock = TestUtcClock()
 
           override fun userClock(userTimeZone: ZoneId): UserClock = TestUserClock()
+
+          override fun elapsedRealtimeClock(): ElapsedRealtimeClock = TestElapsedRealtimeClock()
         })
         .storageModule(object : StorageModule(databaseName = "ignored", runDatabaseQueriesOnMainThread = true) {
           override fun sqliteOpenHelperFactory() = AppSqliteOpenHelperFactory(inMemory = true)

--- a/app/src/main/java/org/simple/clinic/di/AppModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/AppModule.kt
@@ -15,6 +15,7 @@ import org.simple.clinic.storage.StorageModule
 import org.simple.clinic.summary.PatientSummaryModule
 import org.simple.clinic.sync.SyncModule
 import org.simple.clinic.sync.indicator.SyncIndicatorModule
+import org.simple.clinic.util.ElapsedRealtimeClock
 import org.simple.clinic.util.RealUserClock
 import org.simple.clinic.util.UserClock
 import org.simple.clinic.util.UtcClock
@@ -54,6 +55,10 @@ open class AppModule(private val appContext: Application) {
   @Provides
   @AppScope
   open fun userClock(userTimeZone: ZoneId): UserClock= RealUserClock(userTimeZone)
+
+  @Provides
+  @AppScope
+  open fun elapsedRealtimeClock() = ElapsedRealtimeClock()
 
   @Provides
   @AppScope

--- a/app/src/main/java/org/simple/clinic/facility/change/FacilityListItem.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/FacilityListItem.kt
@@ -13,7 +13,8 @@ sealed class FacilityListItem {
   data class FacilityOption(
       val facility: Facility,
       val name: Name,
-      val address: Address
+      val address: Address,
+      val showBottomDivider: Boolean
   ): FacilityListItem() {
 
     sealed class Name(open val text: String) {

--- a/app/src/main/java/org/simple/clinic/facility/change/FacilityListItemBuilder.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/FacilityListItemBuilder.kt
@@ -18,11 +18,16 @@ object FacilityListItemBuilder {
         ?.let { facilitiesNearbyUser(facilities, userLocation, proximityThreshold) }
         ?: emptyList()
 
-    val nearbyFacilityItems = nearbyFacilities.map { uiModel(it, searchQuery) }
-    val allFacilityItems = facilities.map { uiModel(it, searchQuery) }
+    val nearbyFacilityItems = nearbyFacilities.mapIndexed { index, facility ->
+      uiModel(facility, searchQuery, isLastItemInSection = index == nearbyFacilities.size - 1)
+    }
+
+    val allFacilityItems = facilities.mapIndexed { index, facility ->
+      uiModel(facility, searchQuery, isLastItemInSection = index == facilities.size - 1)
+    }
 
     val listItems = mutableListOf<FacilityListItem>()
-    if (nearbyFacilityItems.isNotEmpty()) {
+    if (searchQuery.isBlank() && nearbyFacilityItems.isNotEmpty()) {
       listItems.add(FacilityListItem.Header.SuggestedFacilities)
       listItems.addAll(nearbyFacilityItems)
       listItems.add(FacilityListItem.Header.AllFacilities)
@@ -59,7 +64,7 @@ object FacilityListItemBuilder {
         .map { (facility, _) -> facility }
   }
 
-  private fun uiModel(facility: Facility, searchQuery: String): FacilityOption {
+  private fun uiModel(facility: Facility, searchQuery: String, isLastItemInSection: Boolean): FacilityOption {
     val canHighlight = searchQuery.isNotBlank() && facility.name.contains(searchQuery, ignoreCase = true)
 
     val highlightedName = if (canHighlight) {
@@ -77,6 +82,10 @@ object FacilityListItemBuilder {
       FacilityOption.Address.WithStreet(street = facility.streetAddress, district = facility.district, state = facility.state)
     }
 
-    return FacilityOption(facility = facility, name = highlightedName, address = fullAddress)
+    return FacilityOption(
+        facility = facility,
+        name = highlightedName,
+        address = fullAddress,
+        showBottomDivider = isLastItemInSection.not())
   }
 }

--- a/app/src/main/java/org/simple/clinic/location/LocationRepository.kt
+++ b/app/src/main/java/org/simple/clinic/location/LocationRepository.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.location
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Application
 import android.location.Location
@@ -14,6 +15,7 @@ import org.threeten.bp.Duration
 import javax.inject.Inject
 
 typealias LocationProvider = FusedLocationProviderClient
+const val LOCATION_PERMISSION = Manifest.permission.ACCESS_FINE_LOCATION
 
 @SuppressLint("MissingPermission")
 class LocationRepository @Inject constructor(private val appContext: Application) {

--- a/app/src/main/java/org/simple/clinic/location/LocationRepository.kt
+++ b/app/src/main/java/org/simple/clinic/location/LocationRepository.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Application
 import android.location.Location
+import androidx.annotation.RequiresPermission
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationAvailability
 import com.google.android.gms.location.LocationCallback
@@ -22,6 +23,7 @@ class LocationRepository @Inject constructor(private val appContext: Application
 
   data class LocationStatus(val isUsable: Boolean)
 
+  @RequiresPermission(LOCATION_PERMISSION)
   fun streamUserLocation(updateInterval: Duration): Observable<LocationUpdate> {
     val locationProvider = LocationServices.getFusedLocationProviderClient(appContext)
     val request = locationRequest(updateInterval)

--- a/app/src/main/java/org/simple/clinic/location/LocationUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/location/LocationUpdate.kt
@@ -1,6 +1,20 @@
 package org.simple.clinic.location
 
+import org.simple.clinic.util.ElapsedRealtimeClock
+import org.threeten.bp.Duration
+
 sealed class LocationUpdate {
+
   object Unavailable : LocationUpdate()
-  data class Available(val location: Coordinates) : LocationUpdate()
+
+  data class Available(
+      val location: Coordinates,
+      val timeSinceBootWhenRecorded: Duration
+  ) : LocationUpdate() {
+
+    fun age(elapsedRealtimeClock: ElapsedRealtimeClock): Duration {
+      val timeSinceSystemBoot = Duration.ofMillis(elapsedRealtimeClock.instant().toEpochMilli())
+      return timeSinceSystemBoot - timeSinceBootWhenRecorded
+    }
+  }
 }

--- a/app/src/main/java/org/simple/clinic/registration/RegistrationConfig.kt
+++ b/app/src/main/java/org/simple/clinic/registration/RegistrationConfig.kt
@@ -7,5 +7,6 @@ data class RegistrationConfig(
     val retryBackOffDelayInMinutes: Long, // TODO: convert to Duration
     val locationListenerExpiry: Duration,
     val locationUpdateInterval: Duration,
-    val proximityThresholdForNearbyFacilities: Distance
+    val proximityThresholdForNearbyFacilities: Distance,
+    val staleLocationThreshold: Duration
 )

--- a/app/src/main/java/org/simple/clinic/registration/RegistrationModule.kt
+++ b/app/src/main/java/org/simple/clinic/registration/RegistrationModule.kt
@@ -23,7 +23,8 @@ open class RegistrationModule {
         retryBackOffDelayInMinutes = 1,
         locationListenerExpiry = Duration.ofSeconds(5),
         locationUpdateInterval = Duration.ofSeconds(1),
-        proximityThresholdForNearbyFacilities = Distance.ofKilometers(2.0)))
+        proximityThresholdForNearbyFacilities = Distance.ofKilometers(2.0),
+        staleLocationThreshold = Duration.ofMinutes(10)))
   }
 
   @Provides

--- a/app/src/main/java/org/simple/clinic/registration/facility/FacilitiesAdapter.kt
+++ b/app/src/main/java/org/simple/clinic/registration/facility/FacilitiesAdapter.kt
@@ -21,6 +21,7 @@ import org.simple.clinic.facility.change.FacilityListItem.FacilityOption.Name
 import org.simple.clinic.util.exhaustive
 import org.simple.clinic.widgets.setTopMargin
 import org.simple.clinic.widgets.setTopMarginRes
+import org.simple.clinic.widgets.visibleOrGone
 
 /**
  * FYI: We tried using Groupie for facility screen, but it was resulting in a weird
@@ -104,6 +105,7 @@ class FacilityHeaderViewHolder(rootView: View) : ViewHolder(rootView) {
 class FacilityOptionViewHolder(rootView: View) : ViewHolder(rootView) {
   private val nameTextView by bindView<TextView>(R.id.facility_item_name)
   private val addressTextView by bindView<TextView>(R.id.facility_item_address)
+  private val dividerView by bindView<View>(R.id.facility_item_divider)
 
   lateinit var facilityOption: FacilityListItem.FacilityOption
 
@@ -137,5 +139,8 @@ class FacilityOptionViewHolder(rootView: View) : ViewHolder(rootView) {
             address.state)
       }
     }
+
+    dividerView.visibility = if (facilityOption.showBottomDivider) View.VISIBLE else View.GONE
+    dividerView.visibleOrGone(facilityOption.showBottomDivider)
   }
 }

--- a/app/src/main/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionScreenController.kt
@@ -72,7 +72,7 @@ class RegistrationFacilitySelectionScreenController @Inject constructor(
         .ofType<ScreenCreated>()
         .flatMap { Observable.merge(locationWaitExpiry(), fetchLocation()) }
         .take(1)
-        .map { RegistrationUserLocationUpdated(it) }
+        .map { RegistrationFacilityUserLocationUpdated(it) }
 
     events.mergeWith(locationUpdates)
   }
@@ -95,7 +95,7 @@ class RegistrationFacilitySelectionScreenController @Inject constructor(
 
     val fetchFacilities = fetchFacilitiesOnStart.mergeWith(fetchFacilitiesOnRetry)
 
-    val locationUpdates = events.ofType<RegistrationUserLocationUpdated>()
+    val locationUpdates = events.ofType<RegistrationFacilityUserLocationUpdated>()
 
     // We don't care about the location here. We just want to show
     // progress until we receive an update, even if it's empty.
@@ -123,7 +123,7 @@ class RegistrationFacilitySelectionScreenController @Inject constructor(
         .map { it.query }
 
     val locationUpdates = events
-        .ofType<RegistrationUserLocationUpdated>()
+        .ofType<RegistrationFacilityUserLocationUpdated>()
         .map { it.location }
 
     val filteredFacilityListItems = Observables

--- a/app/src/main/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionScreenEvents.kt
+++ b/app/src/main/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionScreenEvents.kt
@@ -2,6 +2,7 @@ package org.simple.clinic.registration.facility
 
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.location.LocationUpdate
+import org.simple.clinic.util.RuntimePermissionResult
 import org.simple.clinic.widgets.UiEvent
 
 class RegistrationFacilitySelectionRetryClicked : UiEvent {
@@ -21,4 +22,8 @@ data class RegistrationFacilityUserLocationUpdated(val location: LocationUpdate)
     is LocationUpdate.Unavailable -> "TurnedOff"
     is LocationUpdate.Available -> "Available"
   }}"
+}
+
+data class RegistrationFacilityLocationPermissionChanged(val result: RuntimePermissionResult) : UiEvent {
+  override val analyticsName = "Registration:Facility Selection:Location Permission Changed to $result"
 }

--- a/app/src/main/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionScreenEvents.kt
+++ b/app/src/main/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionScreenEvents.kt
@@ -16,7 +16,7 @@ data class RegistrationFacilitySearchQueryChanged(val query: String) : UiEvent {
   override val analyticsName = "Registration:Facility Selection:Search Query Changed"
 }
 
-data class RegistrationUserLocationUpdated(val location: LocationUpdate) : UiEvent {
+data class RegistrationFacilityUserLocationUpdated(val location: LocationUpdate) : UiEvent {
   override val analyticsName = "Registration:Facility Selection:Location Updated ${when (location) {
     is LocationUpdate.Unavailable -> "TurnedOff"
     is LocationUpdate.Available -> "Available"

--- a/app/src/main/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreen.kt
+++ b/app/src/main/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreen.kt
@@ -1,11 +1,10 @@
 package org.simple.clinic.registration.location
 
-import android.Manifest
 import android.content.Context
-import androidx.appcompat.widget.Toolbar
 import android.util.AttributeSet
 import android.widget.Button
 import android.widget.RelativeLayout
+import androidx.appcompat.widget.Toolbar
 import com.jakewharton.rxbinding2.view.RxView
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
@@ -14,6 +13,7 @@ import io.reactivex.schedulers.Schedulers.io
 import kotterknife.bindView
 import org.simple.clinic.R
 import org.simple.clinic.activity.TheActivity
+import org.simple.clinic.location.LOCATION_PERMISSION
 import org.simple.clinic.registration.facility.RegistrationFacilitySelectionScreenKey
 import org.simple.clinic.router.screen.ActivityPermissionResult
 import org.simple.clinic.router.screen.ScreenRouter
@@ -22,7 +22,6 @@ import org.simple.clinic.widgets.hideKeyboard
 import javax.inject.Inject
 
 private const val REQUESTCODE_LOCATION_PERMISSION = 0
-private const val LOCATION_PERMISSION = Manifest.permission.ACCESS_FINE_LOCATION
 
 class RegistrationLocationPermissionScreen(context: Context, attrs: AttributeSet) : RelativeLayout(context, attrs) {
 

--- a/app/src/main/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreen.kt
+++ b/app/src/main/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreen.kt
@@ -70,12 +70,12 @@ class RegistrationLocationPermissionScreen(context: Context, attrs: AttributeSet
     hideKeyboard()
   }
 
-  private fun locationPermissionChanges(): Observable<LocationPermissionChanged> {
+  private fun locationPermissionChanges(): Observable<RegistrationLocationPermissionChanged> {
     return screenRouter.streamScreenResults()
         .ofType<ActivityPermissionResult>()
         .filter { result -> result.requestCode == REQUESTCODE_LOCATION_PERMISSION }
         .map { RuntimePermissions.check(activity, LOCATION_PERMISSION) }
-        .map(::LocationPermissionChanged)
+        .map(::RegistrationLocationPermissionChanged)
   }
 
   private fun requestLocationPermission() {

--- a/app/src/main/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreenController.kt
@@ -22,7 +22,7 @@ class RegistrationLocationPermissionScreenController @Inject constructor() : Obs
 
   private fun handlePermissionGrants(events: Observable<UiEvent>): Observable<UiChange> {
     return events
-        .ofType<LocationPermissionChanged>()
+        .ofType<RegistrationLocationPermissionChanged>()
         .filter { it.result == RuntimePermissionResult.GRANTED }
         .map { { ui: Ui -> ui.openFacilitySelectionScreen() } }
   }

--- a/app/src/main/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreenEvents.kt
+++ b/app/src/main/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreenEvents.kt
@@ -3,6 +3,6 @@ package org.simple.clinic.registration.location
 import org.simple.clinic.util.RuntimePermissionResult
 import org.simple.clinic.widgets.UiEvent
 
-data class LocationPermissionChanged(val result: RuntimePermissionResult) : UiEvent {
+data class RegistrationLocationPermissionChanged(val result: RuntimePermissionResult) : UiEvent {
   override val analyticsName = "Registration:Location Permission:$result"
 }

--- a/app/src/main/java/org/simple/clinic/util/Clocks.kt
+++ b/app/src/main/java/org/simple/clinic/util/Clocks.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.util
 import org.threeten.bp.Clock
 import org.threeten.bp.Instant
 import org.threeten.bp.ZoneId
+import org.threeten.bp.ZoneOffset.UTC
 
 open class UtcClock : Clock() {
 
@@ -15,7 +16,7 @@ open class UtcClock : Clock() {
   override fun instant(): Instant = utcClock.instant()
 }
 
-abstract class UserClock: Clock()
+abstract class UserClock : Clock()
 
 open class RealUserClock(userTimeZone: ZoneId) : UserClock() {
 
@@ -26,4 +27,13 @@ open class RealUserClock(userTimeZone: ZoneId) : UserClock() {
   override fun getZone(): ZoneId = userClock.zone
 
   override fun instant(): Instant = userClock.instant()
+}
+
+open class ElapsedRealtimeClock(private val zone: ZoneId = UTC) : Clock() {
+
+  override fun withZone(zone: ZoneId): Clock = ElapsedRealtimeClock(zone)
+
+  override fun getZone(): ZoneId = zone
+
+  override fun instant(): Instant = Instant.ofEpochMilli(android.os.SystemClock.elapsedRealtime())
 }

--- a/app/src/main/java/org/simple/clinic/util/RuntimePermissions.kt
+++ b/app/src/main/java/org/simple/clinic/util/RuntimePermissions.kt
@@ -7,19 +7,21 @@ import androidx.core.app.ActivityCompat
 enum class RuntimePermissionResult {
   GRANTED,
   DENIED,
-  NEVER_ASK_AGAIN;
+  NEVER_ASK_AGAIN
 }
 
 object RuntimePermissions {
 
   fun check(activity: Activity, permission: String): RuntimePermissionResult {
-    if (ActivityCompat.checkSelfPermission(activity, permission) != PackageManager.PERMISSION_GRANTED) {
+    return if (ActivityCompat.checkSelfPermission(activity, permission) != PackageManager.PERMISSION_GRANTED) {
       if (!ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)) {
-        return RuntimePermissionResult.NEVER_ASK_AGAIN
+        RuntimePermissionResult.NEVER_ASK_AGAIN
+      } else {
+        RuntimePermissionResult.DENIED
       }
-      return RuntimePermissionResult.DENIED
+    } else {
+      RuntimePermissionResult.GRANTED
     }
-    return RuntimePermissionResult.GRANTED
   }
 
   fun request(activity: Activity, permission: String, requestCode: Int) {

--- a/app/src/main/res/layout/list_facility_selection_option.xml
+++ b/app/src/main/res/layout/list_facility_selection_option.xml
@@ -13,9 +13,10 @@
   <TextView
     android:id="@+id/facility_item_address"
     style="@style/Clinic.FacilitySelection.FacilityAddress"
+    android:layout_marginBottom="@dimen/spacing_16"
     tools:text="A really long address for this facility to test line wrapping" />
 
   <View
-    style="@style/Clinic.FacilitySelection.FacilitySeparator"
-    android:layout_marginTop="@dimen/spacing_16" />
+    android:id="@+id/facility_item_divider"
+    style="@style/Clinic.Separator.VerticalContent" />
 </LinearLayout>

--- a/app/src/main/res/layout/list_facility_selection_progress.xml
+++ b/app/src/main/res/layout/list_facility_selection_progress.xml
@@ -30,13 +30,13 @@
     <TextView
       style="@style/Clinic.FacilitySelection.FacilityAddress"
       android:layout_width="140dp"
+      android:layout_marginBottom="15dp"
       android:layout_marginTop="@dimen/spacing_8"
       android:background="@drawable/background_facility_progress_shimmer"
       android:textSize="@dimen/textsize_12" />
 
     <View
-      style="@style/Clinic.FacilitySelection.FacilitySeparator"
-      android:layout_marginTop="15dp"
+      style="@style/Clinic.Separator.VerticalContent"
       android:background="@drawable/background_facility_progress_shimmer" />
   </LinearLayout>
 </com.facebook.shimmer.ShimmerFrameLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -233,10 +233,6 @@
     <item name="android:textColor">@color/black_opacity_50</item>
   </style>
 
-  <style name="Clinic.FacilitySelection.FacilitySeparator" parent="Clinic.Separator.VerticalContent">
-    <item name="android:layout_marginTop">@dimen/spacing_16</item>
-  </style>
-
   <style name="Clinic.FacilitySelection.FacilityContainer">
     <item name="android:layout_width">match_parent</item>
     <item name="android:layout_height">wrap_content</item>

--- a/app/src/sharedTest/java/org/simple/clinic/util/TestClocks.kt
+++ b/app/src/sharedTest/java/org/simple/clinic/util/TestClocks.kt
@@ -66,3 +66,18 @@ private fun clockFromYear(year: Int): Clock {
 
   return Clock.fixed(fixedInstant, UTC)
 }
+
+class TestElapsedRealtimeClock : ElapsedRealtimeClock() {
+
+  private var clock = fixed(Instant.EPOCH, UTC)
+
+  override fun withZone(zone: ZoneId): Clock = clock.withZone(zone)
+
+  override fun getZone(): ZoneId = clock.zone
+
+  override fun instant(): Instant = clock.instant()
+
+  fun advanceBy(duration: Duration) {
+    clock = Clock.offset(clock, duration)
+  }
+}

--- a/app/src/test/java/org/simple/clinic/location/LocationUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/location/LocationUpdateTest.kt
@@ -1,0 +1,24 @@
+package org.simple.clinic.location
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.simple.clinic.util.TestElapsedRealtimeClock
+import org.threeten.bp.Duration
+
+class LocationUpdateTest {
+
+  @Test
+  fun `age of location update should be calculated correctly`() {
+    val elapsedRealtimeClock = TestElapsedRealtimeClock()
+
+    val update = LocationUpdate.Available(
+        location = Coordinates(0.0, 0.0),
+        timeSinceBootWhenRecorded = Duration.ofMillis(elapsedRealtimeClock.millis()))
+
+    val advancement = Duration.ofHours(2)
+    elapsedRealtimeClock.advanceBy(advancement)
+
+    val age = update.age(elapsedRealtimeClock)
+    assertThat(age).isEqualTo(advancement)
+  }
+}

--- a/app/src/test/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionScreenControllerTest.kt
@@ -211,7 +211,7 @@ class RegistrationFacilitySelectionScreenControllerTest {
     whenever(facilitySync.pullWithResult()).thenReturn(Single.just(FacilityPullResult.Success()))
 
     uiEvents.onNext(ScreenCreated())
-    uiEvents.onNext(RegistrationUserLocationUpdated(Unavailable))
+    uiEvents.onNext(RegistrationFacilityUserLocationUpdated(Unavailable))
     uiEvents.onNext(RegistrationFacilitySearchQueryChanged(query = "F"))
     uiEvents.onNext(RegistrationFacilitySearchQueryChanged(query = "Fa"))
     uiEvents.onNext(RegistrationFacilitySearchQueryChanged(query = "Fac"))
@@ -230,7 +230,7 @@ class RegistrationFacilitySelectionScreenControllerTest {
         .thenReturn(Single.just(FacilityPullResult.UnexpectedError()))
         .thenReturn(Single.just(FacilityPullResult.NetworkError()))
 
-    uiEvents.onNext(RegistrationUserLocationUpdated(Unavailable))
+    uiEvents.onNext(RegistrationFacilityUserLocationUpdated(Unavailable))
     uiEvents.onNext(RegistrationFacilitySearchQueryChanged(query = ""))
     uiEvents.onNext(RegistrationFacilitySelectionRetryClicked())
     uiEvents.onNext(RegistrationFacilitySelectionRetryClicked())
@@ -246,7 +246,7 @@ class RegistrationFacilitySelectionScreenControllerTest {
     whenever(facilitySync.pullWithResult()).thenReturn(Single.just(FacilityPullResult.Success()))
     whenever(locationRepository.streamUserLocation(any())).thenReturn(Observable.just(Unavailable))
 
-    uiEvents.onNext(RegistrationUserLocationUpdated(Unavailable))
+    uiEvents.onNext(RegistrationFacilityUserLocationUpdated(Unavailable))
     uiEvents.onNext(RegistrationFacilitySelectionRetryClicked())
 
     verify(screen).hideError()
@@ -266,7 +266,7 @@ class RegistrationFacilitySelectionScreenControllerTest {
     val searchQuery = ""
 
     uiEvents.onNext(ScreenCreated())
-    uiEvents.onNext(RegistrationUserLocationUpdated(Unavailable))
+    uiEvents.onNext(RegistrationFacilityUserLocationUpdated(Unavailable))
     uiEvents.onNext(RegistrationFacilitySearchQueryChanged(searchQuery))
 
     val facilityListItems = FacilityListItemBuilder.build(facilities, searchQuery)

--- a/app/src/test/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreenControllerTest.kt
@@ -31,7 +31,7 @@ class RegistrationLocationPermissionScreenControllerTest {
 
   @Test
   fun `when location permission is received then facility selection screen should be opened`() {
-    uiEvents.onNext(LocationPermissionChanged(RuntimePermissionResult.GRANTED))
+    uiEvents.onNext(RegistrationLocationPermissionChanged(RuntimePermissionResult.GRANTED))
 
     verify(screen).openFacilitySelectionScreen()
   }


### PR DESCRIPTION
This PR brings brings a portion of changes towards this feature:
https://www.pivotaltracker.com/story/show/158963954

Major changes:
 - Discard stale location updates that are older than 10m
 - Hide suggested facilities once the user starts searching facilities
 - Read user location only when permission is granted