### PR TITLE
Fix: Buttons should not be cut off in the phone mask bottom sheet

### DIFF
--- a/app/src/main/res/layout/sheet_phone_mask.xml
+++ b/app/src/main/res/layout/sheet_phone_mask.xml
@@ -35,6 +35,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/spacing_32"
+    android:clipToPadding="false"
     android:orientation="horizontal"
     android:paddingBottom="@dimen/spacing_8"
     android:paddingEnd="@dimen/spacing_16"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/166231978