### PR TITLE
Remove synchronization when initiailizing analytics reporters

### DIFF
--- a/app/src/main/java/org/simple/clinic/ClinicApp.kt
+++ b/app/src/main/java/org/simple/clinic/ClinicApp.kt
@@ -38,7 +38,7 @@ abstract class ClinicApp : Application() {
   @Inject
   lateinit var unauthorizeUser: UnauthorizeUser
 
-  open val analyticsReporters = emptyList<AnalyticsReporter>()
+  protected open val analyticsReporters = emptyList<AnalyticsReporter>()
 
   @SuppressLint("RestrictedApi")
   override fun onCreate() {

--- a/app/src/main/java/org/simple/clinic/ReleaseClinicApp.kt
+++ b/app/src/main/java/org/simple/clinic/ReleaseClinicApp.kt
@@ -7,6 +7,7 @@ import org.simple.clinic.di.AppModule
 import org.simple.clinic.di.DaggerAppComponent
 import org.simple.clinic.sync.SyncScheduler
 import org.simple.clinic.sync.indicator.SyncIndicatorStatusCalculator
+import org.simple.clinic.util.unsafeLazy
 import javax.inject.Inject
 
 @SuppressLint("Registered")
@@ -18,7 +19,7 @@ class ReleaseClinicApp : ClinicApp() {
   @Inject
   lateinit var syncIndicatorStatusCalculator: SyncIndicatorStatusCalculator
 
-  override val analyticsReporters by lazy {
+  override val analyticsReporters by unsafeLazy {
     listOf(HeapAnalyticsReporter(this))
   }
 


### PR DESCRIPTION
Since they are accessed from the Application's onCreate method only,
we can safely skip synchronized initilization.