### PR TITLE
Switch to RxDogTag for improving RxJava stacktraces

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -256,7 +256,6 @@ dependencies {
   kapt "com.squareup.moshi:moshi-kotlin-codegen:$versions.moshi"
   implementation "com.squareup.moshi:moshi-adapters:$versions.moshi"
   implementation "com.f2prateek.rx.preferences2:rx-preferences:$versions.rxPreference"
-  implementation "com.tspoon.traceur:traceur:$versions.traceur"
   implementation "ru.egslava:MaskedEditText:$versions.maskedEditText"
   implementation "io.sentry:sentry-android:$versions.sentry"
   implementation("org.slf4j:slf4j-nop:$versions.slf4j") {
@@ -280,6 +279,7 @@ dependencies {
   debugImplementation "com.squareup.leakcanary:leakcanary-support-fragment:$versions.leakCanary"
 
   implementation "com.budiyev.android:code-scanner:$versions.codeScanner"
+  implementation "com.uber.rxdogtag:rxdogtag:$versions.rxDogTag"
 }
 
 // This must always be present at the bottom of this file, as per:

--- a/app/src/androidTest/java/org/simple/clinic/TestClinicApp.kt
+++ b/app/src/androidTest/java/org/simple/clinic/TestClinicApp.kt
@@ -1,7 +1,7 @@
 package org.simple.clinic
 
 import android.app.Application
-import com.tspoon.traceur.Traceur
+import com.uber.rxdogtag.RxDogTag
 import io.reactivex.Completable
 import io.reactivex.Single
 import okhttp3.OkHttpClient
@@ -62,7 +62,7 @@ class TestClinicApp : ClinicApp() {
     super.onCreate()
 
     Timber.plant(Timber.DebugTree())
-    Traceur.enableLogging()
+    RxDogTag.install()
 
     appComponent().inject(this)
     syncScheduler.cancelAll()

--- a/app/src/main/java/org/simple/clinic/ClinicApp.kt
+++ b/app/src/main/java/org/simple/clinic/ClinicApp.kt
@@ -6,7 +6,7 @@ import androidx.arch.core.executor.ArchTaskExecutor
 import androidx.work.Configuration
 import androidx.work.WorkManager
 import com.gabrielittner.threetenbp.LazyThreeTen
-import com.tspoon.traceur.Traceur
+import com.uber.rxdogtag.RxDogTag
 import io.reactivex.schedulers.Schedulers
 import org.simple.clinic.analytics.UpdateAnalyticsUserId
 import org.simple.clinic.crash.CrashBreadcrumbsTimberTree
@@ -45,7 +45,7 @@ abstract class ClinicApp : Application() {
       throw AssertionError("API endpoint cannot be null!")
     }
 
-    Traceur.enableLogging()
+    RxDogTag.install()
     // Room uses the architecture components executor for doing IO work,
     // which is limited to two threads. This causes thread starvation in some
     // cases, especially when syncs are ongoing. This changes the thread pool

--- a/app/src/sharedTest/java/org/simple/clinic/util/RxErrorsRule.kt
+++ b/app/src/sharedTest/java/org/simple/clinic/util/RxErrorsRule.kt
@@ -1,6 +1,6 @@
 package org.simple.clinic.util
 
-import com.tspoon.traceur.Traceur
+import com.uber.rxdogtag.RxDogTag
 import io.reactivex.plugins.RxJavaPlugins
 import org.junit.rules.TestRule
 import org.junit.runner.Description
@@ -25,14 +25,14 @@ class RxErrorsRule : TestRule {
   override fun apply(base: Statement, description: Description): Statement {
     return object : Statement() {
       override fun evaluate() {
-        Traceur.enableLogging()
+        RxDogTag.install()
         RxJavaPlugins.setErrorHandler { t -> errors.add(t) }
 
         try {
           base.evaluate()
 
         } finally {
-          Traceur.disableLogging()
+          RxDogTag.reset()
           RxJavaPlugins.setErrorHandler(null)
           assertNoErrors()
         }

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ buildscript {
       threeTenBp          : '1.3.6',
       lazyThreeTenBp      : '0.3.0',
       okLoggingInterceptor: '3.10.0',
-      traceur             : '1.0.1',
       maskedEditText      : '1.0.5',
       itemAnimators       : '1.0.2',
       jbcrypt             : '0.3m',
@@ -58,6 +57,7 @@ buildscript {
       firebaseCore        : '16.0.8',
       firebaseConfig      : '16.4.1',
       googleServices      : '4.0.1',
+      rxDogTag            : '0.2.0'
   ]
 
   repositories {


### PR DESCRIPTION
- Traceur is an abandoned project and is also not compatible with
newer versions of RxJava
- We faced a problem where Traceur was causing a crash when an
exception was thrown in a blocking call (root cause not yet determined)

[RxDogTag](https://github.com/uber/RxDogTag) does not have any of these problems, and the stacktraces look
nicer and easier to parse as well.

<img width="1059" alt="Screen Shot 2019-05-24 at 11 59 35 AM" src="https://user-images.githubusercontent.com/1978065/58309247-582ee680-7e21-11e9-8bb3-2506df48f98b.png">
