### PR TITLE
 Add an ADR for documenting why we use a custom bottom sheet widget

### DIFF
--- a/doc/arch/001-screen-controllers.md
+++ b/doc/arch/001-screen-controllers.md
@@ -71,7 +71,7 @@ class LoginScreenController : ObservableTransformer<UiEvent, UiChange>() {
 }
 ```
 
-![data flow from the Ui to the controller](https://raw.githubusercontent.com/simpledotorg/simple-android/sn/22feb/adr-screen-controllers/doc/arch/images/diagram_screen_controller.png)
+![data flow from the Ui to the controller](https://raw.githubusercontent.com/simpledotorg/simple-android/master/doc/arch/images/diagram_screen_controller.png)
 
 ([diagram source](https://docs.google.com/drawings/d/1I_VdUM8Pf9O3nOYViqVF6kiyqFaYFD2fHmKRyvwmEl4/edit?usp=sharing))
 

--- a/doc/arch/002-bottom-sheets.md
+++ b/doc/arch/002-bottom-sheets.md
@@ -1,0 +1,22 @@
+# ADR: Using Activity for bottom sheets instead of Fragment
+
+## Status
+Accepted
+
+## Context
+
+For displaying non-persistent bottom sheets, [Material.io](https://material.io/develop/android/components/bottom-sheet-dialog-fragment/) recommends using BottomSheetDialogFragment. Unfortunately it doesn’t play very nicely with the on-screen keyboard when the sheet includes input text fields. When the on-screen keyboard is shown, it aligns itself with the bottom edge of the field. Everything beneath the focused text field gets covered by the keyboard. 
+
+![BottomSheetDialogFragment without a focused text field](https://raw.githubusercontent.com/simpledotorg/simple-android/master/doc/arch/images/bottomsheetdialogfragment.png)
+
+![BottomSheetDialogFragment with a focused text field](https://raw.githubusercontent.com/simpledotorg/simple-android/master/doc/arch/images/bottomsheetdialogfragment_with_keyboard.png)
+
+This is standard behavior of the on-screen keyboard, but Activities have worked around this by panning or resizing the layout whenever the keyboard is shown. For some reason, changing the softInputMode on the dialog doesn’t have any affect on dialogs.
+
+To be able to align the entire sheet above the keyboard, an Activity called BottomSheetActivity is used instead of BottomSheetDialogFragment that mimics a modal sheet with a translucent background.
+
+![BottomSheetActivity with a focused text field](https://raw.githubusercontent.com/simpledotorg/simple-android/master/doc/arch/images/bottomsheetactivity.png)
+
+# Consequences
+
+`BottomSheetActivity` doesn’t support drag-to-dismissing. We could use [BottomSheetBehavior](https://developer.android.com/reference/android/support/design/widget/BottomSheetBehavior) in the future to add support for it.


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2184102/stories/159982880

The image URLs are broken because they're pointing to `master`. They'll start working once this branch gets merged. I considered uploading them on Imgur instead, but I think it's better to contain the images inside the project. This ADR has already been reviewed by @pratul so I guess it's fine to have broken image links for this PR. 

If you still want to see the images, here's the same ADR hosted on dropbox paper: https://paper.dropbox.com/doc/ADR-Using-Activity-for-bottom-sheets-instead-of-Fragment--AZLLknf6gBx5fQOnxopRsvVbAg-tL4ox6oqIkHo3xTtBr5vc