### PR TITLE
Move generation of list items in search results screen to the view from controller

### DIFF
--- a/app/src/main/java/org/simple/clinic/searchresultsview/PatientSearchResults.kt
+++ b/app/src/main/java/org/simple/clinic/searchresultsview/PatientSearchResults.kt
@@ -5,4 +5,6 @@ import org.simple.clinic.patient.PatientSearchResult
 data class PatientSearchResults(
     val visitedCurrentFacility: List<PatientSearchResult>,
     val notVisitedCurrentFacility: List<PatientSearchResult>
-)
+) {
+  val hasNoResults = visitedCurrentFacility.isEmpty() && notVisitedCurrentFacility.isEmpty()
+}

--- a/app/src/main/java/org/simple/clinic/searchresultsview/PatientSearchView.kt
+++ b/app/src/main/java/org/simple/clinic/searchresultsview/PatientSearchView.kt
@@ -93,7 +93,7 @@ class PatientSearchView(context: Context, attrs: AttributeSet) : RelativeLayout(
     } else {
       setEmptyStateVisible(false)
       SearchResultsItemType
-          .generateListItems(results, currentFacility)
+          .from(results, currentFacility)
           .let { listItems ->
             listItems.forEach { it.uiEvents = downstreamUiEvents }
             adapter.update(listItems)

--- a/app/src/main/java/org/simple/clinic/searchresultsview/PatientSearchView.kt
+++ b/app/src/main/java/org/simple/clinic/searchresultsview/PatientSearchView.kt
@@ -19,6 +19,7 @@ import kotterknife.bindView
 import org.simple.clinic.R
 import org.simple.clinic.activity.TheActivity
 import org.simple.clinic.bindUiToController
+import org.simple.clinic.facility.Facility
 import org.simple.clinic.router.screen.ScreenRouter
 import org.simple.clinic.util.UtcClock
 import org.simple.clinic.widgets.ScreenDestroyed
@@ -82,9 +83,22 @@ class PatientSearchView(context: Context, attrs: AttributeSet) : RelativeLayout(
           .clicks(newPatientButton)
           .map { RegisterNewPatientClicked }
 
-  fun updateSearchResults(results: List<SearchResultsItemType<out ViewHolder>>) {
-    results.forEach { it.uiEvents = downstreamUiEvents }
-    adapter.update(results)
+  fun updateSearchResults(
+      results: PatientSearchResults,
+      currentFacility: Facility
+  ) {
+    if (results.hasNoResults) {
+      setEmptyStateVisible(true)
+      adapter.update(emptyList())
+    } else {
+      setEmptyStateVisible(false)
+      SearchResultsItemType
+          .generateListItems(results, currentFacility)
+          .let { listItems ->
+            listItems.forEach { it.uiEvents = downstreamUiEvents }
+            adapter.update(listItems)
+          }
+    }
   }
 
   fun searchResultClicked(searchResultClickedEvent: SearchResultClicked) {

--- a/app/src/main/java/org/simple/clinic/searchresultsview/PatientSearchViewController.kt
+++ b/app/src/main/java/org/simple/clinic/searchresultsview/PatientSearchViewController.kt
@@ -1,6 +1,5 @@
 package org.simple.clinic.searchresultsview
 
-import com.xwray.groupie.ViewHolder
 import io.reactivex.Observable
 import io.reactivex.ObservableSource
 import io.reactivex.ObservableTransformer
@@ -9,13 +8,8 @@ import io.reactivex.rxkotlin.withLatestFrom
 import org.simple.clinic.ReplayUntilScreenIsDestroyed
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.bp.BloodPressureMeasurement
-import org.simple.clinic.facility.Facility
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.patient.PatientRepository
-import org.simple.clinic.searchresultsview.SearchResultsItemType.InCurrentFacilityHeader
-import org.simple.clinic.searchresultsview.SearchResultsItemType.NoPatientsInCurrentFacility
-import org.simple.clinic.searchresultsview.SearchResultsItemType.NotInCurrentFacilityHeader
-import org.simple.clinic.searchresultsview.SearchResultsItemType.SearchResultRow
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.widgets.UiEvent
 import javax.inject.Inject
@@ -59,37 +53,10 @@ class PatientSearchViewController @Inject constructor(
         .withLatestFrom(currentFacilityStream)
         .map { (results, currentFacility) ->
           { ui: Ui ->
-            ui.updateSearchResults(generateListItems(results, currentFacility))
+            ui.updateSearchResults(SearchResultsItemType.generateListItems(results, currentFacility))
             ui.setEmptyStateVisible(results.visitedCurrentFacility.isEmpty() && results.notVisitedCurrentFacility.isEmpty())
           }
         }
-  }
-
-  private fun generateListItems(
-      results: PatientSearchResults,
-      currentFacility: Facility
-  ): List<SearchResultsItemType<out ViewHolder>> {
-    if (results.visitedCurrentFacility.isEmpty() && results.notVisitedCurrentFacility.isEmpty()) return emptyList()
-
-    val itemsInCurrentFacility = if (results.visitedCurrentFacility.isNotEmpty()) {
-      results.visitedCurrentFacility.map {
-        SearchResultRow(it, currentFacility)
-      }
-    } else {
-      listOf(NoPatientsInCurrentFacility)
-    }
-
-    val itemsInOtherFacility = if (results.notVisitedCurrentFacility.isNotEmpty()) {
-      listOf(NotInCurrentFacilityHeader) +
-          results.notVisitedCurrentFacility.map {
-            SearchResultRow(it, currentFacility)
-          }
-    } else {
-      emptyList()
-    }
-    return listOf(InCurrentFacilityHeader(facilityName = currentFacility.name)) +
-        itemsInCurrentFacility +
-        itemsInOtherFacility
   }
 
   private fun openPatientSummary(events: Observable<UiEvent>): Observable<UiChange> {

--- a/app/src/main/java/org/simple/clinic/searchresultsview/PatientSearchViewController.kt
+++ b/app/src/main/java/org/simple/clinic/searchresultsview/PatientSearchViewController.kt
@@ -53,8 +53,7 @@ class PatientSearchViewController @Inject constructor(
         .withLatestFrom(currentFacilityStream)
         .map { (results, currentFacility) ->
           { ui: Ui ->
-            ui.updateSearchResults(SearchResultsItemType.generateListItems(results, currentFacility))
-            ui.setEmptyStateVisible(results.visitedCurrentFacility.isEmpty() && results.notVisitedCurrentFacility.isEmpty())
+            ui.updateSearchResults(results, currentFacility)
           }
         }
   }

--- a/app/src/main/java/org/simple/clinic/searchresultsview/SearchResultsItemType.kt
+++ b/app/src/main/java/org/simple/clinic/searchresultsview/SearchResultsItemType.kt
@@ -15,6 +15,33 @@ sealed class SearchResultsItemType<T : ViewHolder>(adapterId: Long) : GroupieIte
   companion object {
     private const val HEADER_NOT_IN_CURRENT_FACILITY = 0L
     private const val HEADER_NO_PATIENTS_IN_CURRENT_FACILITY = 1L
+
+    fun generateListItems(
+        results: PatientSearchResults,
+        currentFacility: Facility
+    ): List<SearchResultsItemType<out ViewHolder>> {
+      if (results.visitedCurrentFacility.isEmpty() && results.notVisitedCurrentFacility.isEmpty()) return emptyList()
+
+      val itemsInCurrentFacility = if (results.visitedCurrentFacility.isNotEmpty()) {
+        results.visitedCurrentFacility.map {
+          SearchResultRow(it, currentFacility)
+        }
+      } else {
+        listOf(NoPatientsInCurrentFacility)
+      }
+
+      val itemsInOtherFacility = if (results.notVisitedCurrentFacility.isNotEmpty()) {
+        listOf(NotInCurrentFacilityHeader) +
+            results.notVisitedCurrentFacility.map {
+              SearchResultRow(it, currentFacility)
+            }
+      } else {
+        emptyList()
+      }
+      return listOf(InCurrentFacilityHeader(facilityName = currentFacility.name)) +
+          itemsInCurrentFacility +
+          itemsInOtherFacility
+    }
   }
 
   override lateinit var uiEvents: Subject<UiEvent>

--- a/app/src/test/java/org/simple/clinic/searchresultsview/PatientSearchViewControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/searchresultsview/PatientSearchViewControllerTest.kt
@@ -11,7 +11,6 @@ import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,9 +22,6 @@ import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.patient.PatientSearchCriteria
 import org.simple.clinic.patient.PatientSearchCriteria.Name
 import org.simple.clinic.patient.PatientSearchCriteria.PhoneNumber
-import org.simple.clinic.searchresultsview.SearchResultsItemType.InCurrentFacilityHeader
-import org.simple.clinic.searchresultsview.SearchResultsItemType.NotInCurrentFacilityHeader
-import org.simple.clinic.searchresultsview.SearchResultsItemType.SearchResultRow
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
@@ -67,140 +63,6 @@ class PatientSearchViewControllerTest {
     whenever(patientRepository.search(Name(patientName))).thenReturn(Observable.never())
     whenever(patientRepository.search(PhoneNumber(phoneNumber))).thenReturn(Observable.never())
     uiEvents.compose(controller).subscribe { uiChange -> uiChange(screen) }
-  }
-
-  @Test
-  @Parameters(method = "params for search criteria")
-  @Ignore("will move testing of generation of presentation items to another test")
-  fun `when searching patients by name returns results, the results should be displayed`(searchCriteria: PatientSearchCriteria) {
-    // given
-    val patientUuid1 = UUID.fromString("1d5f18d9-43f7-4e7f-92d3-a4f641709470")
-    val patientUuid2 = UUID.fromString("139bfac5-1adc-43fa-9406-d1000fb67a88")
-    val patientSearchResult1 = PatientMocker.patientSearchResult(patientUuid1)
-    val patientSearchResult2 = PatientMocker.patientSearchResult(patientUuid2)
-    whenever(bloodPressureDao.patientToFacilityIds(listOf(patientUuid1, patientUuid2)))
-        .thenReturn(Flowable.just(listOf(
-            PatientToFacilityId(patientUuid = patientUuid1, facilityUuid = currentFacility.uuid),
-            PatientToFacilityId(patientUuid = patientUuid2, facilityUuid = otherFacility.uuid)
-        )))
-    whenever(patientRepository.search(searchCriteria))
-        .thenReturn(Observable.just(listOf(patientSearchResult1, patientSearchResult2)))
-
-    // when
-    uiEvents.onNext(SearchResultsViewCreated)
-    uiEvents.onNext(SearchPatientWithCriteria(searchCriteria))
-
-    // then
-    verify(screen).updateSearchResults(listOf(
-        InCurrentFacilityHeader(facilityName = currentFacility.name),
-        SearchResultRow(
-            searchResult = patientSearchResult1,
-            currentFacility = currentFacility
-        ),
-        NotInCurrentFacilityHeader,
-        SearchResultRow(
-            searchResult = patientSearchResult2,
-            currentFacility = currentFacility
-        )
-    ))
-    verify(screen).setEmptyStateVisible(false)
-  }
-
-  @Test
-  @Parameters(method = "params for search criteria")
-  @Ignore("will move testing of generation of presentation items to another test")
-  fun `when searching patients by name returns no results, the empty state should be displayed`(searchCriteria: PatientSearchCriteria) {
-    // given
-    whenever(patientRepository.search(searchCriteria))
-        .thenReturn(Observable.just(emptyList()))
-    whenever(bloodPressureDao.patientToFacilityIds(emptyList()))
-        .thenReturn(Flowable.just(emptyList()))
-
-    // when
-    uiEvents.onNext(SearchResultsViewCreated)
-    uiEvents.onNext(SearchPatientWithCriteria(searchCriteria))
-
-    // then
-    verify(screen).updateSearchResults(emptyList())
-    verify(screen).setEmptyStateVisible(true)
-  }
-
-  @Test
-  @Parameters(method = "params for search criteria")
-  @Ignore("will move testing of generation of presentation items to another test")
-  fun `when searching by name and there are patients only in current facility, then "Other Results" header should not be shown`(
-      searchCriteria: PatientSearchCriteria
-  ) {
-    // given
-    val patientUuid1 = UUID.fromString("1d5f18d9-43f7-4e7f-92d3-a4f641709470")
-    val patientUuid2 = UUID.fromString("139bfac5-1adc-43fa-9406-d1000fb67a88")
-    val patientSearchResult1 = PatientMocker.patientSearchResult(patientUuid1)
-    val patientSearchResult2 = PatientMocker.patientSearchResult(patientUuid2)
-    whenever(bloodPressureDao.patientToFacilityIds(listOf(patientUuid1, patientUuid2)))
-        .thenReturn(Flowable.just(listOf(
-            PatientToFacilityId(patientUuid = patientUuid1, facilityUuid = currentFacility.uuid),
-            PatientToFacilityId(patientUuid = patientUuid2, facilityUuid = currentFacility.uuid)
-        )))
-    whenever(patientRepository.search(searchCriteria))
-        .thenReturn(Observable.just(listOf(patientSearchResult1, patientSearchResult2)))
-
-    // when
-    uiEvents.onNext(SearchResultsViewCreated)
-    uiEvents.onNext(SearchPatientWithCriteria(searchCriteria))
-
-    // then
-    verify(screen).updateSearchResults(listOf(
-        InCurrentFacilityHeader(facilityName = currentFacility.name),
-        SearchResultRow(
-            searchResult = patientSearchResult1,
-            currentFacility = currentFacility
-        ),
-        SearchResultRow(
-            searchResult = patientSearchResult2,
-            currentFacility = currentFacility
-        )
-    ))
-    verify(screen).setEmptyStateVisible(false)
-  }
-
-  @Test
-  @Parameters(method = "params for search criteria")
-  @Ignore("will move testing of generation of presentation items to another test")
-  fun `when searching by name and there are patients only in other facilities, then current facility header with "no results" should be shown`(
-      searchCriteria: PatientSearchCriteria
-  ) {
-    // given
-    val patientUuid1 = UUID.fromString("1d5f18d9-43f7-4e7f-92d3-a4f641709470")
-    val patientUuid2 = UUID.fromString("139bfac5-1adc-43fa-9406-d1000fb67a88")
-    val patientSearchResult1 = PatientMocker.patientSearchResult(patientUuid1)
-    val patientSearchResult2 = PatientMocker.patientSearchResult(patientUuid2)
-    whenever(bloodPressureDao.patientToFacilityIds(listOf(patientUuid1, patientUuid2)))
-        .thenReturn(Flowable.just(listOf(
-            PatientToFacilityId(patientUuid = patientUuid1, facilityUuid = otherFacility.uuid),
-            PatientToFacilityId(patientUuid = patientUuid2, facilityUuid = otherFacility.uuid)
-        )))
-    whenever(patientRepository.search(searchCriteria))
-        .thenReturn(Observable.just(listOf(patientSearchResult1, patientSearchResult2)))
-
-    // then
-    uiEvents.onNext(SearchResultsViewCreated)
-    uiEvents.onNext(SearchPatientWithCriteria(searchCriteria))
-
-    // then
-    verify(screen).updateSearchResults(listOf(
-        InCurrentFacilityHeader(facilityName = currentFacility.name),
-        SearchResultsItemType.NoPatientsInCurrentFacility,
-        NotInCurrentFacilityHeader,
-        SearchResultRow(
-            searchResult = patientSearchResult1,
-            currentFacility = currentFacility
-        ),
-        SearchResultRow(
-            searchResult = patientSearchResult2,
-            currentFacility = currentFacility
-        )
-    ))
-    verify(screen).setEmptyStateVisible(false)
   }
 
   @Test

--- a/app/src/test/java/org/simple/clinic/searchresultsview/SearchResultsItemTypeTest.kt
+++ b/app/src/test/java/org/simple/clinic/searchresultsview/SearchResultsItemTypeTest.kt
@@ -1,0 +1,128 @@
+package org.simple.clinic.searchresultsview
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.simple.clinic.patient.PatientMocker
+import java.util.UUID
+
+class SearchResultsItemTypeTest {
+
+  private val currentFacility = PatientMocker.facility(UUID.fromString("69cf85c8-6788-4071-b985-0536ae606b70"))
+
+  @Test
+  fun `list items must be generated from the search results`() {
+    // given
+    val patientUuid1 = UUID.fromString("1d5f18d9-43f7-4e7f-92d3-a4f641709470")
+    val patientUuid2 = UUID.fromString("139bfac5-1adc-43fa-9406-d1000fb67a88")
+    val patientSearchResult1 = PatientMocker.patientSearchResult(patientUuid1)
+    val patientSearchResult2 = PatientMocker.patientSearchResult(patientUuid2)
+    val searchResults = PatientSearchResults(
+        visitedCurrentFacility = listOf(patientSearchResult1),
+        notVisitedCurrentFacility = listOf(patientSearchResult2)
+    )
+
+    // when
+    val listItems = SearchResultsItemType.generateListItems(
+        results = searchResults,
+        currentFacility = currentFacility
+    )
+
+    // then
+    val expected = listOf(
+        SearchResultsItemType.InCurrentFacilityHeader(facilityName = currentFacility.name),
+        SearchResultsItemType.SearchResultRow(
+            searchResult = patientSearchResult1,
+            currentFacility = currentFacility
+        ),
+        SearchResultsItemType.NotInCurrentFacilityHeader,
+        SearchResultsItemType.SearchResultRow(
+            searchResult = patientSearchResult2,
+            currentFacility = currentFacility
+        )
+    )
+    assertThat(listItems).isEqualTo(expected)
+  }
+
+  @Test
+  fun `when there are no search results in other facilities, the other results header must not be generated`() {
+    // given
+    val patientUuid1 = UUID.fromString("1d5f18d9-43f7-4e7f-92d3-a4f641709470")
+    val patientUuid2 = UUID.fromString("139bfac5-1adc-43fa-9406-d1000fb67a88")
+    val patientSearchResult1 = PatientMocker.patientSearchResult(patientUuid1)
+    val patientSearchResult2 = PatientMocker.patientSearchResult(patientUuid2)
+    val searchResults = PatientSearchResults(
+        visitedCurrentFacility = listOf(patientSearchResult1, patientSearchResult2),
+        notVisitedCurrentFacility = emptyList()
+    )
+
+    // when
+    val listItems = SearchResultsItemType.generateListItems(
+        results = searchResults,
+        currentFacility = currentFacility
+    )
+
+    // then
+    val expected = listOf(
+        SearchResultsItemType.InCurrentFacilityHeader(facilityName = currentFacility.name),
+        SearchResultsItemType.SearchResultRow(
+            searchResult = patientSearchResult1,
+            currentFacility = currentFacility
+        ),
+        SearchResultsItemType.SearchResultRow(
+            searchResult = patientSearchResult2,
+            currentFacility = currentFacility
+        )
+    )
+    assertThat(listItems).isEqualTo(expected)
+  }
+
+  @Test
+  fun `when there are no search results in the current facility, then the current facility header with no results must be shown`() {
+    // given
+    val patientUuid1 = UUID.fromString("1d5f18d9-43f7-4e7f-92d3-a4f641709470")
+    val patientUuid2 = UUID.fromString("139bfac5-1adc-43fa-9406-d1000fb67a88")
+    val patientSearchResult1 = PatientMocker.patientSearchResult(patientUuid1)
+    val patientSearchResult2 = PatientMocker.patientSearchResult(patientUuid2)
+    val searchResults = PatientSearchResults(
+        visitedCurrentFacility = emptyList(),
+        notVisitedCurrentFacility = listOf(patientSearchResult1, patientSearchResult2)
+    )
+
+    // when
+    val listItems = SearchResultsItemType.generateListItems(
+        results = searchResults,
+        currentFacility = currentFacility
+    )
+
+    // then
+    val expected = listOf(
+        SearchResultsItemType.InCurrentFacilityHeader(facilityName = currentFacility.name),
+        SearchResultsItemType.NoPatientsInCurrentFacility,
+        SearchResultsItemType.NotInCurrentFacilityHeader,
+        SearchResultsItemType.SearchResultRow(
+            searchResult = patientSearchResult1,
+            currentFacility = currentFacility
+        ),
+        SearchResultsItemType.SearchResultRow(
+            searchResult = patientSearchResult2,
+            currentFacility = currentFacility
+        )
+    )
+    assertThat(listItems).isEqualTo(expected)
+  }
+
+  @Test
+  fun `when there are no search results, then no list items must be generated`() {
+    // given
+    val searchResults = PatientSearchResults(
+        visitedCurrentFacility = emptyList(),
+        notVisitedCurrentFacility = emptyList()
+    )
+
+    // when
+    val listItems = SearchResultsItemType.generateListItems(searchResults, currentFacility)
+
+    // then
+    assertThat(listItems).isEmpty()
+  }
+}

--- a/app/src/test/java/org/simple/clinic/searchresultsview/SearchResultsItemTypeTest.kt
+++ b/app/src/test/java/org/simple/clinic/searchresultsview/SearchResultsItemTypeTest.kt
@@ -22,7 +22,7 @@ class SearchResultsItemTypeTest {
     )
 
     // when
-    val listItems = SearchResultsItemType.generateListItems(
+    val listItems = SearchResultsItemType.from(
         results = searchResults,
         currentFacility = currentFacility
     )
@@ -56,7 +56,7 @@ class SearchResultsItemTypeTest {
     )
 
     // when
-    val listItems = SearchResultsItemType.generateListItems(
+    val listItems = SearchResultsItemType.from(
         results = searchResults,
         currentFacility = currentFacility
     )
@@ -89,7 +89,7 @@ class SearchResultsItemTypeTest {
     )
 
     // when
-    val listItems = SearchResultsItemType.generateListItems(
+    val listItems = SearchResultsItemType.from(
         results = searchResults,
         currentFacility = currentFacility
     )
@@ -120,7 +120,7 @@ class SearchResultsItemTypeTest {
     )
 
     // when
-    val listItems = SearchResultsItemType.generateListItems(searchResults, currentFacility)
+    val listItems = SearchResultsItemType.from(searchResults, currentFacility)
 
     // then
     assertThat(listItems).isEmpty()


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/166784013
https://www.pivotaltracker.com/story/show/166783916

This is needed to ease the transition to the local view model for the `PatientSearchResultView` widget. I didn't want to do this as part of another extremely large PR.