### PR TITLE
Downgrade Heap -> 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ buildscript {
       playServicesAuth    : '16.0.1',
       playServicesVision  : '16.2.0',
       viewPump            : '1.0.0',
-      heap                : '1.1.1',
+      heap                : '1.1.0',
       pinEntryEditText    : '2.0.6',
       fbShimmer           : '0.3.0',
       javaStringSimilarity: '1.1.0',


### PR DESCRIPTION
In Heap 1.1.1, they switched to a new version of the Protobuf library
(https://docs.heap.io/docs/android-changelog#section--1-1-1-2019-08-16).

However, we started seeing crash reports that Heap was crashing on lower
API versions because it was accessing methods that did not exist (tested
on API 21; see https://sentry.io/share/issue/6c4a9e19d17e4d2081798ee208a0a652/).

Downgrading to Heap 1.1.0 fixes this problem.