### PR TITLE
Update build tooling to latest versions

### DIFF
--- a/app/src/main/java/org/simple/clinic/drugs/selection/dosage/DosageAdapter.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/dosage/DosageAdapter.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.drugs.selection.dosage
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -69,6 +70,7 @@ class DosageDiffer : DiffUtil.ItemCallback<DosageListItem>() {
     }
   }
 
+  @SuppressLint("DiffUtilEquals")
   override fun areContentsTheSame(oldItem: DosageListItem, newItem: DosageListItem): Boolean {
     return oldItem.dosageOption == newItem.dosageOption
   }

--- a/app/src/main/java/org/simple/clinic/facility/change/FacilityListItem.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/FacilityListItem.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.facility.change
 
+import android.annotation.SuppressLint
 import androidx.recyclerview.widget.DiffUtil
 import org.simple.clinic.facility.Facility
 
@@ -37,6 +38,7 @@ sealed class FacilityListItem {
       }
     }
 
+    @SuppressLint("DiffUtilEquals")
     override fun areContentsTheSame(oldItem: FacilityListItem, newItem: FacilityListItem): Boolean {
       return oldItem == newItem
     }

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueListAdapter.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueListAdapter.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.home.overdue
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.View
 import android.view.View.GONE
@@ -192,5 +193,6 @@ class OverdueListDiffer : DiffUtil.ItemCallback<OverdueListItem>() {
         oldItem == newItem
       }
 
+  @SuppressLint("DiffUtilEquals")
   override fun areContentsTheSame(oldItem: OverdueListItem, newItem: OverdueListItem): Boolean = oldItem == newItem
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   ext.versions = [
       minSdk              : 21,
       compileSdk          : 28,
-      kotlin              : '1.3.20',
+      kotlin              : '1.3.31',
       supportLib          : '1.0.0',
       recyclerView        : '1.0.0',
       material            : '1.0.0',
@@ -68,7 +68,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.3.1'
+    classpath 'com.android.tools.build:gradle:3.4.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
     classpath "io.sentry:sentry-android-gradle-plugin:$versions.sentry"
     classpath "com.heapanalytics.android:heap-android-gradle:$versions.heap"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Changes:
- Bump gradle plugin to 3.4.0
- Bump Kotlin version to 1.3.31
- Bump gradle version to 5.4.1

I also ended up having to suppress a new lint check that was added in AGP 3.4.0 in DIffUtils because it doesn't seem to realize that we are using sealed classes.