### PR TITLE
Drop screen change breadcrumbs to Sentry

### DIFF
--- a/app/src/main/java/org/simple/clinic/activity/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/activity/TheActivity.kt
@@ -14,6 +14,8 @@ import org.simple.clinic.BuildConfig
 import org.simple.clinic.ClinicApp
 import org.simple.clinic.R
 import org.simple.clinic.analytics.Analytics
+import org.simple.clinic.crash.Breadcrumb
+import org.simple.clinic.crash.CrashReporter
 import org.simple.clinic.home.patients.LoggedOutOnOtherDeviceDialog
 import org.simple.clinic.login.applock.AppLockScreenKey
 import org.simple.clinic.registration.phone.RegistrationPhoneScreenKey
@@ -42,6 +44,9 @@ class TheActivity : AppCompatActivity() {
 
   @Inject
   lateinit var fullScreenKeyChangeAnimator: KeyChangeAnimator<FullScreenKey>
+
+  @Inject
+  lateinit var crashReporter: CrashReporter
 
   lateinit var screenRouter: ScreenRouter
 
@@ -91,6 +96,13 @@ class TheActivity : AppCompatActivity() {
     val outgoingScreenName = outgoing?.analyticsName ?: ""
     val incomingScreenName = incoming.analyticsName
     Analytics.reportScreenChange(outgoingScreenName, incomingScreenName)
+
+    val screenChangedBreadcrumb = Breadcrumb(
+        priority = Breadcrumb.Priority.INFO,
+        tag = "Screen Change",
+        message = "[$outgoingScreenName] -> [$incomingScreenName]"
+    )
+    crashReporter.dropBreadcrumb(screenChangedBreadcrumb)
   }
 
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {


### PR DESCRIPTION
Currently, we often see weird crashes in production which sometimes have
no screen in the stacktrace. See https://sentry.io/organizations/resolve-to-save-lives/issues/1215555012/

This commit adds screen changed breadcrumbs to Sentry so that when
the crash happens, we have visibility into what screen the user is on.