### PR TITLE
Fix crash when starting the Release build

### DIFF
--- a/app/src/main/java/org/simple/clinic/ReleaseClinicApp.kt
+++ b/app/src/main/java/org/simple/clinic/ReleaseClinicApp.kt
@@ -18,7 +18,9 @@ class ReleaseClinicApp : ClinicApp() {
   @Inject
   lateinit var syncIndicatorStatusCalculator: SyncIndicatorStatusCalculator
 
-  override val analyticsReporters = listOf(HeapAnalyticsReporter(this))
+  override val analyticsReporters by lazy {
+    listOf(HeapAnalyticsReporter(this))
+  }
 
   override fun onCreate() {
     super.onCreate()


### PR DESCRIPTION
Earlier, we were initializing them as soon as the clas was instantiated
but this caused a crash when we tried to access them in ClinicApp. This
changes the creation to a getter so that they are initialized after
onCreate() is called