### PR TITLE
Enable testing state machines just driven by effects

### DIFF
--- a/mobius-migration/src/test/java/org/simple/mobius/migration/EventsOnlyTest.kt
+++ b/mobius-migration/src/test/java/org/simple/mobius/migration/EventsOnlyTest.kt
@@ -1,0 +1,36 @@
+package org.simple.mobius.migration
+
+import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
+import org.junit.Test
+import org.simple.mobius.migration.fix.EveModel
+import org.simple.mobius.migration.fix.defaultModel
+import org.simple.mobius.migration.fix.eveEffectHandler
+import org.simple.mobius.migration.fix.eveInit
+import org.simple.mobius.migration.fix.eveUpdate
+
+class EventsOnlyTest {
+  @Test
+  fun `it can run a state machine that's driven without external events`() {
+    // given
+    val modelUpdatesSubject = PublishSubject.create<EveModel>()
+    val testObserver = modelUpdatesSubject.test()
+
+    val fixture = MobiusTestFixture(
+        Observable.empty(),
+        defaultModel,
+        ::eveInit,
+        ::eveUpdate,
+        eveEffectHandler(),
+        modelUpdatesSubject::onNext
+    )
+
+    // then
+    testObserver
+        .assertNoErrors()
+        .assertValues('a', 'b', 'c')
+        .assertNotTerminated()
+
+    fixture.dispose()
+  }
+}

--- a/mobius-migration/src/test/java/org/simple/mobius/migration/MobiusTestFixtureTest.kt
+++ b/mobius-migration/src/test/java/org/simple/mobius/migration/MobiusTestFixtureTest.kt
@@ -4,14 +4,12 @@ import com.google.common.truth.Truth.assertThat
 import io.reactivex.subjects.PublishSubject
 import org.junit.After
 import org.junit.Test
-import org.simple.mobius.migration.fix.CounterEffect.NumberZeroEffect
 import org.simple.mobius.migration.fix.CounterEvent
 import org.simple.mobius.migration.fix.CounterEvent.Decrement
 import org.simple.mobius.migration.fix.CounterEvent.Increment
 import org.simple.mobius.migration.fix.CounterModel
 import org.simple.mobius.migration.fix.VerifiableCounterView
 import org.simple.mobius.migration.fix.createEffectHandler
-import org.simple.mobius.migration.fix.init
 import org.simple.mobius.migration.fix.update
 
 class MobiusTestFixtureTest {
@@ -23,7 +21,7 @@ class MobiusTestFixtureTest {
   private val fixture = MobiusTestFixture(
       events,
       defaultModel,
-      ::init,
+      null,
       ::update,
       effectHandler,
       modelUpdateListener
@@ -81,13 +79,5 @@ class MobiusTestFixtureTest {
     // then
     assertThat(view.model)
         .isEqualTo(defaultModel)
-  }
-
-  @Test
-  fun `it can observe effects from an init function`() {
-    assertThat(fixture.model)
-        .isEqualTo(defaultModel)
-    assertThat(fixture.lastKnownEffect)
-        .isEqualTo(NumberZeroEffect)
   }
 }

--- a/mobius-migration/src/test/java/org/simple/mobius/migration/fix/Counter.kt
+++ b/mobius-migration/src/test/java/org/simple/mobius/migration/fix/Counter.kt
@@ -1,12 +1,10 @@
 package org.simple.mobius.migration.fix
 
-import com.spotify.mobius.First
 import com.spotify.mobius.Next
 import com.spotify.mobius.Next.next
 import com.spotify.mobius.rx2.RxMobius
 import io.reactivex.ObservableTransformer
 import org.simple.mobius.migration.fix.CounterEffect.NegativeNumberEffect
-import org.simple.mobius.migration.fix.CounterEffect.NumberZeroEffect
 import org.simple.mobius.migration.fix.CounterEvent.Decrement
 import org.simple.mobius.migration.fix.CounterEvent.Increment
 import kotlin.properties.Delegates
@@ -16,10 +14,6 @@ typealias CounterModel = Int
 sealed class CounterEvent {
   object Increment : CounterEvent()
   object Decrement : CounterEvent()
-}
-
-fun init(model: CounterModel): First<CounterModel, CounterEffect> {
-  return First.first(model, setOf(NumberZeroEffect))
 }
 
 fun update(
@@ -35,13 +29,11 @@ fun update(
 fun createEffectHandler(view: VerifiableCounterView): ObservableTransformer<CounterEffect, CounterEvent> {
   return RxMobius
       .subtypeEffectHandler<CounterEffect, CounterEvent>()
-      .addAction(NumberZeroEffect::class.java) { /* no-op */ }
       .addAction(NegativeNumberEffect::class.java) { view.notifyNegativeNumber() }
       .build()
 }
 
 sealed class CounterEffect {
-  object NumberZeroEffect : CounterEffect()
   object NegativeNumberEffect : CounterEffect()
 }
 

--- a/mobius-migration/src/test/java/org/simple/mobius/migration/fix/EventsViaEffects.kt
+++ b/mobius-migration/src/test/java/org/simple/mobius/migration/fix/EventsViaEffects.kt
@@ -1,0 +1,47 @@
+package org.simple.mobius.migration.fix
+
+import com.spotify.mobius.First
+import com.spotify.mobius.Next
+import com.spotify.mobius.Next.next
+import com.spotify.mobius.rx2.RxMobius
+import io.reactivex.ObservableTransformer
+import org.simple.mobius.migration.fix.EveEffect.BEffect
+import org.simple.mobius.migration.fix.EveEffect.CEffect
+import org.simple.mobius.migration.fix.EveEvent.BEvent
+import org.simple.mobius.migration.fix.EveEvent.CEvent
+
+typealias EveModel = Char
+
+const val defaultModel: EveModel = 'a'
+
+sealed class EveEvent {
+  object BEvent : EveEvent()
+  object CEvent : EveEvent()
+}
+
+sealed class EveEffect {
+  object BEffect : EveEffect()
+  object CEffect : EveEffect()
+}
+
+fun eveInit(model: EveModel): First<EveModel, EveEffect> {
+  return First.first(model, setOf(BEffect))
+}
+
+fun eveUpdate(
+    @Suppress("UNUSED_PARAMETER") model: EveModel,
+    event: EveEvent
+): Next<EveModel, EveEffect> {
+  return when (event) {
+    BEvent -> next('b', setOf(CEffect))
+    CEvent -> next('c')
+  }
+}
+
+fun eveEffectHandler(): ObservableTransformer<EveEffect, EveEvent> {
+  return RxMobius
+      .subtypeEffectHandler<EveEffect, EveEvent>()
+      .addTransformer(BEffect::class.java) { bEffects -> bEffects.map { BEvent } }
+      .addTransformer(CEffect::class.java) { cEffects -> cEffects.map { CEvent } }
+      .build()
+}


### PR DESCRIPTION
Previously the fixture was able to test only states that were produced in response to external events dispatched through an event source. This implementation also works with state machines that are driven by events generated by the effect handler.