### PR TITLE
Adds a check for evaluating whether to load Heap in classpath based on a gradle param

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,11 +6,10 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'io.sentry.android.gradle'
-
+if (hasProperty('heapEnabled'))
+  apply plugin: 'com.heapanalytics.android'
 
 apply from: "../quality/install-git-hook.gradle"
-if (hasProperty('heapEnabled'))
-    apply plugin: 'com.heapanalytics.android'
 
 repositories {
   maven { url 'https://jitpack.io' }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,9 +6,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'io.sentry.android.gradle'
-apply plugin: 'com.heapanalytics.android'
+
 
 apply from: "../quality/install-git-hook.gradle"
+if (hasProperty('heapEnabled'))
+    apply plugin: 'com.heapanalytics.android'
 
 repositories {
   maven { url 'https://jitpack.io' }

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ buildscript {
     classpath 'com.android.tools.build:gradle:3.3.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
     classpath "io.sentry:sentry-android-gradle-plugin:$versions.sentry"
-      if (project.hasProperty('extraDependencies')) {
+      if (project.hasProperty('heapEnabled')) {
           classpath "com.heapanalytics.android:heap-android-gradle:0.8.3"
       }
     classpath "com.google.gms:google-services:$versions.googleServices"

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ buildscript {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
     classpath "io.sentry:sentry-android-gradle-plugin:$versions.sentry"
       if (project.hasProperty('heapEnabled')) {
-          classpath "com.heapanalytics.android:heap-android-gradle:0.8.3"
+          classpath "com.heapanalytics.android:heap-android-gradle:$versions.heap"
       }
     classpath "com.google.gms:google-services:$versions.googleServices"
   }

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,9 @@ buildscript {
     classpath 'com.android.tools.build:gradle:3.3.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
     classpath "io.sentry:sentry-android-gradle-plugin:$versions.sentry"
-    classpath "com.heapanalytics.android:heap-android-gradle:$versions.heap"
+      if (project.hasProperty('extraDependencies')) {
+          classpath "com.heapanalytics.android:heap-android-gradle:0.8.3"
+      }
     classpath "com.google.gms:google-services:$versions.googleServices"
   }
 }


### PR DESCRIPTION
(Attempting to fix #347) 

### Run  

To run with heap disabled : 
```./gradlew :app:assembleDebug``` or any build variant configuration

To run with heap enabled : 
```./gradlew -PheapEnabled=true :app:assembleDebug```

### Nice to have : 
Create an install script -  `../gradle/build_init.gradle` file and apply plugin checks for the same in the `app` module and add install tasks may be 

