### PR TITLE
Mobius delegate improvements

### DIFF
--- a/app/src/main/java/org/simple/clinic/allpatientsinfacility/AllPatientsInFacilityView.kt
+++ b/app/src/main/java/org/simple/clinic/allpatientsinfacility/AllPatientsInFacilityView.kt
@@ -67,6 +67,7 @@ class AllPatientsInFacilityView(
         .createEffectHandler(userSession, facilityRepository, patientRepository, schedulersProvider)
 
     MobiusDelegate(
+        Observable.never(),
         AllPatientsInFacilityModel.FETCHING_PATIENTS,
         ::allPatientsInFacilityInit,
         ::allPatientsInFacilityUpdate,

--- a/app/src/main/java/org/simple/clinic/allpatientsinfacility/AllPatientsInFacilityView.kt
+++ b/app/src/main/java/org/simple/clinic/allpatientsinfacility/AllPatientsInFacilityView.kt
@@ -56,7 +56,7 @@ class AllPatientsInFacilityView(
   @Inject
   lateinit var crashReporter: CrashReporter
 
-  private val viewRenderer by unsafeLazy { AllPatientsInFacilityUiRenderer(this) }
+  private val viewRenderer = AllPatientsInFacilityUiRenderer(this)
 
   override val uiEvents: Observable<UiEvent>
     get() = Observable.merge(searchResultClicks(), listScrollEvents())

--- a/app/src/main/java/org/simple/clinic/allpatientsinfacility/AllPatientsInFacilityView.kt
+++ b/app/src/main/java/org/simple/clinic/allpatientsinfacility/AllPatientsInFacilityView.kt
@@ -119,9 +119,8 @@ class AllPatientsInFacilityView(
   }
 
   override fun onRestoreInstanceState(state: Parcelable?) {
-    super.onRestoreInstanceState(delegate.onRestoreInstanceState(state as Bundle?)).also {
-      delegate.prepare()
-    }
+    val viewState = delegate.onRestoreInstanceState(state as Bundle?)
+    super.onRestoreInstanceState(viewState)
   }
 
   private fun searchResultClicks(): Observable<UiEvent> {

--- a/app/src/main/java/org/simple/clinic/allpatientsinfacility/AllPatientsInFacilityView.kt
+++ b/app/src/main/java/org/simple/clinic/allpatientsinfacility/AllPatientsInFacilityView.kt
@@ -1,7 +1,6 @@
 package org.simple.clinic.allpatientsinfacility
 
 import android.content.Context
-import android.os.Bundle
 import android.os.Parcelable
 import android.util.AttributeSet
 import android.view.View
@@ -119,7 +118,7 @@ class AllPatientsInFacilityView(
   }
 
   override fun onRestoreInstanceState(state: Parcelable?) {
-    val viewState = delegate.onRestoreInstanceState(state as Bundle?)
+    val viewState = delegate.onRestoreInstanceState(state)
     super.onRestoreInstanceState(viewState)
   }
 

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
@@ -159,9 +159,8 @@ class EditPatientScreen(context: Context, attributeSet: AttributeSet) : Relative
 
 
   override fun onRestoreInstanceState(state: Parcelable?) {
-    super.onRestoreInstanceState(delegate.onRestoreInstanceState(state as Bundle?)).also {
-      delegate.prepare()
-    }
+    val viewState = delegate.onRestoreInstanceState(state as Bundle?)
+    super.onRestoreInstanceState(viewState)
   }
 
   private fun saveClicks(): Observable<EditPatientEvent> {

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
@@ -15,7 +15,6 @@ import com.jakewharton.rxbinding2.view.RxView
 import com.jakewharton.rxbinding2.widget.RxRadioGroup
 import com.jakewharton.rxbinding2.widget.RxTextView
 import io.reactivex.Observable
-import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.cast
 import kotlinx.android.synthetic.main.screen_edit_patient.view.*
 import org.simple.clinic.R
@@ -119,11 +118,10 @@ class EditPatientScreen(context: Context, attributeSet: AttributeSet) : Relative
     ).compose(ReportAnalyticsEvents())
         .cast()
 
-  private lateinit var eventsDisposable: Disposable
-
   private val delegate by unsafeLazy {
     val (patient, address, phoneNumber) = screenKey
     MobiusDelegate(
+        events,
         EditPatientModel.from(patient, address, phoneNumber, dateOfBirthFormat),
         EditPatientInit(patient, address, phoneNumber),
         EditPatientUpdate(numberValidator, dateOfBirthValidator),
@@ -148,14 +146,10 @@ class EditPatientScreen(context: Context, attributeSet: AttributeSet) : Relative
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
     delegate.start()
-    eventsDisposable = events.subscribe { delegate.eventSource.notifyEvent(it) }
   }
 
   override fun onDetachedFromWindow() {
     delegate.stop()
-    if (::eventsDisposable.isInitialized && eventsDisposable.isDisposed.not()) {
-      eventsDisposable.dispose()
-    }
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
@@ -1,7 +1,6 @@
 package org.simple.clinic.editpatient
 
 import android.content.Context
-import android.os.Bundle
 import android.os.Parcelable
 import android.util.AttributeSet
 import android.widget.RadioButton
@@ -157,9 +156,8 @@ class EditPatientScreen(context: Context, attributeSet: AttributeSet) : Relative
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 
-
   override fun onRestoreInstanceState(state: Parcelable?) {
-    val viewState = delegate.onRestoreInstanceState(state as Bundle?)
+    val viewState = delegate.onRestoreInstanceState(state)
     super.onRestoreInstanceState(viewState)
   }
 

--- a/app/src/main/java/org/simple/clinic/mobius/MobiusDelegate.kt
+++ b/app/src/main/java/org/simple/clinic/mobius/MobiusDelegate.kt
@@ -88,14 +88,15 @@ class MobiusDelegate<M : Parcelable, E, F>(
     controller.stop()
   }
 
-  fun onSaveInstanceState(androidViewState: Parcelable?): Bundle {
+  fun onSaveInstanceState(androidViewState: Parcelable?): Parcelable {
     return Bundle().apply {
       putParcelable(viewStateKey, androidViewState)
       putParcelable(modelKey, controller.model)
     }
   }
 
-  fun onRestoreInstanceState(bundle: Bundle?): Parcelable? {
+  fun onRestoreInstanceState(parcelable: Parcelable?): Parcelable? {
+    val bundle = parcelable as? Bundle
     lastKnownModel = bundle?.getParcelable(modelKey) ?: defaultModel
     return bundle?.getParcelable<Parcelable?>(viewStateKey)
         .also { prepare() }

--- a/app/src/main/java/org/simple/clinic/mobius/MobiusDelegate.kt
+++ b/app/src/main/java/org/simple/clinic/mobius/MobiusDelegate.kt
@@ -97,7 +97,8 @@ class MobiusDelegate<M : Parcelable, E, F>(
 
   fun onRestoreInstanceState(bundle: Bundle?): Parcelable? {
     lastKnownModel = bundle?.getParcelable(modelKey) ?: defaultModel
-    return bundle?.getParcelable(viewStateKey)
+    return bundle?.getParcelable<Parcelable?>(viewStateKey)
+        .also { prepare() }
   }
 
   override fun connect(output: Consumer<E>): Connection<M> {


### PR DESCRIPTION
- Manage event subscription on its own
- Remove temporal coupling from `onRestoreInstanceState`