### PR TITLE
Remotely configure phone number masking

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -230,6 +230,7 @@ dependencies {
   implementation "androidx.room:room-rxjava2:$versions.room"
   implementation "android.arch.work:work-runtime-ktx:$versions.workRuntimeKtx"
   implementation "com.google.android.gms:play-services-location:$versions.playServicesLocation"
+  implementation "com.google.firebase:firebase-config:$versions.firebaseConfig"
 
   implementation "com.jakewharton.timber:timber:$versions.timber"
   implementation "com.google.dagger:dagger:$versions.dagger"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -279,3 +279,7 @@ dependencies {
 
   implementation "com.budiyev.android:code-scanner:$versions.codeScanner"
 }
+
+// This must always be present at the bottom of this file, as per:
+// https://console.firebase.google.com/u/2/project/simple-org/settings/general/
+apply plugin: 'com.google.gms.google-services'

--- a/app/src/debug/google-services.json
+++ b/app/src/debug/google-services.json
@@ -1,0 +1,42 @@
+{
+  "project_info": {
+    "project_number": "235314010044",
+    "firebase_url": "https://simple-org.firebaseio.com",
+    "project_id": "simple-org",
+    "storage_bucket": "simple-org.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:235314010044:android:26e63edde5002dd6",
+        "android_client_info": {
+          "package_name": "org.simple.clinic.qa.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "235314010044-5cs4deattnhsdcs4ooljphm0fla9vjvh.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDtpDbqQ-TXRED-gdOhbRbgQIOicyGAiaM"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
+++ b/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
@@ -3,6 +3,7 @@ package org.simple.clinic
 import android.annotation.SuppressLint
 import android.app.Activity
 import com.facebook.stetho.Stetho
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.squareup.leakcanary.LeakCanary
 import io.github.inflationx.viewpump.ViewPump
 import io.reactivex.Observable
@@ -114,10 +115,6 @@ class DebugClinicApp : ClinicApp() {
             return super.providePatientConfig()
                 .map { it.copy(scanSimpleCardFeatureEnabled = true) }
           }
-
-          override fun phoneNumberMaskerConfig(): Single<PhoneNumberMaskerConfig> =
-              super.phoneNumberMaskerConfig()
-                  .map { it.copy(maskingEnabled = true) }
         })
         .build()
   }

--- a/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
+++ b/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import com.facebook.stetho.Stetho
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 import com.squareup.leakcanary.LeakCanary
 import io.github.inflationx.viewpump.ViewPump
 import io.reactivex.Observable
@@ -119,6 +120,16 @@ class DebugClinicApp : ClinicApp() {
           }
         })
         .networkModule(object : NetworkModule() {
+          override fun remoteConfig(): FirebaseRemoteConfig {
+            return super.remoteConfig().apply {
+              // Enable developer mode so that calls are not throttled during dev.
+              // More details in FirebaseRemoteConfigCacheExpiration.
+              setConfigSettings(FirebaseRemoteConfigSettings.Builder()
+                  .setDeveloperModeEnabled(true)
+                  .build())
+            }
+          }
+
           override fun remoteConfigCacheExpiration() = FirebaseRemoteConfigCacheExpiration.DEBUG
         })
         .build()

--- a/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
+++ b/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
@@ -15,12 +15,14 @@ import org.simple.clinic.di.AppComponent
 import org.simple.clinic.di.AppModule
 import org.simple.clinic.di.DaggerDebugAppComponent
 import org.simple.clinic.di.DebugAppComponent
+import org.simple.clinic.di.NetworkModule
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.login.LoginModule
 import org.simple.clinic.login.applock.AppLockConfig
 import org.simple.clinic.patient.PatientConfig
 import org.simple.clinic.patient.PatientModule
 import org.simple.clinic.phone.PhoneNumberMaskerConfig
