### PR TITLE
Fix: Overdue Appointments not loading

### DIFF
--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreenController.kt
@@ -18,6 +18,7 @@ import org.threeten.bp.LocalDateTime
 import org.threeten.bp.Period
 import org.threeten.bp.ZoneOffset.UTC
 import org.threeten.bp.temporal.ChronoUnit.DAYS
+import timber.log.Timber
 import javax.inject.Inject
 
 typealias Ui = OverdueScreen
@@ -51,14 +52,11 @@ class OverdueScreenController @Inject constructor(
   }
 
   private fun screenSetup(events: Observable<UiEvent>): Observable<UiChange> {
-    val currentFacilityStream = userSession
-        .requireLoggedInUser()
-        .switchMap { facilityRepository.currentFacility(it) }
-
     val overdueAppointmentsStream = events
         .ofType<OverdueScreenCreated>()
-        .withLatestFrom(currentFacilityStream)
-        .flatMap { (_, currentFacility) -> appointmentRepository.overdueAppointments(currentFacility) }
+        .flatMap { userSession.requireLoggedInUser() }
+        .switchMap { facilityRepository.currentFacility(it) }
+        .flatMap { currentFacility -> appointmentRepository.overdueAppointments(currentFacility) }
         .replay()
         .refCount()
 


### PR DESCRIPTION
Bug Tracker Link: https://www.pivotaltracker.com/story/show/166494209

Post-mortem:
We refactored the AppointmentRepository to accept the current facility
externally instead of looking it up itself in a past commit. As part of
that change, we updated OverdueScreenController to load the facility
and query the method like so -

  val facilityStream = userSession
	.requireLoggedInUser()
	.switchMap { facilityRepository.currentFacility(it) }

  events.ofType<ScreenCreated>()
	.withLatestFrom(facilityStream)
	.flatMap { (_, facility) ->
		appointmentRepository.overdue(facility)
	}

The failure happened because the ScreenCreated event was getting
emitted *BEFORE* the facility was queried, so when the
wlf(facilityStream) is called, there is no facility yet as part of that
stream to combine, so the overdue appointments nver get called.

The test passed because the test emits the ScreenCreated event after
the facility gets emitted in the test.

Fix: This was fixed by changing the stream to start querying the
current facility *AFTER* the ScreenCreated event is emitted.