### PR TITLE
Fix failing tests due to introduction of the start function

### DIFF
--- a/mobius-migration/src/test/java/org/simple/mobius/migration/EventsOnlyTest.kt
+++ b/mobius-migration/src/test/java/org/simple/mobius/migration/EventsOnlyTest.kt
@@ -23,7 +23,9 @@ class EventsOnlyTest {
         ::eveUpdate,
         eveEffectHandler(),
         modelUpdatesSubject::onNext
-    )
+    ).also {
+      it.start()
+    }
 
     // then
     testObserver

--- a/mobius-migration/src/test/java/org/simple/mobius/migration/MobiusTestFixtureTest.kt
+++ b/mobius-migration/src/test/java/org/simple/mobius/migration/MobiusTestFixtureTest.kt
@@ -3,6 +3,7 @@ package org.simple.mobius.migration
 import com.google.common.truth.Truth.assertThat
 import io.reactivex.subjects.PublishSubject
 import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.simple.mobius.migration.fix.CounterEvent
 import org.simple.mobius.migration.fix.CounterEvent.Decrement
@@ -26,6 +27,11 @@ class MobiusTestFixtureTest {
       effectHandler,
       modelUpdateListener
   )
+
+  @Before
+  fun setup() {
+    fixture.start()
+  }
 
   @After
   fun teardown() {


### PR DESCRIPTION
This also means,
1. Our pre-push hook should run `./gradlew test` so that we can run tests present in all modules.
2. Our CI didn't fail, so we should revisit our CI setup as well.