### PR TITLE
Fix: Wrong data being shown in patient search results.

### DIFF
--- a/app/src/main/java/org/simple/clinic/search/results/PatientSearchResultsController.kt
+++ b/app/src/main/java/org/simple/clinic/search/results/PatientSearchResultsController.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.search.results
 
+import com.xwray.groupie.ViewHolder
 import io.reactivex.Observable
 import io.reactivex.ObservableSource
 import io.reactivex.ObservableTransformer
@@ -76,7 +77,7 @@ class PatientSearchResultsController @Inject constructor(
   private fun generateListItems(
       results: PatientSearchResults,
       currentFacility: Facility
-  ): List<PatientSearchResultsItemType> {
+  ): List<PatientSearchResultsItemType<out ViewHolder>> {
     if (results.visitedCurrentFacility.isEmpty() && results.notVisitedCurrentFacility.isEmpty()) return emptyList()
 
     val itemsInCurrentFacility = if (results.visitedCurrentFacility.isNotEmpty()) {

--- a/app/src/main/java/org/simple/clinic/search/results/PatientSearchResultsScreen.kt
+++ b/app/src/main/java/org/simple/clinic/search/results/PatientSearchResultsScreen.kt
@@ -11,7 +11,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.jakewharton.rxbinding2.view.RxView
 import com.xwray.groupie.GroupAdapter
-import com.xwray.groupie.kotlinandroidextensions.ViewHolder
+import com.xwray.groupie.ViewHolder
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
 import io.reactivex.schedulers.Schedulers.io
@@ -95,7 +95,7 @@ class PatientSearchResultsScreen(context: Context, attrs: AttributeSet) : Relati
           .clicks(newPatientButton)
           .map { CreateNewPatientClicked() }
 
-  fun updateSearchResults(results: List<PatientSearchResultsItemType>) {
+  fun updateSearchResults(results: List<PatientSearchResultsItemType<out ViewHolder>>) {
     results.forEach { it.uiEvents = adapterUiEvents }
     adapter.update(results)
   }


### PR DESCRIPTION
Whenever we scroll, the data in the patient results RecyclerView
seems to update to incorrect values. This was happening because of the
usage of lazy to instantiate the views and those views not updating
everytime the ViewHolder updated. To fix this: we have used custom
ViewHolder for patient search result row.

Story: https://www.pivotaltracker.com/story/show/165308633