### PR TITLE
Speed up showing of Progress tab by instantiating it on app start

### DIFF
--- a/app/src/main/java/org/simple/clinic/home/HomePagerAdapter.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomePagerAdapter.kt
@@ -17,7 +17,7 @@ class HomePagerAdapter(private val context: Context) : PagerAdapter() {
   override fun instantiateItem(container: ViewGroup, position: Int): Any {
     val inflater = LayoutInflater.from(container.context)
 
-    val screenForTab = inflater.inflate(HomeTabs.values()[position].key, container, false)
+    val screenForTab = inflater.inflate(HomeTab.values()[position].key, container, false)
     container.addView(screenForTab)
 
     return screenForTab
@@ -27,14 +27,14 @@ class HomePagerAdapter(private val context: Context) : PagerAdapter() {
     container.removeView(viewKey as View)
   }
 
-  override fun getPageTitle(position: Int): CharSequence = context.resources.getString(HomeTabs.values()[position].title)
+  override fun getPageTitle(position: Int): CharSequence = context.resources.getString(HomeTab.values()[position].title)
 
-  override fun getCount() = HomeTabs.values().size
+  override fun getCount() = HomeTab.values().size
 
   override fun isViewFromObject(view: View, viewKey: Any) = view === viewKey
 }
 
-enum class HomeTabs(@LayoutRes val key: Int, @StringRes val title: Int) {
+enum class HomeTab(@LayoutRes val key: Int, @StringRes val title: Int) {
 
   PATIENT(PatientsScreenKey().layoutRes(), R.string.tab_patient),
 

--- a/app/src/main/java/org/simple/clinic/home/HomePagerAdapter.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomePagerAdapter.kt
@@ -36,7 +36,7 @@ class HomePagerAdapter(private val context: Context) : PagerAdapter() {
 
 enum class HomeTab(@LayoutRes val key: Int, @StringRes val title: Int) {
 
-  PATIENT(PatientsScreenKey().layoutRes(), R.string.tab_patient),
+  PATIENTS(PatientsScreenKey().layoutRes(), R.string.tab_patient),
 
   OVERDUE(OverdueScreenKey().layoutRes(), R.string.tab_overdue),
 

--- a/app/src/main/java/org/simple/clinic/home/HomePagerAdapter.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomePagerAdapter.kt
@@ -1,12 +1,12 @@
 package org.simple.clinic.home
 
 import android.content.Context
-import androidx.annotation.LayoutRes
-import androidx.annotation.StringRes
-import androidx.viewpager.widget.PagerAdapter
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.annotation.StringRes
+import androidx.viewpager.widget.PagerAdapter
 import org.simple.clinic.R
 import org.simple.clinic.home.overdue.OverdueScreenKey
 import org.simple.clinic.home.patients.PatientsScreenKey
@@ -34,7 +34,7 @@ class HomePagerAdapter(private val context: Context) : PagerAdapter() {
   override fun isViewFromObject(view: View, viewKey: Any) = view === viewKey
 }
 
-private enum class HomeTabs(@LayoutRes val key: Int, @StringRes val title: Int) {
+enum class HomeTabs(@LayoutRes val key: Int, @StringRes val title: Int) {
 
   PATIENT(PatientsScreenKey().layoutRes(), R.string.tab_patient),
 

--- a/app/src/main/java/org/simple/clinic/home/HomeScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomeScreen.kt
@@ -55,7 +55,7 @@ class HomeScreen(context: Context, attrs: AttributeSet) : RelativeLayout(context
 
     // The WebView in "Progress" tab is expensive to load. Pre-instantiating
     // it when the app starts reduces its time-to-display.
-    viewPager.offscreenPageLimit = HomeTabs.REPORTS.ordinal - HomeTabs.PATIENT.ordinal
+    viewPager.offscreenPageLimit = HomeTab.REPORTS.ordinal - HomeTab.PATIENT.ordinal
   }
 
   private fun screenCreates() = Observable.just(ScreenCreated())

--- a/app/src/main/java/org/simple/clinic/home/HomeScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomeScreen.kt
@@ -2,11 +2,11 @@ package org.simple.clinic.home
 
 import android.annotation.SuppressLint
 import android.content.Context
-import androidx.viewpager.widget.ViewPager
 import android.util.AttributeSet
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.RelativeLayout
+import androidx.viewpager.widget.ViewPager
 import com.jakewharton.rxbinding2.view.RxView
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
@@ -52,6 +52,10 @@ class HomeScreen(context: Context, attrs: AttributeSet) : RelativeLayout(context
     rootLayout.hideKeyboard()
 
     viewPager.adapter = HomePagerAdapter(context)
+
+    // The WebView in "Progress" tab is expensive to load. Pre-instantiating
+    // it when the app starts reduces its time-to-display.
+    viewPager.offscreenPageLimit = HomeTabs.REPORTS.ordinal - HomeTabs.PATIENT.ordinal
   }
 
   private fun screenCreates() = Observable.just(ScreenCreated())

--- a/app/src/main/java/org/simple/clinic/home/HomeScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomeScreen.kt
@@ -55,7 +55,7 @@ class HomeScreen(context: Context, attrs: AttributeSet) : RelativeLayout(context
 
     // The WebView in "Progress" tab is expensive to load. Pre-instantiating
     // it when the app starts reduces its time-to-display.
-    viewPager.offscreenPageLimit = HomeTab.REPORTS.ordinal - HomeTab.PATIENT.ordinal
+    viewPager.offscreenPageLimit = HomeTab.REPORTS.ordinal - HomeTab.PATIENTS.ordinal
   }
 
   private fun screenCreates() = Observable.just(ScreenCreated())


### PR DESCRIPTION
The WebView in "Progress" tab is expensive to load and freezes the app for a good 1-2s when the tab is clicked. Instantiating it when the ViewPager is starting solves it at the expense of theoretically slightly delaying the app startup. The delay seems to be unnoticeable in my limited testing so this looks harmless to me.

**Note for reviewer**: please profile the app startup and let me know if you notice a difference before and after applying this commit. We could try delaying the inflation of WebView to potentially improve this further.