+import org.simple.clinic.remoteconfig.FirebaseRemoteConfigCacheExpiration
 import org.simple.clinic.security.pin.BruteForceProtectionConfig
 import org.simple.clinic.security.pin.BruteForceProtectionModule
 import org.simple.clinic.sync.SyncScheduler
@@ -115,6 +117,9 @@ class DebugClinicApp : ClinicApp() {
             return super.providePatientConfig()
                 .map { it.copy(scanSimpleCardFeatureEnabled = true) }
           }
+        })
+        .networkModule(object : NetworkModule() {
+          override fun remoteConfigCacheExpiration() = FirebaseRemoteConfigCacheExpiration.DEBUG
         })
         .build()
   }

--- a/app/src/main/java/org/simple/clinic/di/NetworkModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/NetworkModule.kt
@@ -1,5 +1,7 @@
 package org.simple.clinic.di
 
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import dagger.Module
@@ -9,9 +11,10 @@ import okhttp3.logging.HttpLoggingInterceptor
 import org.simple.clinic.BuildConfig
 import org.simple.clinic.analytics.NetworkAnalyticsInterceptor
 import org.simple.clinic.overdue.AppointmentCancelReason
-import org.simple.clinic.patient.businessid.BusinessId
 import org.simple.clinic.patient.PatientSummaryResult
+import org.simple.clinic.patient.businessid.BusinessId
 import org.simple.clinic.patient.sync.PatientPayload
+import org.simple.clinic.phone.PhoneNumberMaskerConfig
 import org.simple.clinic.user.LoggedInUserHttpInterceptor
 import org.simple.clinic.util.InstantMoshiAdapter
 import org.simple.clinic.util.LocalDateMoshiAdapter
@@ -99,5 +102,16 @@ open class NetworkModule {
     return commonRetrofitBuilder
         .baseUrl(baseUrl)
         .build()
+  }
+
+  @Provides
+  @AppScope
+  fun remoteConfig(): FirebaseRemoteConfig {
+    return FirebaseRemoteConfig.getInstance().apply {
+      setDefaults(PhoneNumberMaskerConfig.defaultValues())
+      setConfigSettings(FirebaseRemoteConfigSettings.Builder()
+          .setDeveloperModeEnabled(BuildConfig.DEBUG)
+          .build())
+    }
   }
 }

--- a/app/src/main/java/org/simple/clinic/di/NetworkModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/NetworkModule.kt
@@ -15,6 +15,7 @@ import org.simple.clinic.patient.PatientSummaryResult
 import org.simple.clinic.patient.businessid.BusinessId
 import org.simple.clinic.patient.sync.PatientPayload
 import org.simple.clinic.phone.PhoneNumberMaskerConfig
+import org.simple.clinic.remoteconfig.FirebaseRemoteConfigCacheExpiration
 import org.simple.clinic.user.LoggedInUserHttpInterceptor
 import org.simple.clinic.util.InstantMoshiAdapter
 import org.simple.clinic.util.LocalDateMoshiAdapter
@@ -109,9 +110,17 @@ open class NetworkModule {
   fun remoteConfig(): FirebaseRemoteConfig {
     return FirebaseRemoteConfig.getInstance().apply {
       setDefaults(PhoneNumberMaskerConfig.defaultValues())
+
+      // Enable developer mode so that calls are not throttled during dev.
+      // More details in FirebaseRemoteConfigCacheExpiration.
       setConfigSettings(FirebaseRemoteConfigSettings.Builder()
           .setDeveloperModeEnabled(BuildConfig.DEBUG)
           .build())
     }
+  }
+
+  @Provides
+  open fun remoteConfigCacheExpiration(): FirebaseRemoteConfigCacheExpiration {
+    return FirebaseRemoteConfigCacheExpiration.PRODUCTION
   }
 }

