### PR TITLE
Group simple launcher icons

### DIFF
--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-  <string name="app_name">DEBUG Simple</string>
+  <string name="app_name">Simple DEBUG</string>
   <!--suppress UnusedResources -->
-  <string name="leak_canary_display_activity_label">DEBUG Simple Leaks</string>
+  <string name="leak_canary_display_activity_label">Simple DEBUG Leaks</string>
 </resources>

--- a/app/src/sandbox/res/values/strings.xml
+++ b/app/src/sandbox/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-  <string name="app_name">SANDBOX Simple</string>
+  <string name="app_name">Simple SANDBOX</string>
 </resources>


### PR DESCRIPTION
In the launcher the simple app icons are scattered across because the variant names are placed before the app name. This PR ensure all the app variants are grouped together in the launcher by moving the variant names as suffixes.