### PR TITLE
Add CodeClimate configuration to the repository

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,43 @@
+version: "2"
+checks:
+  argument-count:
+    enabled: false
+    config:
+      threshold: 4
+  complex-logic:
+    config:
+      threshold: 4
+  file-lines:
+    enabled: false
+    config:
+      threshold: 250
+  method-complexity:
+    config:
+      threshold: 20
+  method-count:
+    enabled: false
+    config:
+      threshold: 20
+  method-lines:
+    enabled: false
+    config:
+      threshold: 25
+  nested-control-flow:
+    config:
+      threshold: 4
+  return-statements:
+    config:
+      threshold: 4
+  similar-code:
+    enabled: false
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
+  identical-code:
+    enabled: false
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
+exclude_patterns:
+  - "**/androidTest/"
+  - "**/test/"
+  - "**/src/main/java/org/simple/clinic/storage/Migration_*.kt"
+  - "**/build/"


### PR DESCRIPTION
This adds a CodeClimate quality config file (https://docs.codeclimate.com/docs/advanced-configuration)
to the repository. Currently, it is set to the same defaults that are
configured on the web app, but it serves as a starting point for us to
tweak in the future.