--- a/app/src/main/java/org/simple/clinic/di/NetworkModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/NetworkModule.kt
@@ -1,7 +1,6 @@
 package org.simple.clinic.di
 
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
-import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import dagger.Module
@@ -107,15 +106,9 @@ open class NetworkModule {
 
   @Provides
   @AppScope
-  fun remoteConfig(): FirebaseRemoteConfig {
+  open fun remoteConfig(): FirebaseRemoteConfig {
     return FirebaseRemoteConfig.getInstance().apply {
       setDefaults(PhoneNumberMaskerConfig.defaultValues())
-
-      // Enable developer mode so that calls are not throttled during dev.
-      // More details in FirebaseRemoteConfigCacheExpiration.
-      setConfigSettings(FirebaseRemoteConfigSettings.Builder()
-          .setDeveloperModeEnabled(BuildConfig.DEBUG)
-          .build())
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/patient/PatientModule.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientModule.kt
@@ -1,12 +1,12 @@
 package org.simple.clinic.patient
 
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
 import io.reactivex.Observable
 import io.reactivex.Single
-import org.simple.clinic.BuildConfig
 import org.simple.clinic.patient.businessid.BusinessId
 import org.simple.clinic.patient.businessid.BusinessIdMeta
 import org.simple.clinic.patient.businessid.BusinessIdMetaAdapter
@@ -47,11 +47,9 @@ open class PatientModule {
   ))
 
   @Provides
-  open fun phoneNumberMaskerConfig(): Single<PhoneNumberMaskerConfig> =
-      Single.just(PhoneNumberMaskerConfig(
-          maskingEnabled = false,
-          proxyPhoneNumber = BuildConfig.MASKED_PHONE_NUMBER
-      ))
+  fun phoneNumberMaskerConfig(remoteConfig: FirebaseRemoteConfig): Single<PhoneNumberMaskerConfig> {
+    return PhoneNumberMaskerConfig.read(remoteConfig).firstOrError()
+  }
 
   @Provides
   fun provideBusinessIdMetaAdapter(moshi: Moshi): BusinessIdMetaAdapter {

--- a/app/src/main/java/org/simple/clinic/patient/PatientModule.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientModule.kt
@@ -50,7 +50,7 @@ open class PatientModule {
   open fun phoneNumberMaskerConfig(): Single<PhoneNumberMaskerConfig> =
       Single.just(PhoneNumberMaskerConfig(
           maskingEnabled = false,
-          phoneNumber = BuildConfig.MASKED_PHONE_NUMBER
+          proxyPhoneNumber = BuildConfig.MASKED_PHONE_NUMBER
       ))
 
   @Provides

--- a/app/src/main/java/org/simple/clinic/phone/OfflineMaskedPhoneCaller.kt
+++ b/app/src/main/java/org/simple/clinic/phone/OfflineMaskedPhoneCaller.kt
@@ -18,11 +18,11 @@ class OfflineMaskedPhoneCaller @Inject constructor(
 
   private fun maskNumber(config: PhoneNumberMaskerConfig, numberToMask: String): String {
     return if (config.maskingEnabled) {
-      val number = config.phoneNumber
+      val proxyNumber = config.proxyPhoneNumber
 
       val stopCharacter = "#"
       val dtmfTones = "$numberToMask$stopCharacter"
-      "$number,$dtmfTones"
+      "$proxyNumber,$dtmfTones"
 
     } else {
       numberToMask

--- a/app/src/main/java/org/simple/clinic/phone/PhoneNumberMaskerConfig.kt
+++ b/app/src/main/java/org/simple/clinic/phone/PhoneNumberMaskerConfig.kt
@@ -1,6 +1,31 @@
 package org.simple.clinic.phone
 
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import io.reactivex.Observable
+import org.simple.clinic.BuildConfig
+
 data class PhoneNumberMaskerConfig(
     val maskingEnabled: Boolean,
     val proxyPhoneNumber: String
-)
+) {
+
+  companion object {
+    private const val KEY_MASKING_ENABLED = "phonenumbermasker_masking_enabled"
+    private const val KEY_PROXY_PHONE_NUM = "phonenumbermasker_proxy_phone_number"
+
+    fun read(source: FirebaseRemoteConfig): Observable<PhoneNumberMaskerConfig> {
+      return Observable.fromCallable {
+        PhoneNumberMaskerConfig(
+            maskingEnabled = source.getBoolean(KEY_MASKING_ENABLED),
+            proxyPhoneNumber = source.getString(KEY_PROXY_PHONE_NUM))
+      }
+    }
+
+    fun defaultValues(): Map<String, Any> {
+      return mapOf(
+          KEY_MASKING_ENABLED to false,
+          KEY_PROXY_PHONE_NUM to BuildConfig.MASKED_PHONE_NUMBER
+      )
+    }
+  }
+}

--- a/app/src/main/java/org/simple/clinic/phone/PhoneNumberMaskerConfig.kt
+++ b/app/src/main/java/org/simple/clinic/phone/PhoneNumberMaskerConfig.kt
@@ -2,5 +2,5 @@ package org.simple.clinic.phone
 
 data class PhoneNumberMaskerConfig(
     val maskingEnabled: Boolean,
-    val phoneNumber: String
+    val proxyPhoneNumber: String
 )

--- a/app/src/main/java/org/simple/clinic/remoteconfig/FirebaseRemoteConfigCacheExpiration.kt
+++ b/app/src/main/java/org/simple/clinic/remoteconfig/FirebaseRemoteConfigCacheExpiration.kt
@@ -1,0 +1,30 @@
+package org.simple.clinic.remoteconfig
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
+import org.threeten.bp.Duration
+
+/**
+ * Duration to cache local values before they're synced with Firebase again.
+ * This is required because Firebase throttles network calls by returning cached
+ * values once the limit is reached. More information here:
+ *
+ * https://firebase.google.com/docs/remote-config/android
+ *
+ * TODO: convert to inline class once they're stable.
+ */
+data class FirebaseRemoteConfigCacheExpiration(val value: Duration) {
+
+  companion object {
+    /**
+     * Calls on production builds are limited to a maximum of 5 per 60 minutes.
+     */
+    val PRODUCTION = FirebaseRemoteConfigCacheExpiration(Duration.ofMinutes(12))
+
+    /**
+     * Firebase says calls are unthrottled when developer mode is enabled with up
+     * to 10 developers. Developer mode is enabled using
+     * [FirebaseRemoteConfigSettings.Builder.setDeveloperModeEnabled].
+     */
+    val DEBUG = FirebaseRemoteConfigCacheExpiration(Duration.ofMinutes(0))
+  }
+}

--- a/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
+++ b/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
@@ -1,0 +1,46 @@
+package org.simple.clinic.remoteconfig
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import io.reactivex.Completable
+import io.reactivex.Single
+import org.simple.clinic.BuildConfig
+import org.simple.clinic.sync.BatchSize
+import org.simple.clinic.sync.ModelSync
+import org.simple.clinic.sync.SyncConfig
+import org.simple.clinic.sync.SyncGroup
+import org.simple.clinic.sync.SyncInterval
+import timber.log.Timber
+import javax.inject.Inject
+
+class RemoteConfigSync @Inject constructor(private val remoteConfig: FirebaseRemoteConfig) : ModelSync {
+
+  override fun sync(): Completable = pull()
+
+  override fun push(): Completable = Completable.complete()
+
+  override fun pull(): Completable {
+    // Firebase throttles network calls to 5 per hour.
+    // Source: https://firebase.google.com/docs/remote-config/android
+    val cacheExpiration = if (BuildConfig.DEBUG) 0 else SyncInterval.FREQUENT.frequency.seconds
+
+    return Completable.fromAction {
+      remoteConfig.fetch(cacheExpiration)
+          .addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+              Timber.i("Firebase remote config updated successfully")
+              remoteConfig.activateFetched()
+
+            } else {
+              Timber.w("Failed to update Firebase remote config")
+            }
+          }
+    }
+  }
+
+  override fun syncConfig(): Single<SyncConfig> {
+    return Single.just(SyncConfig(
+        syncInterval = SyncInterval.FREQUENT,
+        batchSize = BatchSize.SMALL,
+        syncGroup = SyncGroup.FREQUENT))
+  }
+}

--- a/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
+++ b/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
@@ -3,7 +3,6 @@ package org.simple.clinic.remoteconfig
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import io.reactivex.Completable
 import io.reactivex.Single
-import org.simple.clinic.BuildConfig
 import org.simple.clinic.sync.BatchSize
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
@@ -12,24 +11,22 @@ import org.simple.clinic.sync.SyncInterval
 import timber.log.Timber
 import javax.inject.Inject
 
-class RemoteConfigSync @Inject constructor(private val remoteConfig: FirebaseRemoteConfig) : ModelSync {
+class RemoteConfigSync @Inject constructor(
+    private val remoteConfig: FirebaseRemoteConfig,
+    private val cacheExpiration: FirebaseRemoteConfigCacheExpiration
+) : ModelSync {
 
   override fun sync(): Completable = pull()
 
   override fun push(): Completable = Completable.complete()
 
   override fun pull(): Completable {
-    // Firebase throttles network calls to 5 per hour.
-    // Source: https://firebase.google.com/docs/remote-config/android
-    val cacheExpiration = if (BuildConfig.DEBUG) 0 else SyncInterval.FREQUENT.frequency.seconds
-
     return Completable.fromAction {
-      remoteConfig.fetch(cacheExpiration)
+      remoteConfig.fetch(cacheExpiration.value.seconds)
           .addOnCompleteListener { task ->
             if (task.isSuccessful) {
               Timber.i("Firebase remote config updated successfully")
               remoteConfig.activateFetched()
-
             } else {
               Timber.w("Failed to update Firebase remote config")
             }

--- a/app/src/main/java/org/simple/clinic/sync/SyncModule.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncModule.kt
@@ -80,7 +80,7 @@ class SyncModule {
 
   @Provides
   @Named("frequently_syncing_repositories")
-  fun syncRepositories(
+  fun frequentlySyncingRepositories(
       patientSyncRepository: PatientRepository,
       bloodPressureSyncRepository: BloodPressureRepository,
       medicalHistorySyncRepository: MedicalHistoryRepository,

--- a/app/src/main/java/org/simple/clinic/sync/SyncModule.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncModule.kt
@@ -25,6 +25,7 @@ import org.simple.clinic.patient.sync.PatientSync
 import org.simple.clinic.patient.sync.PatientSyncModule
 import org.simple.clinic.protocol.ProtocolModule
 import org.simple.clinic.protocol.sync.ProtocolSync
+import org.simple.clinic.remoteconfig.RemoteConfigSync
 import org.simple.clinic.reports.ReportsModule
 import org.simple.clinic.reports.ReportsSync
 import javax.inject.Named
@@ -69,12 +70,14 @@ class SyncModule {
       appointmentSync: AppointmentSync,
       communicationSync: CommunicationSync,
       prescriptionSync: PrescriptionSync,
-      reportsSync: ReportsSync
+      reportsSync: ReportsSync,
+      remoteConfigSync: RemoteConfigSync
   ): ArrayList<ModelSync> {
     return arrayListOf(
         facilitySync, protocolSync, patientSync,
         bloodPressureSync, medicalHistorySync, appointmentSync,
-        communicationSync, prescriptionSync, reportsSync
+        communicationSync, prescriptionSync, reportsSync,
+        remoteConfigSync
     )
   }
 

--- a/app/src/production/google-services.json
+++ b/app/src/production/google-services.json
@@ -1,0 +1,42 @@
+{
+  "project_info": {
+    "project_number": "205889824117",
+    "firebase_url": "https://simple-production-69031.firebaseio.com",
+    "project_id": "simple-production-69031",
+    "storage_bucket": "simple-production-69031.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:205889824117:android:8f8631aa57d4d20b",
+        "android_client_info": {
+          "package_name": "org.simple.clinic"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "205889824117-n517gus0rgrv194nl0nlr8sjrim4l1r7.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCPCKvA1DrqPjlh7X6Qi3_UDUYCAVbqPhU"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/sandbox/google-services.json
+++ b/app/src/sandbox/google-services.json
@@ -1,0 +1,42 @@
+{
+  "project_info": {
+    "project_number": "1080901647110",
+    "firebase_url": "https://simple-sandbox-51a70.firebaseio.com",
+    "project_id": "simple-sandbox-51a70",
+    "storage_bucket": "simple-sandbox-51a70.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:1080901647110:android:4a52180720d6670e",
+        "android_client_info": {
+          "package_name": "org.simple.clinic.sandbox"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "1080901647110-ld4u86b8a2losdq8hqddv4s0r6vq5ac2.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAxPCs3TSJVOYBMuMF_A6fZI1URj-IquBc"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/staging/google-services.json
+++ b/app/src/staging/google-services.json
@@ -1,0 +1,42 @@
+{
+  "project_info": {
+    "project_number": "1081998734768",
+    "firebase_url": "https://simple-demo-5c1b3.firebaseio.com",
+    "project_id": "simple-demo-5c1b3",
+    "storage_bucket": "simple-demo-5c1b3.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:1081998734768:android:897b0365032b903d",
+        "android_client_info": {
+          "package_name": "org.simple.clinic.staging"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "1081998734768-3n9b43dkt1s8o5gt736qarsglas21rfs.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyBvVz6lZdymDmWG5z3G1A6Ve3wbbiSP8KI"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/test/java/org/simple/clinic/home/overdue/OverdueScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/OverdueScreenControllerTest.kt
@@ -49,7 +49,7 @@ class OverdueScreenControllerTest {
     controller = OverdueScreenController(
         repository,
         maskedPhoneCaller,
-        Single.just(PhoneNumberMaskerConfig(maskingEnabled = true, phoneNumber = "0123456789"))
+        Single.just(PhoneNumberMaskerConfig(maskingEnabled = true, proxyPhoneNumber = "0123456789"))
     )
 
     uiEvents.compose(controller).subscribe { uiChange -> uiChange(screen) }
@@ -177,7 +177,7 @@ class OverdueScreenControllerTest {
     val controller = OverdueScreenController(
         repository,
         maskedPhoneCaller,
-        Single.just(PhoneNumberMaskerConfig(maskingEnabled = false, phoneNumber = "0123456789"))
+        Single.just(PhoneNumberMaskerConfig(maskingEnabled = false, proxyPhoneNumber = "0123456789"))
     )
 
     val uiEvents = PublishSubject.create<UiEvent>()

--- a/app/src/test/java/org/simple/clinic/phone/OfflineMaskedPhoneCallerTest.kt
+++ b/app/src/test/java/org/simple/clinic/phone/OfflineMaskedPhoneCallerTest.kt
@@ -26,7 +26,7 @@ class OfflineMaskedPhoneCallerTest {
 
   @Test
   fun `when masking is disabled then plain phone numbers should be called`() {
-    config = PhoneNumberMaskerConfig(maskingEnabled = false, phoneNumber = "")
+    config = PhoneNumberMaskerConfig(maskingEnabled = false, proxyPhoneNumber = "")
 
     val plainNumber = "123"
 
@@ -37,7 +37,7 @@ class OfflineMaskedPhoneCallerTest {
 
   @Test
   fun `when masking is enabled then masked phone number should be called`() {
-    config = PhoneNumberMaskerConfig(maskingEnabled = true, phoneNumber = "987")
+    config = PhoneNumberMaskerConfig(maskingEnabled = true, proxyPhoneNumber = "987")
     val plainNumber = "123"
 
     maskedPhoneCaller.maskAndCall(plainNumber, caller = caller).blockingAwait()

--- a/app/src/test/java/org/simple/clinic/remoteconfig/RemoteConfigSyncTest.kt
+++ b/app/src/test/java/org/simple/clinic/remoteconfig/RemoteConfigSyncTest.kt
@@ -1,0 +1,43 @@
+package org.simple.clinic.remoteconfig
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigFetchThrottledException
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.simple.clinic.crash.CrashReporter
+import java.net.SocketTimeoutException
+
+@RunWith(JUnitParamsRunner::class)
+class RemoteConfigSyncTest {
+
+  @Test
+  @Parameters(method = "errors expected during remote config sync")
+  fun `all errors should be swallowed`(error: Throwable) {
+    val remoteConfig = mock<FirebaseRemoteConfig>()
+    val crashReporter = mock<CrashReporter>()
+    val cacheExpiration = FirebaseRemoteConfigCacheExpiration.DEBUG
+
+    // fyi: thenThrow() doesn't work because it expects checked exceptions
+    // to be declared in the function's signature.
+    whenever(remoteConfig.fetch(any())).thenAnswer { throw error }
+
+    val configSync = RemoteConfigSync(remoteConfig, cacheExpiration, crashReporter)
+    configSync.sync()
+        .test()
+        .await()
+        .assertNoErrors()
+  }
+
+  @Suppress("unused")
+  fun `errors expected during remote config sync`(): List<Throwable> {
+    return listOf(
+        AssertionError("You shall not pass"),
+        SocketTimeoutException(),
+        mock<FirebaseRemoteConfigFetchThrottledException>())
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,8 @@ buildscript {
       leakCanary          : '1.6.2',
       constraintLayout    : '1.1.3',
       playServicesLocation: '16.0.0',
-      codeScanner         : '2.1.0'
+      codeScanner         : '2.1.0',
+      firebaseConfig      : '16.4.0',
   ]
 
   repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,9 @@ buildscript {
       constraintLayout    : '1.1.3',
       playServicesLocation: '16.0.0',
       codeScanner         : '2.1.0',
+      firebaseCore        : '16.0.1',
       firebaseConfig      : '16.4.0',
+      googleServices      : '4.0.1',
   ]
 
   repositories {
@@ -70,6 +72,7 @@ buildscript {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
     classpath "io.sentry:sentry-android-gradle-plugin:$versions.sentry"
     classpath "com.heapanalytics.android:heap-android-gradle:$versions.heap"
+    classpath "com.google.gms:google-services:$versions.googleServices"
   }
 }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/164954589

This PR introduces Firebase remote config and wires it for our phone number masking feature. Rest of the feature configs are still hardcoded in the app.

Wiring a config object with `FirebaseRemoteConfig` is very verbose right now. It feels like working with JSON where we're forced to hand-write type adapters. I'm going to write a reflection based parser so backing configs with firebase won't require a lot of extra effort.

#### How to test this?
We've four Firebase projects, one each for debug, sandbox, demo and production. The debug project should be available to everyone in the project. 

The [debug project](https://console.firebase.google.com/u/2/project/simple-org/config) already has config values for phone number masking so you can try playing with them. Remote configs are updated as part of our existing sync framework so you can force a sync by clicking on sync indicator. 

Keep in mind that Firebase throttles syncs. They claim to throttle it to 5 syncs per hour in release mode and infinite in debug mode, but the debug mode doesn't seem to work for me. Keep an eye on the logs to ensure that remote configs were updated. 

**Important**: Make sure the project builds correctly for all flavors. Firebase will break the build if the `google-services.json` file was not found in the correct directory.