### PR TITLE
Fix: Taps sometimes don't work in recent patients list

### DIFF
--- a/app/src/main/java/org/simple/clinic/recentpatientsview/RecentPatientsView.kt
+++ b/app/src/main/java/org/simple/clinic/recentpatientsview/RecentPatientsView.kt
@@ -59,6 +59,7 @@ class RecentPatientsView(context: Context, attrs: AttributeSet) : FrameLayout(co
     recyclerView.apply {
       layoutManager = LinearLayoutManager(context)
       adapter = groupAdapter
+      isNestedScrollingEnabled = false
     }
 
     bindUiToController(

--- a/app/src/main/res/layout/recent_patients.xml
+++ b/app/src/main/res/layout/recent_patients.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:orientation="vertical">
+  android:layout_height="wrap_content"
+  tools:context="org.simple.clinic.recentpatientsview.RecentPatientsView"
+  tools:parentTag="org.simple.clinic.recentpatientsview.RecentPatientsView">
 
   <androidx.recyclerview.widget.RecyclerView
     android:id="@+id/recentpatients_recyclerview"
@@ -22,4 +24,4 @@
     android:background="@drawable/results_row_empty_state_background"
     android:padding="@dimen/spacing_16"
     android:text="@string/patients_recentpatients_no_recent_patients" />
-</FrameLayout>
+</merge>


### PR DESCRIPTION
I thought I had added the code to disable nestedscrolling in the recyclerview. I must have been mistaken. This seems to have fixed the issue.

https://www.pivotaltracker.com/story/show/165815684