### PR TITLE
Strangulate logic from screen controller to Mobius

### DIFF
--- a/app/src/main/java/org/simple/clinic/mobius/MobiusDelegate.kt
+++ b/app/src/main/java/org/simple/clinic/mobius/MobiusDelegate.kt
@@ -85,7 +85,9 @@ class MobiusDelegate<M : Parcelable, E, F>(
     if (::eventsDisposable.isInitialized && eventsDisposable.isDisposed.not()) {
       eventsDisposable.dispose()
     }
-    controller.stop()
+
+    startControllerIfNotAlreadyRunning()
+    stopAndDisconnectController()
   }
 
   fun onSaveInstanceState(androidViewState: Parcelable?): Parcelable {
@@ -116,4 +118,15 @@ class MobiusDelegate<M : Parcelable, E, F>(
 
   private fun identity(): Function<M, M> =
       Function { it }
+
+  private fun startControllerIfNotAlreadyRunning() {
+    if (controller.isRunning.not()) {
+      controller.start()
+    }
+  }
+
+  private fun stopAndDisconnectController() {
+    controller.stop()
+    controller.disconnect()
+  }
 }

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffect.kt
@@ -1,3 +1,11 @@
 package org.simple.clinic.newentry
 
+import org.simple.clinic.patient.OngoingNewPatientEntry
+
 sealed class PatientEntryEffect
+
+object FetchPatientEntry : PatientEntryEffect()
+
+data class PrefillFields(
+    val patientEntry: OngoingNewPatientEntry
+) : PatientEntryEffect()

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffect.kt
@@ -1,0 +1,3 @@
+package org.simple.clinic.newentry
+
+sealed class PatientEntryEffect

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffect.kt
@@ -9,3 +9,5 @@ object FetchPatientEntry : PatientEntryEffect()
 data class PrefillFields(
     val patientEntry: OngoingNewPatientEntry
 ) : PatientEntryEffect()
+
+object ScrollFormToBottom : PatientEntryEffect()

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffectHandler.kt
@@ -22,6 +22,7 @@ object PatientEntryEffectHandler {
         .subtypeEffectHandler<PatientEntryEffect, PatientEntryEvent>()
         .addTransformer(FetchPatientEntry::class.java, fetchOngoingEntryEffectHandler(userSession, facilityRepository, patientRepository, schedulersProvider.io()))
         .addConsumer(PrefillFields::class.java, { ui.preFillFields(it.patientEntry) }, schedulersProvider.ui())
+        .addAction(ScrollFormToBottom::class.java, { ui.scrollFormToBottom() }, schedulersProvider.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffectHandler.kt
@@ -2,14 +2,50 @@ package org.simple.clinic.newentry
 
 import com.spotify.mobius.rx2.RxMobius
 import io.reactivex.ObservableTransformer
+import io.reactivex.Scheduler
+import io.reactivex.rxkotlin.Singles
+import org.simple.clinic.facility.FacilityRepository
+import org.simple.clinic.patient.OngoingNewPatientEntry
+import org.simple.clinic.patient.PatientRepository
+import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.scheduler.SchedulersProvider
 
 object PatientEntryEffectHandler {
   fun createEffectHandler(
+      userSession: UserSession,
+      facilityRepository: FacilityRepository,
+      patientRepository: PatientRepository,
+      ui: PatientEntryUi,
       schedulersProvider: SchedulersProvider
   ): ObservableTransformer<PatientEntryEffect, PatientEntryEvent> {
     return RxMobius
         .subtypeEffectHandler<PatientEntryEffect, PatientEntryEvent>()
+        .addTransformer(FetchPatientEntry::class.java, fetchOngoingEntryEffectHandler(userSession, facilityRepository, patientRepository, schedulersProvider.io()))
+        .addConsumer(PrefillFields::class.java, { ui.preFillFields(it.patientEntry) }, schedulersProvider.ui())
         .build()
+  }
+
+  private fun fetchOngoingEntryEffectHandler(
+      userSession: UserSession,
+      facilityRepository: FacilityRepository,
+      patientRepository: PatientRepository,
+      scheduler: Scheduler
+  ): ObservableTransformer<FetchPatientEntry, PatientEntryEvent> {
+    return ObservableTransformer { fetchPatientEntries ->
+      val getPatientEntryAndFacility = Singles.zip(
+          patientRepository.ongoingEntry(),
+          facilityRepository.currentFacility(userSession).firstOrError()
+      )
+
+      fetchPatientEntries
+          .flatMapSingle { getPatientEntryAndFacility }
+          .subscribeOn(scheduler)
+          .map { (entry, facility) ->
+            // TODO(rj): 2019-10-03 Extract as function!
+            entry.takeIf { it.address != null }
+                ?: entry.copy(address = OngoingNewPatientEntry.Address(colonyOrVillage = "", district = facility.district, state = facility.state))
+          }
+          .map { OngoingEntryFetched(it) }
+    }
   }
 }

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffectHandler.kt
@@ -1,0 +1,15 @@
+package org.simple.clinic.newentry
+
+import com.spotify.mobius.rx2.RxMobius
+import io.reactivex.ObservableTransformer
+import org.simple.clinic.util.scheduler.SchedulersProvider
+
+object PatientEntryEffectHandler {
+  fun createEffectHandler(
+      schedulersProvider: SchedulersProvider
+  ): ObservableTransformer<PatientEntryEffect, PatientEntryEvent> {
+    return RxMobius
+        .subtypeEffectHandler<PatientEntryEffect, PatientEntryEvent>()
+        .build()
+  }
+}

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryLogic.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryLogic.kt
@@ -28,6 +28,10 @@ fun patientEntryUpdate(
     } else {
       return next(updatedModel)
     }
+  } else if (event is AgeChanged) {
+    return next(model.updateAge(event.age))
+  } else if (event is DateOfBirthChanged) {
+    return next(model.updateDateOfBirth(event.dateOfBirth))
   }
 
   return noChange()

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryLogic.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryLogic.kt
@@ -20,6 +20,14 @@ fun patientEntryUpdate(
         model.patientEntryFetched(event.patientEntry),
         setOf(PrefillFields(event.patientEntry))
     )
+  } else if (event is GenderChanged) {
+    val updatedModel = model.updateGender(event.gender)
+
+    if (event.gender.isNotEmpty() && model.isSelectingGenderForTheFirstTime) {
+      return next(updatedModel.copy(isSelectingGenderForTheFirstTime = false), setOf(ScrollFormToBottom))
+    } else {
+      return next(updatedModel)
+    }
   }
 
   return noChange()

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryLogic.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryLogic.kt
@@ -1,0 +1,19 @@
+package org.simple.clinic.newentry
+
+import com.spotify.mobius.First
+import com.spotify.mobius.First.first
+import com.spotify.mobius.Next
+import com.spotify.mobius.Next.noChange
+
+fun patientEntryInit(
+    model: PatientEntryModel
+): First<PatientEntryModel, PatientEntryEffect> {
+  return first(model)
+}
+
+fun patientEntryUpdate(
+    model: PatientEntryModel,
+    event: PatientEntryEvent
+): Next<PatientEntryModel, PatientEntryEffect> {
+  return noChange()
+}

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryLogic.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryLogic.kt
@@ -21,7 +21,7 @@ fun patientEntryUpdate(
         setOf(PrefillFields(event.patientEntry))
     )
   } else if (event is GenderChanged) {
-    val updatedModel = model.updateGender(event.gender)
+    val updatedModel = model.withGender(event.gender)
 
     if (event.gender.isNotEmpty() && model.isSelectingGenderForTheFirstTime) {
       return next(updatedModel.copy(isSelectingGenderForTheFirstTime = false), setOf(ScrollFormToBottom))
@@ -29,9 +29,9 @@ fun patientEntryUpdate(
       return next(updatedModel)
     }
   } else if (event is AgeChanged) {
-    return next(model.updateAge(event.age))
+    return next(model.withAge(event.age))
   } else if (event is DateOfBirthChanged) {
-    return next(model.updateDateOfBirth(event.dateOfBirth))
+    return next(model.withDateOfBirth(event.dateOfBirth))
   }
 
   return noChange()

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryLogic.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryLogic.kt
@@ -3,17 +3,24 @@ package org.simple.clinic.newentry
 import com.spotify.mobius.First
 import com.spotify.mobius.First.first
 import com.spotify.mobius.Next
+import com.spotify.mobius.Next.next
 import com.spotify.mobius.Next.noChange
 
 fun patientEntryInit(
     model: PatientEntryModel
-): First<PatientEntryModel, PatientEntryEffect> {
-  return first(model)
-}
+): First<PatientEntryModel, PatientEntryEffect> =
+    first(model, setOf(FetchPatientEntry))
 
 fun patientEntryUpdate(
     model: PatientEntryModel,
     event: PatientEntryEvent
 ): Next<PatientEntryModel, PatientEntryEffect> {
+  if (event is OngoingEntryFetched) {
+    return next(
+        model.patientEntryFetched(event.patientEntry),
+        setOf(PrefillFields(event.patientEntry))
+    )
+  }
+
   return noChange()
 }

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryModel.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryModel.kt
@@ -20,7 +20,7 @@ data class PatientEntryModel(
       copy(patientEntry = patientEntry)
 
   // TODO(rj): 2019-10-03 Replace this with Arrow's lens or flatten the model
-  fun updateGender(gender: Optional<Gender>): PatientEntryModel {
+  fun withGender(gender: Optional<Gender>): PatientEntryModel {
     return copy(
         patientEntry = patientEntry?.copy(
             personalDetails = patientEntry.personalDetails?.copy(
@@ -30,7 +30,7 @@ data class PatientEntryModel(
     )
   }
 
-  fun updateAge(age: String): PatientEntryModel {
+  fun withAge(age: String): PatientEntryModel {
     val personalDetails = patientEntry?.personalDetails ?: PersonalDetails("", null, null, null)
 
     return copy(
@@ -40,7 +40,7 @@ data class PatientEntryModel(
     )
   }
 
-  fun updateDateOfBirth(dateOfBirth: String): PatientEntryModel {
+  fun withDateOfBirth(dateOfBirth: String): PatientEntryModel {
     val personalDetails = patientEntry?.personalDetails ?: PersonalDetails("", null, null, null)
 
     return copy(

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryModel.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryModel.kt
@@ -1,3 +1,14 @@
 package org.simple.clinic.newentry
 
-object PatientEntryModel
+import org.simple.clinic.patient.OngoingNewPatientEntry
+
+data class PatientEntryModel(
+    val patientEntry: OngoingNewPatientEntry? = null
+) {
+  companion object {
+    val DEFAULT = PatientEntryModel()
+  }
+
+  fun patientEntryFetched(patientEntry: OngoingNewPatientEntry): PatientEntryModel =
+      copy(patientEntry = patientEntry)
+}

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryModel.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryModel.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 import org.simple.clinic.patient.Gender
 import org.simple.clinic.patient.OngoingNewPatientEntry
+import org.simple.clinic.patient.OngoingNewPatientEntry.PersonalDetails
 import org.simple.clinic.util.Optional
 
 @Parcelize
@@ -25,6 +26,26 @@ data class PatientEntryModel(
             personalDetails = patientEntry.personalDetails?.copy(
                 gender = gender.toNullable()
             )
+        )
+    )
+  }
+
+  fun updateAge(age: String): PatientEntryModel {
+    val personalDetails = patientEntry?.personalDetails ?: PersonalDetails("", null, null, null)
+
+    return copy(
+        patientEntry = patientEntry?.copy(
+            personalDetails = personalDetails.copy(age = age)
+        )
+    )
+  }
+
+  fun updateDateOfBirth(dateOfBirth: String): PatientEntryModel {
+    val personalDetails = patientEntry?.personalDetails ?: PersonalDetails("", null, null, null)
+
+    return copy(
+        patientEntry = patientEntry?.copy(
+            personalDetails = personalDetails.copy(dateOfBirth = dateOfBirth)
         )
     )
   }

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryModel.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryModel.kt
@@ -1,10 +1,13 @@
 package org.simple.clinic.newentry
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
 import org.simple.clinic.patient.OngoingNewPatientEntry
 
+@Parcelize
 data class PatientEntryModel(
     val patientEntry: OngoingNewPatientEntry? = null
-) {
+) : Parcelable {
   companion object {
     val DEFAULT = PatientEntryModel()
   }

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryModel.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryModel.kt
@@ -1,0 +1,3 @@
+package org.simple.clinic.newentry
+
+object PatientEntryModel

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryModel.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryModel.kt
@@ -2,11 +2,14 @@ package org.simple.clinic.newentry
 
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
+import org.simple.clinic.patient.Gender
 import org.simple.clinic.patient.OngoingNewPatientEntry
+import org.simple.clinic.util.Optional
 
 @Parcelize
 data class PatientEntryModel(
-    val patientEntry: OngoingNewPatientEntry? = null
+    val patientEntry: OngoingNewPatientEntry? = null,
+    val isSelectingGenderForTheFirstTime: Boolean = true
 ) : Parcelable {
   companion object {
     val DEFAULT = PatientEntryModel()
@@ -14,4 +17,15 @@ data class PatientEntryModel(
 
   fun patientEntryFetched(patientEntry: OngoingNewPatientEntry): PatientEntryModel =
       copy(patientEntry = patientEntry)
+
+  // TODO(rj): 2019-10-03 Replace this with Arrow's lens or flatten the model
+  fun updateGender(gender: Optional<Gender>): PatientEntryModel {
+    return copy(
+        patientEntry = patientEntry?.copy(
+            personalDetails = patientEntry.personalDetails?.copy(
+                gender = gender.toNullable()
+            )
+        )
+    )
+  }
 }

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreenController.kt
@@ -73,8 +73,7 @@ class PatientEntryScreenController @Inject constructor(
         saveOngoingEntry(replayedEvents),
         savePatient(replayedEvents),
         showValidationErrorsOnSaveClick(replayedEvents),
-        resetValidationErrors(replayedEvents),
-        scrollToBottomOnGenderSelection(replayedEvents))
+        resetValidationErrors(replayedEvents))
   }
 
   private fun preFillOnStart(events: Observable<UiEvent>): Observable<UiChange> {
@@ -322,13 +321,5 @@ class PatientEntryScreenController @Inject constructor(
             else -> Single.never()
           }
         }
-  }
-
-  private fun scrollToBottomOnGenderSelection(events: Observable<UiEvent>): Observable<UiChange> {
-    return events
-        .ofType<GenderChanged>()
-        .filter { it.gender.isNotEmpty() }
-        .take(1)
-        .map { { ui: Ui -> ui.scrollFormToBottom() } }
   }
 }

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreenController.kt
@@ -40,9 +40,6 @@ import org.simple.clinic.util.None
 import org.simple.clinic.util.nullIfBlank
 import org.simple.clinic.widgets.ScreenCreated
 import org.simple.clinic.widgets.UiEvent
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility.AGE_VISIBLE
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility.BOTH_VISIBLE
-import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility.DATE_OF_BIRTH_VISIBLE
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
 import javax.inject.Inject
 import javax.inject.Named
@@ -68,7 +65,6 @@ class PatientEntryScreenController @Inject constructor(
 
     return Observable.mergeArray(
         preFillOnStart(replayedEvents),
-        switchBetweenDateOfBirthAndAge(replayedEvents),
         toggleDatePatternInDateOfBirthLabel(replayedEvents),
         saveOngoingEntry(replayedEvents),
         savePatient(replayedEvents),
@@ -92,27 +88,6 @@ class PatientEntryScreenController @Inject constructor(
                   state = facility.state))
         }
         .flatMap { Observable.never<UiChange>() }
-  }
-
-  private fun switchBetweenDateOfBirthAndAge(events: Observable<UiEvent>): Observable<UiChange> {
-    val isDateOfBirthBlanks = events
-        .ofType<DateOfBirthChanged>()
-        .map { it.dateOfBirth.isBlank() }
-
-    val isAgeBlanks = events
-        .ofType<AgeChanged>()
-        .map { it.age.isBlank() }
-
-    return Observables.combineLatest(isDateOfBirthBlanks, isAgeBlanks)
-        .distinctUntilChanged()
-        .map<UiChange> { (dateBlank, ageBlank) ->
-          when {
-            !dateBlank && ageBlank -> { ui: Ui -> ui.setDateOfBirthAndAgeVisibility(DATE_OF_BIRTH_VISIBLE) }
-            dateBlank && !ageBlank -> { ui: Ui -> ui.setDateOfBirthAndAgeVisibility(AGE_VISIBLE) }
-            dateBlank && ageBlank -> { ui: Ui -> ui.setDateOfBirthAndAgeVisibility(BOTH_VISIBLE) }
-            else -> throw AssertionError("Both date-of-birth and age cannot have user input at the same time")
-          }
-        }
   }
 
   private fun toggleDatePatternInDateOfBirthLabel(events: Observable<UiEvent>): Observable<UiChange> {

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreenController.kt
@@ -50,6 +50,7 @@ import javax.inject.Named
 typealias Ui = PatientEntryUi
 typealias UiChange = (Ui) -> Unit
 
+@Deprecated("This is being replaced with a Mobius loop instead.")
 class PatientEntryScreenController @Inject constructor(
     private val patientRepository: PatientRepository,
     private val facilityRepository: FacilityRepository,
@@ -92,7 +93,7 @@ class PatientEntryScreenController @Inject constructor(
                   district = facility.district,
                   state = facility.state))
         }
-        .map { { ui: Ui -> ui.preFillFields(it) } }
+        .flatMap { Observable.never<UiChange>() }
   }
 
   private fun switchBetweenDateOfBirthAndAge(events: Observable<UiEvent>): Observable<UiChange> {

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreenController.kt
@@ -74,8 +74,7 @@ class PatientEntryScreenController @Inject constructor(
         savePatient(replayedEvents),
         showValidationErrorsOnSaveClick(replayedEvents),
         resetValidationErrors(replayedEvents),
-        scrollToBottomOnGenderSelection(replayedEvents),
-        toggleVisibilityOfIdentifierSection(replayedEvents))
+        scrollToBottomOnGenderSelection(replayedEvents))
   }
 
   private fun preFillOnStart(events: Observable<UiEvent>): Observable<UiChange> {
@@ -331,28 +330,5 @@ class PatientEntryScreenController @Inject constructor(
         .filter { it.gender.isNotEmpty() }
         .take(1)
         .map { { ui: Ui -> ui.scrollFormToBottom() } }
-  }
-
-  private fun toggleVisibilityOfIdentifierSection(events: Observable<UiEvent>): Observable<UiChange> {
-    val screenCreates = events
-        .ofType<ScreenCreated>()
-
-    val savedOngoingEntry = patientRepository
-        .ongoingEntry()
-        .toObservable()
-        .replay()
-        .refCount()
-
-    val showIdentifiersSection = screenCreates
-        .withLatestFrom(savedOngoingEntry) { _, entry -> entry }
-        .filter { it.identifier != null }
-        .map { { ui: Ui -> ui.showIdentifierSection() } }
-
-    val hideIdentifiersSection = screenCreates
-        .withLatestFrom(savedOngoingEntry) { _, entry -> entry }
-        .filter { it.identifier == null }
-        .map { { ui: Ui -> ui.hideIdentifierSection() } }
-
-    return showIdentifiersSection.mergeWith(hideIdentifiersSection)
   }
 }

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreenEvents.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreenEvents.kt
@@ -7,6 +7,8 @@ import org.simple.clinic.widgets.UiEvent
 
 sealed class PatientEntryEvent : UiEvent
 
+data class OngoingEntryFetched(val patientEntry: OngoingNewPatientEntry) : PatientEntryEvent()
+
 data class FullNameChanged(val fullName: String) : PatientEntryEvent() {
   override val analyticsName = "Create Patient Entry:Full Name Text Changed"
 }

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryViewRenderer.kt
@@ -1,15 +1,32 @@
 package org.simple.clinic.newentry
 
 import org.simple.clinic.mobius.ViewRenderer
+import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility.AGE_VISIBLE
+import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility.BOTH_VISIBLE
+import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility.DATE_OF_BIRTH_VISIBLE
 
 class PatientEntryViewRenderer(val ui: PatientEntryUi) : ViewRenderer<PatientEntryModel> {
   override fun render(model: PatientEntryModel) {
-    if (model.patientEntry == null) return
+    val patientEntry = model.patientEntry ?: return
 
-    if (model.patientEntry.identifier != null) {
+    if (patientEntry.identifier != null) {
       ui.showIdentifierSection()
     } else {
       ui.hideIdentifierSection()
+    }
+
+    val personalDetails = patientEntry.personalDetails ?: return
+    val age = personalDetails.age
+    val dateOfBirth = personalDetails.dateOfBirth
+
+    if (age.isNullOrBlank() && dateOfBirth.isNullOrBlank()) {
+      ui.setDateOfBirthAndAgeVisibility(BOTH_VISIBLE)
+    } else if (age?.isNotBlank() == true && dateOfBirth?.isNotBlank() == true) {
+      throw AssertionError("Both date-of-birth and age cannot have user input at the same time")
+    } else if (age?.isNotBlank() == true) {
+      ui.setDateOfBirthAndAgeVisibility(AGE_VISIBLE)
+    } else if (dateOfBirth?.isNotBlank() == true) {
+      ui.setDateOfBirthAndAgeVisibility(DATE_OF_BIRTH_VISIBLE)
     }
   }
 }

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryViewRenderer.kt
@@ -1,0 +1,9 @@
+package org.simple.clinic.newentry
+
+import org.simple.clinic.mobius.ViewRenderer
+
+class PatientEntryViewRenderer(val ui: PatientEntryUi) : ViewRenderer<PatientEntryModel> {
+  override fun render(model: PatientEntryModel) {
+    // **crickets**
+  }
+}

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryViewRenderer.kt
@@ -4,6 +4,12 @@ import org.simple.clinic.mobius.ViewRenderer
 
 class PatientEntryViewRenderer(val ui: PatientEntryUi) : ViewRenderer<PatientEntryModel> {
   override fun render(model: PatientEntryModel) {
-    // **crickets**
+    if (model.patientEntry == null) return
+
+    if (model.patientEntry.identifier != null) {
+      ui.showIdentifierSection()
+    } else {
+      ui.hideIdentifierSection()
+    }
   }
 }

--- a/app/src/main/java/org/simple/clinic/patient/OngoingNewPatientEntry.kt
+++ b/app/src/main/java/org/simple/clinic/patient/OngoingNewPatientEntry.kt
@@ -1,5 +1,7 @@
 package org.simple.clinic.patient
 
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
 import org.simple.clinic.patient.PatientEntryValidationError.BOTH_DATEOFBIRTH_AND_AGE_ABSENT
 import org.simple.clinic.patient.PatientEntryValidationError.BOTH_DATEOFBIRTH_AND_AGE_PRESENT
 import org.simple.clinic.patient.PatientEntryValidationError.COLONY_OR_VILLAGE_EMPTY
@@ -14,6 +16,7 @@ import org.simple.clinic.patient.PatientEntryValidationError.PHONE_NUMBER_LENGTH
 import org.simple.clinic.patient.PatientEntryValidationError.PHONE_NUMBER_LENGTH_TOO_SHORT
 import org.simple.clinic.patient.PatientEntryValidationError.PHONE_NUMBER_NON_NULL_BUT_BLANK
 import org.simple.clinic.patient.PatientEntryValidationError.STATE_EMPTY
+import org.simple.clinic.patient.PatientPhoneNumberType.Mobile
 import org.simple.clinic.patient.businessid.Identifier
 import org.simple.clinic.registration.phone.PhoneNumberValidator
 import org.simple.clinic.registration.phone.PhoneNumberValidator.Result.BLANK
@@ -30,12 +33,13 @@ import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result
  * Parsing of user input happens later when this data class is converted
  * into a Patient object in [PatientRepository.saveOngoingEntryAsPatient].
  */
+@Parcelize
 data class OngoingNewPatientEntry(
     val personalDetails: PersonalDetails? = null,
     val address: Address? = null,
     val phoneNumber: PhoneNumber? = null,
     val identifier: Identifier? = null
-) {
+) : Parcelable {
 
   companion object {
     fun fromFullName(fullName: String): OngoingNewPatientEntry {
@@ -120,9 +124,12 @@ data class OngoingNewPatientEntry(
    * [age] is stored as a String instead of an Int because it's easy
    * to forget that [Int.toString] will return literal "null" for null Ints.
    */
-  data class PersonalDetails(val fullName: String, val dateOfBirth: String?, val age: String?, val gender: Gender?)
+  @Parcelize
+  data class PersonalDetails(val fullName: String, val dateOfBirth: String?, val age: String?, val gender: Gender?) : Parcelable
 
-  data class PhoneNumber(val number: String, val type: PatientPhoneNumberType = PatientPhoneNumberType.Mobile, val active: Boolean = true)
+  @Parcelize
+  data class PhoneNumber(val number: String, val type: PatientPhoneNumberType = Mobile, val active: Boolean = true) : Parcelable
 
-  data class Address(val colonyOrVillage: String, val district: String, val state: String)
+  @Parcelize
+  data class Address(val colonyOrVillage: String, val district: String, val state: String): Parcelable
 }

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
@@ -147,7 +147,7 @@ class PatientEntryScreenControllerTest {
     verify(ui).preFillFields(OngoingNewPatientEntry(address = address))
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `when save button is clicked then a patient record should be created from the form input`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
     whenever(patientRepository.saveOngoingEntry(any())).thenReturn(Completable.complete())
@@ -173,7 +173,7 @@ class PatientEntryScreenControllerTest {
     verify(patientRegisteredCount).set(1)
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `when save is clicked and patient is saved then patient registered count should be incremented`() {
     val existingPatientRegisteredCount = 5
     val ongoingEntry = OngoingNewPatientEntry(
@@ -195,7 +195,7 @@ class PatientEntryScreenControllerTest {
     verify(patientRegisteredCount).set(existingPatientRegisteredCount + 1)
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `date-of-birth and age fields should only be visible while one of them is empty`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
     with(uiEvents) {
@@ -214,7 +214,7 @@ class PatientEntryScreenControllerTest {
     verify(ui).setDateOfBirthAndAgeVisibility(DateOfBirthAndAgeVisibility.AGE_VISIBLE)
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `when both date-of-birth and age fields have text then an assertion error should be thrown`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
     errorConsumer = { assertThat(it).isInstanceOf(AssertionError::class.java) }
@@ -225,7 +225,7 @@ class PatientEntryScreenControllerTest {
     }
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `while date-of-birth has focus or has some input then date format should be shown in the label`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
     with(uiEvents) {
@@ -240,7 +240,7 @@ class PatientEntryScreenControllerTest {
     verify(ui).setShowDatePatternInDateOfBirthLabel(true)
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `when screen is paused then ongoing patient entry should be saved`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
     whenever(patientRepository.saveOngoingEntry(any())).thenReturn(Completable.complete())
@@ -265,7 +265,7 @@ class PatientEntryScreenControllerTest {
     ))
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `when save is clicked then user input should be validated`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
     with(uiEvents) {
@@ -317,7 +317,7 @@ class PatientEntryScreenControllerTest {
     verify(ui, atLeastOnce()).showLengthTooLongPhoneNumberError(true)
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `when input validation fails, the errors must be sent to analytics`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
     with(uiEvents) {
@@ -354,7 +354,7 @@ class PatientEntryScreenControllerTest {
     assertThat(validationErrors).isNotEmpty()
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `validation errors should be cleared on every input change`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
 
@@ -385,7 +385,7 @@ class PatientEntryScreenControllerTest {
 
   // TODO: Write these similarly structured regression tests in a smarter way.
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `regression test for validations 1`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
     whenever(patientRepository.saveOngoingEntry(any())).thenReturn(Completable.complete())
@@ -407,7 +407,7 @@ class PatientEntryScreenControllerTest {
     verify(patientRepository, never()).saveOngoingEntry(any())
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `regression test for validations 2`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
     whenever(patientRepository.saveOngoingEntry(any())).thenReturn(Completable.complete())
@@ -429,7 +429,7 @@ class PatientEntryScreenControllerTest {
     verify(patientRepository, never()).saveOngoingEntry(any())
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `regression test for validations 3`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
     whenever(patientRepository.saveOngoingEntry(any())).thenReturn(Completable.complete())
@@ -451,7 +451,7 @@ class PatientEntryScreenControllerTest {
     verify(patientRepository, never()).saveOngoingEntry(any())
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `regression test for validations 4`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
     whenever(patientRepository.saveOngoingEntry(any())).thenReturn(Completable.complete())
@@ -475,7 +475,7 @@ class PatientEntryScreenControllerTest {
     verify(patientRegisteredCount).set(any())
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   @Parameters(method = "params for gender values")
   fun `when gender is selected for the first time then the form should be scrolled to bottom`(gender: Gender) {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
@@ -493,7 +493,7 @@ class PatientEntryScreenControllerTest {
     return listOf(Male, Female, Transgender)
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `when validation errors are shown then the form should be scrolled to the first field with error`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
     whenever(patientRepository.saveOngoingEntry(any())).thenReturn(Completable.complete())
@@ -518,7 +518,7 @@ class PatientEntryScreenControllerTest {
     inOrder.verify(ui).scrollToFirstFieldWithError()
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `when the ongoing entry has an identifier it must be retained when accepting input`() {
     val identifier = Identifier(value = "id", type = BpPassport)
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry(identifier = identifier)))
@@ -555,7 +555,7 @@ class PatientEntryScreenControllerTest {
     verify(patientRepository).saveOngoingEntry(expectedSavedEntry)
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `when the ongoing patient entry has an identifier, the identifier section must be shown`() {
     initialOngoingPatientEntrySubject.onNext(OngoingNewPatientEntry(identifier = Identifier("id", BpPassport)))
 
@@ -564,7 +564,7 @@ class PatientEntryScreenControllerTest {
     verify(ui).showIdentifierSection()
   }
 
-  @Test
+  @Test // TODO: Migrate to Mobius
   fun `when the ongoing patient entry does not have an identifier, the identifier section must be hidden`() {
     initialOngoingPatientEntrySubject.onNext(OngoingNewPatientEntry(identifier = null))
 

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
@@ -195,14 +195,19 @@ class PatientEntryScreenControllerTest {
     verify(patientRegisteredCount).set(existingPatientRegisteredCount + 1)
   }
 
-  @Test // TODO: Migrate to Mobius
+  @Test
   fun `date-of-birth and age fields should only be visible while one of them is empty`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
+    screenCreatedForMobius()
+
     with(uiEvents) {
       onNext(AgeChanged(""))
       onNext(DateOfBirthChanged(""))
     }
-    verify(ui).setDateOfBirthAndAgeVisibility(DateOfBirthAndAgeVisibility.BOTH_VISIBLE)
+
+    // TODO(rj): 2019-10-03 This function gets invoked twice in Mobius because we don't have a way to do granular updates right now.
+    // TODO                 But we can live this this because it is an idempotent operation at the moment.
+    verify(ui, times(2)).setDateOfBirthAndAgeVisibility(DateOfBirthAndAgeVisibility.BOTH_VISIBLE)
 
     uiEvents.onNext(DateOfBirthChanged("1"))
     verify(ui).setDateOfBirthAndAgeVisibility(DateOfBirthAndAgeVisibility.DATE_OF_BIRTH_VISIBLE)
@@ -214,7 +219,7 @@ class PatientEntryScreenControllerTest {
     verify(ui).setDateOfBirthAndAgeVisibility(DateOfBirthAndAgeVisibility.AGE_VISIBLE)
   }
 
-  @Test // TODO: Migrate to Mobius
+  @Test
   fun `when both date-of-birth and age fields have text then an assertion error should be thrown`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
     errorConsumer = { assertThat(it).isInstanceOf(AssertionError::class.java) }

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
@@ -90,14 +90,22 @@ class PatientEntryScreenControllerTest {
 
     val sharedEvents = uiEvents.hide().share()
 
+    val effectHandler = PatientEntryEffectHandler.createEffectHandler(
+        userSession,
+        facilityRepository,
+        patientRepository,
+        ui,
+        TrampolineSchedulersProvider()
+    )
+
     fixture = MobiusTestFixture(
         sharedEvents.ofType(),
-        PatientEntryModel,
+        PatientEntryModel.DEFAULT,
         ::patientEntryInit,
         ::patientEntryUpdate,
-        PatientEntryEffectHandler.createEffectHandler(TrampolineSchedulersProvider()),
+        effectHandler,
         PatientEntryViewRenderer(ui)::render
-    ).also { it.start() }
+    )
 
     sharedEvents
         .compose(controller)
@@ -118,7 +126,11 @@ class PatientEntryScreenControllerTest {
 
     screenCreated()
 
-    verify(ui).preFillFields(OngoingNewPatientEntry(
+    // FIXME
+    // We have changed this to `times(2)` because both implementations are invoking the same boundary.
+    // We will revert this assert this assertion back as soon as the production code also has the Mobius setup,
+    // after which we will nullify the code in the controller.
+    verify(ui, times(2)).preFillFields(OngoingNewPatientEntry(
         address = Address(
             colonyOrVillage = "",
             district = "district",
@@ -136,7 +148,11 @@ class PatientEntryScreenControllerTest {
 
     screenCreated()
 
-    verify(ui).preFillFields(OngoingNewPatientEntry(address = address))
+    // FIXME
+    // We have changed this to `times(2)` because both implementations are invoking the same boundary.
+    // We will revert this assert this assertion back as soon as the production code also has the Mobius setup,
+    // after which we will nullify the code in the controller.
+    verify(ui, times(2)).preFillFields(OngoingNewPatientEntry(address = address))
   }
 
   @Test
@@ -567,5 +583,6 @@ class PatientEntryScreenControllerTest {
 
   private fun screenCreated() {
     uiEvents.onNext(ScreenCreated())
+    fixture.start()
   }
 }

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
@@ -475,10 +475,12 @@ class PatientEntryScreenControllerTest {
     verify(patientRegisteredCount).set(any())
   }
 
-  @Test // TODO: Migrate to Mobius
+  @Test
   @Parameters(method = "params for gender values")
   fun `when gender is selected for the first time then the form should be scrolled to bottom`(gender: Gender) {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
+    screenCreatedForMobius()
+
     with(uiEvents) {
       onNext(GenderChanged(None))
       onNext(GenderChanged(Just(gender)))
@@ -575,6 +577,10 @@ class PatientEntryScreenControllerTest {
 
   private fun screenCreated() {
     uiEvents.onNext(ScreenCreated())
+    screenCreatedForMobius()
+  }
+
+  private fun screenCreatedForMobius() {
     fixture.start()
   }
 }

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
@@ -126,11 +126,7 @@ class PatientEntryScreenControllerTest {
 
     screenCreated()
 
-    // FIXME
-    // We have changed this to `times(2)` because both implementations are invoking the same boundary.
-    // We will revert this assert this assertion back as soon as the production code also has the Mobius setup,
-    // after which we will nullify the code in the controller.
-    verify(ui, times(2)).preFillFields(OngoingNewPatientEntry(
+    verify(ui).preFillFields(OngoingNewPatientEntry(
         address = Address(
             colonyOrVillage = "",
             district = "district",
@@ -148,11 +144,7 @@ class PatientEntryScreenControllerTest {
 
     screenCreated()
 
-    // FIXME
-    // We have changed this to `times(2)` because both implementations are invoking the same boundary.
-    // We will revert this assert this assertion back as soon as the production code also has the Mobius setup,
-    // after which we will nullify the code in the controller.
-    verify(ui, times(2)).preFillFields(OngoingNewPatientEntry(address = address))
+    verify(ui).preFillFields(OngoingNewPatientEntry(address = address))
   }
 
   @Test

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
@@ -4,6 +4,7 @@ import com.f2prateek.rx.preferences2.Preference
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.atLeastOnce
+import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.inOrder
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
@@ -77,14 +78,13 @@ class PatientEntryScreenControllerTest {
       patientRegisteredCount
   )
   private val reporter = MockAnalyticsReporter()
-  private val initialOngoingPatientEntrySubject = PublishSubject.create<OngoingNewPatientEntry>()
 
   private lateinit var errorConsumer: (Throwable) -> Unit
 
   @Before
   fun setUp() {
     whenever(facilityRepository.currentFacility(userSession)).thenReturn(Observable.just(PatientMocker.facility()))
-    whenever(patientRepository.ongoingEntry()).thenReturn(initialOngoingPatientEntrySubject.firstOrError())
+    whenever(patientRepository.ongoingEntry()).thenReturn(Single.never())
 
     errorConsumer = { throw it }
 
@@ -555,18 +555,18 @@ class PatientEntryScreenControllerTest {
     verify(patientRepository).saveOngoingEntry(expectedSavedEntry)
   }
 
-  @Test // TODO: Migrate to Mobius
+  @Test
   fun `when the ongoing patient entry has an identifier, the identifier section must be shown`() {
-    initialOngoingPatientEntrySubject.onNext(OngoingNewPatientEntry(identifier = Identifier("id", BpPassport)))
+    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry(identifier = Identifier("id", BpPassport))))
 
     screenCreated()
 
     verify(ui).showIdentifierSection()
   }
 
-  @Test // TODO: Migrate to Mobius
+  @Test
   fun `when the ongoing patient entry does not have an identifier, the identifier section must be hidden`() {
-    initialOngoingPatientEntrySubject.onNext(OngoingNewPatientEntry(identifier = null))
+    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry(identifier = null)))
 
     screenCreated()
 

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenControllerTest.kt
@@ -101,7 +101,7 @@ class PatientEntryScreenControllerTest {
   fun `when screen is created then existing data should be pre-filled`() {
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry()))
 
-    uiEvents.onNext(ScreenCreated())
+    screenCreated()
 
     verify(ui).preFillFields(OngoingNewPatientEntry(
         address = Address(
@@ -119,7 +119,7 @@ class PatientEntryScreenControllerTest {
     )
     whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(OngoingNewPatientEntry(address = address)))
 
-    uiEvents.onNext(ScreenCreated())
+    screenCreated()
 
     verify(ui).preFillFields(OngoingNewPatientEntry(address = address))
   }
@@ -536,7 +536,7 @@ class PatientEntryScreenControllerTest {
   fun `when the ongoing patient entry has an identifier, the identifier section must be shown`() {
     initialOngoingPatientEntrySubject.onNext(OngoingNewPatientEntry(identifier = Identifier("id", BpPassport)))
 
-    uiEvents.onNext(ScreenCreated())
+    screenCreated()
 
     verify(ui).showIdentifierSection()
   }
@@ -545,8 +545,12 @@ class PatientEntryScreenControllerTest {
   fun `when the ongoing patient entry does not have an identifier, the identifier section must be hidden`() {
     initialOngoingPatientEntrySubject.onNext(OngoingNewPatientEntry(identifier = null))
 
-    uiEvents.onNext(ScreenCreated())
+    screenCreated()
 
     verify(ui).hideIdentifierSection()
+  }
+
+  private fun screenCreated() {
+    uiEvents.onNext(ScreenCreated())
   }
 }

--- a/mobius-migration/src/main/java/org/simple/mobius/migration/ImmediateEventSource.kt
+++ b/mobius-migration/src/main/java/org/simple/mobius/migration/ImmediateEventSource.kt
@@ -15,7 +15,6 @@ internal class ImmediateEventSource<E> : EventSource<E> {
   }
 
   fun notifyEvent(e: E) {
-    requireNotNull(consumer) { "'consumer' cannot be null" }
-    consumer!!.accept(e)
+    consumer?.accept(e)
   }
 }


### PR DESCRIPTION
The following logic was moved from `PatientEntryScreenController` to Mobius

- Screen created
- Date of birth & age updates
- Toggle identifier section
- Scrolling to the bottom of the screen when gender is selected for the first time