### PR TITLE
Manually override the default locale in activities

### DIFF
--- a/app/src/main/java/org/simple/clinic/AppDatabase.kt
+++ b/app/src/main/java/org/simple/clinic/AppDatabase.kt
@@ -29,9 +29,9 @@ import org.simple.clinic.user.LoggedInUserFacilityMapping
 import org.simple.clinic.user.OngoingLoginEntry
 import org.simple.clinic.user.User
 import org.simple.clinic.user.UserStatus
-import org.simple.clinic.util.InstantRoomTypeConverter
-import org.simple.clinic.util.LocalDateRoomTypeConverter
-import org.simple.clinic.util.UuidRoomTypeConverter
+import org.simple.clinic.util.room.InstantRoomTypeConverter
+import org.simple.clinic.util.room.LocalDateRoomTypeConverter
+import org.simple.clinic.util.room.UuidRoomTypeConverter
 
 @Database(
     entities = [

--- a/app/src/main/java/org/simple/clinic/activity/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/activity/TheActivity.kt
@@ -26,7 +26,9 @@ import org.simple.clinic.router.screen.KeyChangeAnimator
 import org.simple.clinic.router.screen.NestedKeyChanger
 import org.simple.clinic.router.screen.RouterDirection
 import org.simple.clinic.router.screen.ScreenRouter
+import org.simple.clinic.util.LocaleOverrideContextWrapper
 import org.simple.clinic.util.unsafeLazy
+import java.util.Locale
 import javax.inject.Inject
 
 class TheActivity : AppCompatActivity() {
@@ -43,6 +45,9 @@ class TheActivity : AppCompatActivity() {
 
   @Inject
   lateinit var fullScreenKeyChangeAnimator: KeyChangeAnimator<FullScreenKey>
+
+  @Inject
+  lateinit var locale: Locale
 
   private val screenRouter: ScreenRouter by unsafeLazy {
     ScreenRouter.create(this, NestedKeyChanger(), screenResults)
@@ -68,7 +73,8 @@ class TheActivity : AppCompatActivity() {
 
   override fun attachBaseContext(baseContext: Context) {
     setupDiGraph()
-    val contextWithRouter = wrapContextWithRouter(baseContext)
+    val contextWithOverriddenLocale = LocaleOverrideContextWrapper.wrap(baseContext, locale)
+    val contextWithRouter = wrapContextWithRouter(contextWithOverriddenLocale)
     super.attachBaseContext(ViewPumpContextWrapper.wrap(contextWithRouter))
   }
 

--- a/app/src/main/java/org/simple/clinic/activity/TheActivityComponent.kt
+++ b/app/src/main/java/org/simple/clinic/activity/TheActivityComponent.kt
@@ -66,7 +66,7 @@ import org.simple.clinic.summary.addphone.AddPhoneNumberDialog
 import org.simple.clinic.summary.linkId.LinkIdWithPatientView
 import org.simple.clinic.summary.updatephone.UpdatePhoneNumberDialog
 import org.simple.clinic.sync.indicator.SyncIndicatorView
-import org.simple.clinic.util.InstantRxPreferencesConverter
+import org.simple.clinic.util.preference.InstantRxPreferencesConverter
 import org.simple.clinic.widgets.PatientSearchResultItemView
 import org.simple.clinic.widgets.qrcodescanner.QrCodeScannerView
 import org.threeten.bp.Instant

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureModule.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureModule.kt
@@ -8,11 +8,10 @@ import org.simple.clinic.AppDatabase
 import org.simple.clinic.bp.sync.BloodPressureSyncApi
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
-import org.simple.clinic.util.OptionalRxPreferencesConverter
-import org.simple.clinic.util.StringPreferenceConverter
+import org.simple.clinic.util.preference.OptionalRxPreferencesConverter
+import org.simple.clinic.util.preference.StringPreferenceConverter
 import org.simple.clinic.util.UserInputDatePaddingCharacter
 import retrofit2.Retrofit
-import java.util.Locale
 import javax.inject.Named
 
 @Module

--- a/app/src/main/java/org/simple/clinic/di/AppComponent.kt
+++ b/app/src/main/java/org/simple/clinic/di/AppComponent.kt
@@ -13,6 +13,7 @@ import org.simple.clinic.storage.Migration_34_35
 import org.simple.clinic.sync.DataSync
 import org.simple.clinic.sync.SyncWorker
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.widgets.BottomSheetActivity
 import javax.inject.Scope
 
 @AppScope
@@ -28,6 +29,7 @@ interface AppComponent {
   fun inject(target: Migration_27_28)
   fun inject(target: Migration_29_30)
   fun inject(target: Migration_34_35)
+  fun inject(target: BottomSheetActivity)
 
   fun activityComponentBuilder(): TheActivityComponent.Builder
   fun userSession(): UserSession

--- a/app/src/main/java/org/simple/clinic/di/AppModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/AppModule.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.res.Resources
 import android.os.Vibrator
 import androidx.work.WorkManager
+import com.f2prateek.rx.preferences2.Preference
 import dagger.Module
 import dagger.Provides
 import org.simple.clinic.appupdate.AppUpdateModule
@@ -21,6 +22,7 @@ import org.simple.clinic.registration.RegistrationModule
 import org.simple.clinic.remoteconfig.RemoteConfigModule
 import org.simple.clinic.screen.KeyChangeAnimatorModule
 import org.simple.clinic.security.pin.BruteForceProtectionModule
+import org.simple.clinic.settings.SettingsModule
 import org.simple.clinic.storage.StorageModule
 import org.simple.clinic.summary.PatientSummaryModule
 import org.simple.clinic.sync.DataSyncOnApprovalModule
@@ -35,6 +37,7 @@ import org.simple.clinic.util.scheduler.DefaultSchedulersProvider
 import org.simple.clinic.util.scheduler.SchedulersProvider
 import org.threeten.bp.ZoneId
 import java.util.Locale
+import javax.inject.Named
 
 @Module(includes = [
   SyncModule::class,
@@ -58,7 +61,8 @@ import java.util.Locale
   HomescreenIllustrationModule::class,
   SimpleVideoModule::class,
   MobiusMigrationModule::class,
-  RemoteConfigModule::class
+  RemoteConfigModule::class,
+  SettingsModule::class
 ])
 open class AppModule(private val appContext: Application) {
 
@@ -86,7 +90,9 @@ open class AppModule(private val appContext: Application) {
   open fun elapsedRealtimeClock() = ElapsedRealtimeClock()
 
   @Provides
-  fun currentLocale(): Locale = Locale.getDefault()
+  fun currentLocale(@Named("preference_user_selected_locale") userSelectedLocalePreference: Preference<Locale>): Locale {
+    return userSelectedLocalePreference.get()
+  }
 
   @Provides
   @AppScope

--- a/app/src/main/java/org/simple/clinic/di/NetworkModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/NetworkModule.kt
@@ -20,10 +20,10 @@ import org.simple.clinic.patient.sync.PatientPayload
 import org.simple.clinic.remoteconfig.ConfigReader
 import org.simple.clinic.user.LoggedInUserHttpInterceptor
 import org.simple.clinic.user.UserStatus
-import org.simple.clinic.util.InstantMoshiAdapter
-import org.simple.clinic.util.LocalDateMoshiAdapter
-import org.simple.clinic.util.MoshiOptionalAdapterFactory
-import org.simple.clinic.util.UuidMoshiAdapter
+import org.simple.clinic.util.moshi.InstantMoshiAdapter
+import org.simple.clinic.util.moshi.LocalDateMoshiAdapter
+import org.simple.clinic.util.moshi.MoshiOptionalAdapterFactory
+import org.simple.clinic.util.moshi.UuidMoshiAdapter
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory

--- a/app/src/main/java/org/simple/clinic/drugs/PrescriptionModule.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/PrescriptionModule.kt
@@ -8,8 +8,8 @@ import org.simple.clinic.AppDatabase
 import org.simple.clinic.drugs.sync.PrescriptionSyncApi
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
-import org.simple.clinic.util.OptionalRxPreferencesConverter
-import org.simple.clinic.util.StringPreferenceConverter
+import org.simple.clinic.util.preference.OptionalRxPreferencesConverter
+import org.simple.clinic.util.preference.StringPreferenceConverter
 import retrofit2.Retrofit
 import javax.inject.Named
 

--- a/app/src/main/java/org/simple/clinic/facility/FacilityModule.kt
+++ b/app/src/main/java/org/simple/clinic/facility/FacilityModule.kt
@@ -8,8 +8,8 @@ import org.simple.clinic.AppDatabase
 import org.simple.clinic.user.LoggedInUserFacilityMapping
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
-import org.simple.clinic.util.OptionalRxPreferencesConverter
-import org.simple.clinic.util.StringPreferenceConverter
+import org.simple.clinic.util.preference.OptionalRxPreferencesConverter
+import org.simple.clinic.util.preference.StringPreferenceConverter
 import retrofit2.Retrofit
 import javax.inject.Named
 

--- a/app/src/main/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentScreen.kt
@@ -20,8 +20,10 @@ import org.simple.clinic.overdue.AppointmentCancelReason.MovedToPrivatePractitio
 import org.simple.clinic.overdue.AppointmentCancelReason.Other
 import org.simple.clinic.overdue.AppointmentCancelReason.PatientNotResponding
 import org.simple.clinic.overdue.AppointmentCancelReason.TransferredToAnotherPublicHospital
+import org.simple.clinic.util.LocaleOverrideContextWrapper
 import org.simple.clinic.widgets.ScreenDestroyed
 import org.simple.clinic.widgets.UiEvent
+import java.util.Locale
 import java.util.UUID
 import javax.inject.Inject
 
@@ -40,6 +42,9 @@ class RemoveAppointmentScreen : AppCompatActivity() {
   @Inject
   lateinit var controller: RemoveAppointmentScreenController
 
+  @Inject
+  lateinit var locale: Locale
+
   private val patientAlreadyVisitedRadioButton by bindView<RadioButton>(R.id.removeappointment_reason_patient_already_visited)
   private val notRespondingRadioButton by bindView<RadioButton>(R.id.removeappointment_reason_patient_not_responding)
   private val invalidPhoneNumberRadioButton by bindView<RadioButton>(R.id.removeappointment_reason_invalid_phone_number)
@@ -56,7 +61,6 @@ class RemoveAppointmentScreen : AppCompatActivity() {
     super.onCreate(savedInstanceState)
 
     setContentView(R.layout.screen_remove_appointment)
-    TheActivity.component.inject(this)
 
     bindUiToController(
         ui = this,
@@ -72,6 +76,11 @@ class RemoveAppointmentScreen : AppCompatActivity() {
     )
 
     toolbar.setNavigationOnClickListener { closeScreen() }
+  }
+
+  override fun attachBaseContext(base: Context) {
+    TheActivity.component.inject(this)
+    super.attachBaseContext(LocaleOverrideContextWrapper.wrap(base, locale))
   }
 
   override fun onDestroy() {

--- a/app/src/main/java/org/simple/clinic/home/patients/PatientsModule.kt
+++ b/app/src/main/java/org/simple/clinic/home/patients/PatientsModule.kt
@@ -4,7 +4,7 @@ import com.f2prateek.rx.preferences2.Preference
 import com.f2prateek.rx.preferences2.RxSharedPreferences
 import dagger.Module
 import dagger.Provides
-import org.simple.clinic.util.InstantRxPreferencesConverter
+import org.simple.clinic.util.preference.InstantRxPreferencesConverter
 import org.threeten.bp.Instant
 import javax.inject.Named
 

--- a/app/src/main/java/org/simple/clinic/login/LoginModule.kt
+++ b/app/src/main/java/org/simple/clinic/login/LoginModule.kt
@@ -13,8 +13,8 @@ import org.simple.clinic.security.PasswordHasher
 import org.simple.clinic.user.OngoingLoginEntry
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
-import org.simple.clinic.util.OptionalRxPreferencesConverter
-import org.simple.clinic.util.StringPreferenceConverter
+import org.simple.clinic.util.preference.OptionalRxPreferencesConverter
+import org.simple.clinic.util.preference.StringPreferenceConverter
 import org.simple.clinic.util.scheduler.SchedulersProvider
 import retrofit2.Retrofit
 import java.util.concurrent.TimeUnit

--- a/app/src/main/java/org/simple/clinic/medicalhistory/Answer.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/Answer.kt
@@ -4,7 +4,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.room.TypeConverter
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
-import org.simple.clinic.util.SafeEnumTypeAdapter
+import org.simple.clinic.util.room.SafeEnumTypeAdapter
 
 sealed class Answer {
 

--- a/app/src/main/java/org/simple/clinic/medicalhistory/MedicalHistoryModule.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/MedicalHistoryModule.kt
@@ -8,8 +8,8 @@ import org.simple.clinic.AppDatabase
 import org.simple.clinic.medicalhistory.sync.MedicalHistorySyncApi
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
-import org.simple.clinic.util.OptionalRxPreferencesConverter
-import org.simple.clinic.util.StringPreferenceConverter
+import org.simple.clinic.util.preference.OptionalRxPreferencesConverter
+import org.simple.clinic.util.preference.StringPreferenceConverter
 import retrofit2.Retrofit
 import javax.inject.Named
 

--- a/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
@@ -12,7 +12,7 @@ import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
 import io.reactivex.Flowable
 import org.simple.clinic.patient.SyncStatus
-import org.simple.clinic.util.SafeEnumTypeAdapter
+import org.simple.clinic.util.room.SafeEnumTypeAdapter
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
 import java.util.UUID

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentCancelReason.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentCancelReason.kt
@@ -4,7 +4,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.room.TypeConverter
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
-import org.simple.clinic.util.SafeEnumTypeAdapter
+import org.simple.clinic.util.room.SafeEnumTypeAdapter
 
 sealed class AppointmentCancelReason {
 

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentModule.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentModule.kt
@@ -12,8 +12,8 @@ import org.simple.clinic.scheduleappointment.TimeToAppointment.Months
 import org.simple.clinic.scheduleappointment.TimeToAppointment.Weeks
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
-import org.simple.clinic.util.OptionalRxPreferencesConverter
-import org.simple.clinic.util.StringPreferenceConverter
+import org.simple.clinic.util.preference.OptionalRxPreferencesConverter
+import org.simple.clinic.util.preference.StringPreferenceConverter
 import org.threeten.bp.Period
 import retrofit2.Retrofit
 import javax.inject.Named

--- a/app/src/main/java/org/simple/clinic/patient/Gender.kt
+++ b/app/src/main/java/org/simple/clinic/patient/Gender.kt
@@ -11,7 +11,7 @@ import org.simple.clinic.patient.Gender.Female
 import org.simple.clinic.patient.Gender.Male
 import org.simple.clinic.patient.Gender.Transgender
 import org.simple.clinic.patient.Gender.Unknown
-import org.simple.clinic.util.SafeEnumTypeAdapter
+import org.simple.clinic.util.room.SafeEnumTypeAdapter
 
 sealed class Gender: Parcelable {
 

--- a/app/src/main/java/org/simple/clinic/patient/PatientPhoneNumberType.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientPhoneNumberType.kt
@@ -6,7 +6,7 @@ import androidx.room.TypeConverter
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
 import kotlinx.android.parcel.Parcelize
-import org.simple.clinic.util.SafeEnumTypeAdapter
+import org.simple.clinic.util.room.SafeEnumTypeAdapter
 
 sealed class PatientPhoneNumberType : Parcelable {
 

--- a/app/src/main/java/org/simple/clinic/patient/PatientStatus.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientStatus.kt
@@ -6,7 +6,7 @@ import androidx.room.TypeConverter
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
 import kotlinx.android.parcel.Parcelize
-import org.simple.clinic.util.SafeEnumTypeAdapter
+import org.simple.clinic.util.room.SafeEnumTypeAdapter
 
 sealed class PatientStatus: Parcelable {
 

--- a/app/src/main/java/org/simple/clinic/patient/SyncStatus.kt
+++ b/app/src/main/java/org/simple/clinic/patient/SyncStatus.kt
@@ -1,7 +1,7 @@
 package org.simple.clinic.patient
 
 import org.simple.clinic.patient.SyncStatus.*
-import org.simple.clinic.util.RoomEnumTypeConverter
+import org.simple.clinic.util.room.RoomEnumTypeConverter
 
 enum class SyncStatus {
   PENDING,

--- a/app/src/main/java/org/simple/clinic/patient/businessid/BusinessId.kt
+++ b/app/src/main/java/org/simple/clinic/patient/businessid/BusinessId.kt
@@ -19,7 +19,7 @@ import io.reactivex.Single
 import org.simple.clinic.patient.Patient
 import org.simple.clinic.patient.businessid.Identifier.IdentifierType
 import org.simple.clinic.patient.sync.BusinessIdPayload
-import org.simple.clinic.util.SafeEnumTypeAdapter
+import org.simple.clinic.util.room.SafeEnumTypeAdapter
 import org.threeten.bp.Instant
 import java.util.UUID
 

--- a/app/src/main/java/org/simple/clinic/patient/businessid/Identifier.kt
+++ b/app/src/main/java/org/simple/clinic/patient/businessid/Identifier.kt
@@ -7,7 +7,7 @@ import androidx.room.TypeConverter
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
 import kotlinx.android.parcel.Parcelize
-import org.simple.clinic.util.SafeEnumTypeAdapter
+import org.simple.clinic.util.room.SafeEnumTypeAdapter
 
 @Parcelize
 data class Identifier(

--- a/app/src/main/java/org/simple/clinic/patient/sync/PatientSyncModule.kt
+++ b/app/src/main/java/org/simple/clinic/patient/sync/PatientSyncModule.kt
@@ -6,8 +6,8 @@ import dagger.Module
 import dagger.Provides
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
-import org.simple.clinic.util.OptionalRxPreferencesConverter
-import org.simple.clinic.util.StringPreferenceConverter
+import org.simple.clinic.util.preference.OptionalRxPreferencesConverter
+import org.simple.clinic.util.preference.StringPreferenceConverter
 import retrofit2.Retrofit
 import javax.inject.Named
 

--- a/app/src/main/java/org/simple/clinic/protocol/ProtocolModule.kt
+++ b/app/src/main/java/org/simple/clinic/protocol/ProtocolModule.kt
@@ -7,8 +7,8 @@ import dagger.Provides
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
-import org.simple.clinic.util.OptionalRxPreferencesConverter
-import org.simple.clinic.util.StringPreferenceConverter
+import org.simple.clinic.util.preference.OptionalRxPreferencesConverter
+import org.simple.clinic.util.preference.StringPreferenceConverter
 import retrofit2.Retrofit
 import javax.inject.Named
 

--- a/app/src/main/java/org/simple/clinic/recentpatientsview/RecentPatientsView.kt
+++ b/app/src/main/java/org/simple/clinic/recentpatientsview/RecentPatientsView.kt
@@ -35,9 +35,6 @@ class RecentPatientsView(context: Context, attrs: AttributeSet) : FrameLayout(co
   lateinit var controller: RecentPatientsViewController
 
   @Inject
-  lateinit var activity: TheActivity
-
-  @Inject
   lateinit var utcClock: UtcClock
 
   @Inject
@@ -87,7 +84,7 @@ class RecentPatientsView(context: Context, attrs: AttributeSet) : FrameLayout(co
   }
 
   fun openPatientSummary(patientUuid: UUID) {
-    activity.screenRouter.push(
+    screenRouter.push(
         PatientSummaryScreenKey(
             patientUuid = patientUuid,
             intention = OpenIntention.ViewExistingPatient,

--- a/app/src/main/java/org/simple/clinic/settings/SettingsModule.kt
+++ b/app/src/main/java/org/simple/clinic/settings/SettingsModule.kt
@@ -4,7 +4,7 @@ import com.f2prateek.rx.preferences2.Preference
 import com.f2prateek.rx.preferences2.RxSharedPreferences
 import dagger.Module
 import dagger.Provides
-import org.simple.clinic.util.LocalePreferenceConverter
+import org.simple.clinic.util.preference.LocalePreferenceConverter
 import java.util.Locale
 import javax.inject.Named
 

--- a/app/src/main/java/org/simple/clinic/settings/SettingsModule.kt
+++ b/app/src/main/java/org/simple/clinic/settings/SettingsModule.kt
@@ -1,0 +1,19 @@
+package org.simple.clinic.settings
+
+import com.f2prateek.rx.preferences2.Preference
+import com.f2prateek.rx.preferences2.RxSharedPreferences
+import dagger.Module
+import dagger.Provides
+import org.simple.clinic.util.LocalePreferenceConverter
+import java.util.Locale
+import javax.inject.Named
+
+@Module
+class SettingsModule {
+
+  @Provides
+  @Named("preference_user_selected_locale")
+  fun provideUserSelectedLocalePreference(rxSharedPreferences: RxSharedPreferences): Preference<Locale> {
+    return rxSharedPreferences.getObject("preference_user_selected_locale", Locale.getDefault(), LocalePreferenceConverter())
+  }
+}

--- a/app/src/main/java/org/simple/clinic/user/User.kt
+++ b/app/src/main/java/org/simple/clinic/user/User.kt
@@ -9,7 +9,7 @@ import androidx.room.PrimaryKey
 import androidx.room.Query
 import androidx.room.Transaction
 import io.reactivex.Flowable
-import org.simple.clinic.util.RoomEnumTypeConverter
+import org.simple.clinic.util.room.RoomEnumTypeConverter
 import org.simple.clinic.util.UtcClock
 import org.threeten.bp.Instant
 import java.util.UUID

--- a/app/src/main/java/org/simple/clinic/user/UserStatus.kt
+++ b/app/src/main/java/org/simple/clinic/user/UserStatus.kt
@@ -4,7 +4,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.room.TypeConverter
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
-import org.simple.clinic.util.SafeEnumTypeAdapter
+import org.simple.clinic.util.room.SafeEnumTypeAdapter
 
 sealed class UserStatus {
 

--- a/app/src/main/java/org/simple/clinic/util/InstantRoomTypeConverter.kt
+++ b/app/src/main/java/org/simple/clinic/util/InstantRoomTypeConverter.kt
@@ -1,7 +1,6 @@
 package org.simple.clinic.util
 
 import androidx.room.TypeConverter
-import com.f2prateek.rx.preferences2.Preference
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
 import org.threeten.bp.Instant
@@ -36,13 +35,3 @@ class InstantMoshiAdapter {
   }
 }
 
-class InstantRxPreferencesConverter : Preference.Converter<Instant> {
-
-  override fun deserialize(value: String): Instant {
-    return Instant.parse(value)
-  }
-
-  override fun serialize(value: Instant): String {
-    return value.toString()
-  }
-}

--- a/app/src/main/java/org/simple/clinic/util/LocaleOverrideContextWrapper.kt
+++ b/app/src/main/java/org/simple/clinic/util/LocaleOverrideContextWrapper.kt
@@ -1,0 +1,26 @@
+package org.simple.clinic.util
+
+import android.content.Context
+import android.content.ContextWrapper
+import java.util.Locale
+
+class LocaleOverrideContextWrapper private constructor(base: Context) : ContextWrapper(base) {
+
+  companion object {
+    fun wrap(base: Context, locale: Locale): Context {
+      return overrideLocaleInContext(base, locale)
+    }
+
+    private fun overrideLocaleInContext(context: Context, overrideLocale: Locale): Context {
+      Locale.setDefault(overrideLocale)
+
+      val overrideContext = with(context.resources.configuration) {
+        setLocale(overrideLocale)
+        setLayoutDirection(overrideLocale)
+        context.createConfigurationContext(this)
+      }
+
+      return LocaleOverrideContextWrapper(overrideContext)
+    }
+  }
+}

--- a/app/src/main/java/org/simple/clinic/util/LocalePreferenceConverter.kt
+++ b/app/src/main/java/org/simple/clinic/util/LocalePreferenceConverter.kt
@@ -1,0 +1,15 @@
+package org.simple.clinic.util
+
+import com.f2prateek.rx.preferences2.Preference
+import java.util.Locale
+
+class LocalePreferenceConverter : Preference.Converter<Locale> {
+
+  override fun deserialize(serialized: String): Locale {
+    return Locale.forLanguageTag(serialized)
+  }
+
+  override fun serialize(value: Locale): String {
+    return value.toLanguageTag()
+  }
+}

--- a/app/src/main/java/org/simple/clinic/util/UuidTypeConverters.kt
+++ b/app/src/main/java/org/simple/clinic/util/UuidTypeConverters.kt
@@ -1,8 +1,6 @@
 package org.simple.clinic.util
 
 import androidx.room.TypeConverter
-import com.squareup.moshi.FromJson
-import com.squareup.moshi.ToJson
 import java.util.UUID
 
 class UuidRoomTypeConverter {
@@ -18,15 +16,3 @@ class UuidRoomTypeConverter {
   }
 }
 
-class UuidMoshiAdapter {
-
-  @FromJson
-  fun toUuid(value: String?): UUID? {
-    return value?.let { UUID.fromString(it) }
-  }
-
-  @ToJson
-  fun fromUuid(uuid: UUID?): String? {
-    return uuid?.toString()
-  }
-}

--- a/app/src/main/java/org/simple/clinic/util/moshi/InstantMoshiAdapter.kt
+++ b/app/src/main/java/org/simple/clinic/util/moshi/InstantMoshiAdapter.kt
@@ -1,20 +1,20 @@
-package org.simple.clinic.util
+package org.simple.clinic.util.moshi
 
-import androidx.room.TypeConverter
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
 import org.threeten.bp.Instant
 
-class InstantRoomTypeConverter {
+class InstantMoshiAdapter {
 
-  @TypeConverter
+  @FromJson
   fun toInstant(value: String?): Instant? {
     return value?.let {
       return Instant.parse(value)
     }
   }
 
-  @TypeConverter
+  @ToJson
   fun fromInstant(instant: Instant?): String? {
     return instant?.toString()
   }
 }
-

--- a/app/src/main/java/org/simple/clinic/util/moshi/LocalDateMoshiAdapter.kt
+++ b/app/src/main/java/org/simple/clinic/util/moshi/LocalDateMoshiAdapter.kt
@@ -1,25 +1,25 @@
-package org.simple.clinic.util
+package org.simple.clinic.util.moshi
 
-import androidx.room.TypeConverter
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
 import org.threeten.bp.LocalDate
 import org.threeten.bp.format.DateTimeFormatter
 
-class LocalDateRoomTypeConverter {
+class LocalDateMoshiAdapter {
 
   companion object {
     private val formatter = DateTimeFormatter.ISO_DATE!!
   }
 
-  @TypeConverter
+  @FromJson
   fun toLocalDate(value: String?): LocalDate? {
     return value?.let {
       return formatter.parse(value, LocalDate::from)
     }
   }
 
-  @TypeConverter
+  @ToJson
   fun fromLocalDate(date: LocalDate?): String? {
     return date?.format(formatter)
   }
 }
-

--- a/app/src/main/java/org/simple/clinic/util/moshi/OptionalMoshiAdapter.kt
+++ b/app/src/main/java/org/simple/clinic/util/moshi/OptionalMoshiAdapter.kt
@@ -1,9 +1,12 @@
-package org.simple.clinic.util
+package org.simple.clinic.util.moshi
 
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
+import org.simple.clinic.util.Just
+import org.simple.clinic.util.None
+import org.simple.clinic.util.Optional
 
 import java.io.IOException
 import java.lang.reflect.ParameterizedType

--- a/app/src/main/java/org/simple/clinic/util/moshi/UuidMoshiAdapter.kt
+++ b/app/src/main/java/org/simple/clinic/util/moshi/UuidMoshiAdapter.kt
@@ -1,0 +1,18 @@
+package org.simple.clinic.util.moshi
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.util.UUID
+
+class UuidMoshiAdapter {
+
+  @FromJson
+  fun toUuid(value: String?): UUID? {
+    return value?.let { UUID.fromString(it) }
+  }
+
+  @ToJson
+  fun fromUuid(uuid: UUID?): String? {
+    return uuid?.toString()
+  }
+}

--- a/app/src/main/java/org/simple/clinic/util/preference/InstantRxPreferencesConverter.kt
+++ b/app/src/main/java/org/simple/clinic/util/preference/InstantRxPreferencesConverter.kt
@@ -1,0 +1,15 @@
+package org.simple.clinic.util.preference
+
+import com.f2prateek.rx.preferences2.Preference
+import org.threeten.bp.Instant
+
+class InstantRxPreferencesConverter : Preference.Converter<Instant> {
+
+  override fun deserialize(value: String): Instant {
+    return Instant.parse(value)
+  }
+
+  override fun serialize(value: Instant): String {
+    return value.toString()
+  }
+}

--- a/app/src/main/java/org/simple/clinic/util/preference/LocalePreferenceConverter.kt
+++ b/app/src/main/java/org/simple/clinic/util/preference/LocalePreferenceConverter.kt
@@ -1,4 +1,4 @@
-package org.simple.clinic.util
+package org.simple.clinic.util.preference
 
 import com.f2prateek.rx.preferences2.Preference
 import java.util.Locale

--- a/app/src/main/java/org/simple/clinic/util/preference/OptionalRxPreferencesConverter.kt
+++ b/app/src/main/java/org/simple/clinic/util/preference/OptionalRxPreferencesConverter.kt
@@ -1,6 +1,9 @@
-package org.simple.clinic.util
+package org.simple.clinic.util.preference
 
 import com.f2prateek.rx.preferences2.Preference
+import org.simple.clinic.util.Just
+import org.simple.clinic.util.None
+import org.simple.clinic.util.Optional
 
 class OptionalRxPreferencesConverter<T : Any>(private val valueConverter: Preference.Converter<T>) : Preference.Converter<Optional<T>> {
 

--- a/app/src/main/java/org/simple/clinic/util/preference/StringPreferenceConverter.kt
+++ b/app/src/main/java/org/simple/clinic/util/preference/StringPreferenceConverter.kt
@@ -1,4 +1,4 @@
-package org.simple.clinic.util
+package org.simple.clinic.util.preference
 
 import com.f2prateek.rx.preferences2.Preference
 

--- a/app/src/main/java/org/simple/clinic/util/room/InstantRoomTypeConverter.kt
+++ b/app/src/main/java/org/simple/clinic/util/room/InstantRoomTypeConverter.kt
@@ -1,4 +1,4 @@
-package org.simple.clinic.util
+package org.simple.clinic.util.room
 
 import androidx.room.TypeConverter
 import org.threeten.bp.Instant

--- a/app/src/main/java/org/simple/clinic/util/room/LocalDateRoomTypeConverter.kt
+++ b/app/src/main/java/org/simple/clinic/util/room/LocalDateRoomTypeConverter.kt
@@ -1,4 +1,4 @@
-package org.simple.clinic.util
+package org.simple.clinic.util.room
 
 import androidx.room.TypeConverter
 import org.threeten.bp.LocalDate

--- a/app/src/main/java/org/simple/clinic/util/room/RoomEnumTypeConverter.kt
+++ b/app/src/main/java/org/simple/clinic/util/room/RoomEnumTypeConverter.kt
@@ -1,4 +1,4 @@
-package org.simple.clinic.util
+package org.simple.clinic.util.room
 
 import androidx.room.TypeConverter
 

--- a/app/src/main/java/org/simple/clinic/util/room/SafeEnumTypeConverter.kt
+++ b/app/src/main/java/org/simple/clinic/util/room/SafeEnumTypeConverter.kt
@@ -1,4 +1,4 @@
-package org.simple.clinic.util
+package org.simple.clinic.util.room
 
 /**
  * This class is meant to provide a safe way to (de)serialise enum values from network responses

--- a/app/src/main/java/org/simple/clinic/util/room/UuidRoomTypeConverter.kt
+++ b/app/src/main/java/org/simple/clinic/util/room/UuidRoomTypeConverter.kt
@@ -1,4 +1,4 @@
-package org.simple.clinic.util
+package org.simple.clinic.util.room
 
 import androidx.room.TypeConverter
 import java.util.UUID

--- a/app/src/main/java/org/simple/clinic/widgets/BottomSheetActivity.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/BottomSheetActivity.kt
@@ -10,7 +10,12 @@ import androidx.appcompat.app.AppCompatActivity
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
 import kotterknife.bindView
 import org.simple.clinic.BuildConfig
+import org.simple.clinic.ClinicApp
 import org.simple.clinic.R
+import org.simple.clinic.di.AppComponent
+import org.simple.clinic.util.LocaleOverrideContextWrapper
+import java.util.Locale
+import javax.inject.Inject
 
 /**
  * We're using Activities as fake bottom sheets instead of BottomSheetDialog because we want
@@ -21,6 +26,9 @@ import org.simple.clinic.R
  * TODO: Add BottomSheet behavior to dismiss the sheet by dragging it downwards.
  */
 abstract class BottomSheetActivity : AppCompatActivity() {
+
+  @Inject
+  lateinit var locale: Locale
 
   private val backgroundView by bindView<View>(R.id.bottomsheet_background)
   private val contentContainer by bindView<ViewGroup>(R.id.bottomsheet_content_container)
@@ -49,7 +57,9 @@ abstract class BottomSheetActivity : AppCompatActivity() {
   }
 
   override fun attachBaseContext(baseContext: Context) {
-    super.attachBaseContext(ViewPumpContextWrapper.wrap(baseContext))
+    ClinicApp.appComponent.inject(this)
+    val contextWithOverridenLocale = LocaleOverrideContextWrapper.wrap(baseContext, locale)
+    super.attachBaseContext(ViewPumpContextWrapper.wrap(contextWithOverridenLocale))
   }
 
   override fun finish() {

--- a/app/src/test/java/org/simple/clinic/util/SafeEnumTypeAdapterTest.kt
+++ b/app/src/test/java/org/simple/clinic/util/SafeEnumTypeAdapterTest.kt
@@ -5,6 +5,7 @@ import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.simple.clinic.util.room.SafeEnumTypeAdapter
 
 @RunWith(JUnitParamsRunner::class)
 class SafeEnumTypeAdapterTest {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/167310696

This enables overriding of the language when opening an `Activity`. Currently, it will show the default language because the changing of the language is not yet implemented; it will be done in another PR.

To test this change, replace the `locale` being provided to the `LocaleOverrideContextWrapper` in any activity with `Locale.forLanguageTag("hi-IN")`.