### PR TITLE
Hide "Not You?" button on app lock screen

### DIFF
--- a/app/src/main/res/layout/screen_app_lock.xml
+++ b/app/src/main/res/layout/screen_app_lock.xml
@@ -57,6 +57,7 @@
         android:paddingTop="2dp"
         android:text="@string/applock_logout"
         android:textAppearance="@style/Clinic.V2.TextAppearance.Button2.White100"
+        android:visibility="gone"
         tools:ignore="UnusedAttribute" />
     </LinearLayout>
   </LinearLayout>


### PR DESCRIPTION
Pivotal Story Link: https://www.pivotaltracker.com/story/show/165815696