### PR TITLE
Disable Kotlin view extensions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -160,6 +160,7 @@ android {
 
   androidExtensions {
     experimental = true
+    features = ["parcelize"]
   }
 
   sourceSets {

--- a/app/src/main/java/org/simple/clinic/patient/recent/RecentPatientItem.kt
+++ b/app/src/main/java/org/simple/clinic/patient/recent/RecentPatientItem.kt
@@ -2,9 +2,12 @@ package org.simple.clinic.patient.recent
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
 import com.xwray.groupie.ViewHolder
 import io.reactivex.subjects.Subject
-import kotlinx.android.synthetic.main.recent_patient_item_view.view.*
+import kotterknife.bindView
 import org.simple.clinic.R
 import org.simple.clinic.patient.Gender
 import org.simple.clinic.summary.GroupieItemWithUiEvents
@@ -13,7 +16,7 @@ import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.visibleOrGone
 import java.util.UUID
 
-sealed class RecentPatientItemType(adapterId: Long) : GroupieItemWithUiEvents<ViewHolder>(adapterId) {
+sealed class RecentPatientItemType<T : ViewHolder>(adapterId: Long) : GroupieItemWithUiEvents<T>(adapterId) {
   override lateinit var uiEvents: Subject<UiEvent>
 }
 
@@ -23,37 +26,56 @@ data class RecentPatientItem(
     val age: Int,
     val lastBp: LastBp?,
     val gender: Gender
-) : RecentPatientItemType(uuid.hashCode().toLong()) {
+) : RecentPatientItemType<RecentPatientItem.RecentPatientViewHolder>(uuid.hashCode().toLong()) {
 
   override fun getLayout(): Int = R.layout.recent_patient_item_view
 
-  @SuppressLint("SetTextI18n")
-  override fun bind(viewHolder: ViewHolder, position: Int) {
-    viewHolder.itemView.apply {
-      recentpatient_item_title.text = "$name, $age"
-
-      val lastBpText = lastBpText(context)
-      recentpatient_item_last_bp.text = lastBpText
-      recentpatient_item_last_bp_label.visibleOrGone(lastBpText.isNotBlank())
-      recentpatient_item_gender.setImageResource(gender.displayIconRes)
-
-      setOnClickListener {
-        uiEvents.onNext(RecentPatientItemClicked(patientUuid = uuid))
-      }
-    }
+  override fun createViewHolder(itemView: View): RecentPatientViewHolder {
+    return RecentPatientViewHolder(itemView)
   }
 
-  private fun lastBpText(context: Context): String =
-      lastBp?.run { "$systolic/$diastolic, ${updatedAtRelativeTimestamp.displayText(context)}" } ?: ""
+  @SuppressLint("SetTextI18n")
+  override fun bind(viewHolder: RecentPatientViewHolder, position: Int) {
+    viewHolder.itemView.setOnClickListener {
+      uiEvents.onNext(RecentPatientItemClicked(patientUuid = uuid))
+    }
+
+    viewHolder.render(name, age, lastBp, gender)
+  }
 
   data class LastBp(
       val systolic: Int,
       val diastolic: Int,
       val updatedAtRelativeTimestamp: RelativeTimestamp
   )
+
+  class RecentPatientViewHolder(rootView: View) : ViewHolder(rootView) {
+    private val nameAgeTextView by bindView<TextView>(R.id.recentpatient_item_nameage)
+    private val lastBpTextView by bindView<TextView>(R.id.recentpatient_item_last_bp)
+    private val lastBpLabel by bindView<View>(R.id.recentpatient_item_last_bp_label)
+    private val genderImageView by bindView<ImageView>(R.id.recentpatient_item_gender)
+
+    fun render(
+        name: String,
+        age: Int,
+        lastBp: LastBp?,
+        gender: Gender
+    ) {
+      nameAgeTextView.text = itemView.resources.getString(R.string.patients_recentpatients_nameage, name, age)
+
+      val lastBpText = lastBpText(itemView.context, lastBp)
+      lastBpTextView.text = lastBpText
+      lastBpLabel.visibleOrGone(lastBpText.isNotBlank())
+      genderImageView.setImageResource(gender.displayIconRes)
+    }
+
+    private fun lastBpText(context: Context, lastBp: LastBp?): String {
+      return lastBp?.run { "$systolic/$diastolic, ${updatedAtRelativeTimestamp.displayText(context)}" } ?: ""
+    }
+  }
 }
 
-object SeeAllItem : RecentPatientItemType(0) {
+object SeeAllItem : RecentPatientItemType<ViewHolder>(0) {
   override fun getLayout() = R.layout.see_all_item_view
 
   override fun bind(viewHolder: ViewHolder, position: Int) {

--- a/app/src/main/res/layout/recent_patient_item_view.xml
+++ b/app/src/main/res/layout/recent_patient_item_view.xml
@@ -24,7 +24,7 @@
       tools:src="@drawable/ic_patient_transgender" />
 
     <TextView
-      android:id="@+id/recentpatient_item_title"
+      android:id="@+id/recentpatient_item_nameage"
       style="@style/Clinic.V2.TextAppearance.Subtitle1Left.Blue1"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
@@ -43,8 +43,8 @@
       android:layout_marginTop="@dimen/spacing_4"
       android:text="@string/patientsearchresults_item_last_bp"
       android:textAllCaps="true"
-      app:layout_constraintStart_toStartOf="@+id/recentpatient_item_title"
-      app:layout_constraintTop_toBottomOf="@+id/recentpatient_item_title" />
+      app:layout_constraintStart_toStartOf="@+id/recentpatient_item_nameage"
+      app:layout_constraintTop_toBottomOf="@+id/recentpatient_item_nameage" />
 
     <TextView
       android:id="@+id/recentpatient_item_last_bp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,6 +124,7 @@
   <string name="patients_recentpatients_title">Recent Patients</string>
   <string name="patients_recentpatients_no_recent_patients">No recent patients</string>
   <string name="patients_recentpatients_see_all">See All</string>
+  <string name="patients_recentpatients_nameage">%1$s, %2$d</string>
 
   <!-- Blood pressure entry -->
   <string name="bloodpressureentry_sheet_title_enter_blood_pressure">Blood pressure</string>


### PR DESCRIPTION
Pivotal Story Link: https://www.pivotaltracker.com/story/show/165490945

This PR also includes removal of view extensions from the `RecentPatientsView`.