### PR TITLE
Update to Android Studio 3.5

### DIFF
--- a/app/src/main/java/org/simple/clinic/patient/filter/WeightedLevenshteinSearch.kt
+++ b/app/src/main/java/org/simple/clinic/patient/filter/WeightedLevenshteinSearch.kt
@@ -5,6 +5,7 @@ import info.debatty.java.stringsimilarity.CharacterSubstitutionInterface
 import info.debatty.java.stringsimilarity.WeightedLevenshtein
 import io.reactivex.Single
 import org.simple.clinic.patient.PatientSearchResult
+import java.util.Locale
 import java.util.UUID
 
 class WeightedLevenshteinSearch(
@@ -74,5 +75,5 @@ class WeightedLevenshteinSearch(
       .filter { it.length >= minimumSearchTermLength }
       .map { namePart -> namePart.filter { it.isLetter() } }
       .filter { it.isNotBlank() }
-      .map { it.toLowerCase() }
+      .map { it.toLowerCase(Locale.ROOT) }
 }

--- a/app/src/main/java/org/simple/clinic/sync/SyncModule.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncModule.kt
@@ -29,6 +29,7 @@ import org.simple.clinic.remoteconfig.ConfigReader
 import org.simple.clinic.remoteconfig.RemoteConfigSync
 import org.simple.clinic.reports.ReportsModule
 import org.simple.clinic.reports.ReportsSync
+import java.util.Locale
 import javax.inject.Named
 
 @Module(includes = [
@@ -121,7 +122,7 @@ data class SyncModuleConfig(
       return Observable.fromCallable {
         val frequentConfigString = reader.string("syncmodule_frequentsync_batchsize", default = "large")
 
-        val frequentBatchSize = when (frequentConfigString.toLowerCase()) {
+        val frequentBatchSize = when (frequentConfigString.toLowerCase(Locale.ROOT)) {
           "verysmall" -> BatchSize.VERY_SMALL
           "small" -> BatchSize.SMALL
           "medium" -> BatchSize.MEDIUM
@@ -131,7 +132,7 @@ data class SyncModuleConfig(
 
         val dailyConfigString = reader.string("syncmodule_dailysync_batchsize", default = "large")
 
-        val dailyBatchSize = when (dailyConfigString.toLowerCase()) {
+        val dailyBatchSize = when (dailyConfigString.toLowerCase(Locale.ROOT)) {
           "verysmall" -> BatchSize.VERY_SMALL
           "small" -> BatchSize.SMALL
           "medium" -> BatchSize.MEDIUM

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.0'
+    classpath 'com.android.tools.build:gradle:3.5.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
     classpath "io.sentry:sentry-android-gradle-plugin:$versions.sentry"
     classpath "com.heapanalytics.android:heap-android-gradle:$versions.heap"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
       recyclerView        : '1.0.0',
       material            : '1.0.0',
       cardview            : '1.0.0',
-      room                : '2.0.0',
+      room                : '2.1.0',
       supportTest         : '1.1.1',
       timber              : '4.7.0',
       dagger              : '2.24',

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
       room                : '2.0.0',
       supportTest         : '1.1.1',
       timber              : '4.7.0',
-      dagger              : '2.16',
+      dagger              : '2.24',
       butterKnife         : '8.8.1',
       kotterKnife         : 'e157638df1',
       coreTesting         : '2.0.0',

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   ext.versions = [
       minSdk              : 21,
       compileSdk          : 28,
-      kotlin              : '1.3.31',
+      kotlin              : '1.3.41',
       supportLib          : '1.0.0',
       recyclerView        : '1.0.0',
       material            : '1.0.0',

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,8 @@ org.gradle.jvmargs=-Xmx3072m
 
 # Use Gradle build caching: https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching=true
+# KAPT Incremental annotation processing (https://kotlinlang.org/docs/reference/kapt.html)
+kapt.incremental.apt=true
 
 # We want the ability to turn off Proguard at will.
 runProguard=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip

--- a/spellfix/.gitignore
+++ b/spellfix/.gitignore
@@ -1,2 +1,3 @@
 /build
 .externalNativeBuild
+.cxx


### PR DESCRIPTION
This PR bumps the Gradle plugin to 3.5.0. In addition, it updates libraries which use KAPT (Dagger, Room) to the latest versions and enabled KAPT incremental annotation processing.