### PR TITLE
Prepare tests to introduce Mobius fixture

### DIFF
--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryEffect.kt
@@ -1,0 +1,3 @@
+package org.simple.clinic.bp.entry
+
+sealed class BloodPressureEntryEffect

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryEffectHandler.kt
@@ -1,0 +1,12 @@
+package org.simple.clinic.bp.entry
+
+import io.reactivex.Observable
+import io.reactivex.ObservableTransformer
+
+object BloodPressureEntryEffectHandler {
+  fun create(): ObservableTransformer<BloodPressureEntryEffect, BloodPressureEntryEvent> {
+    return ObservableTransformer {
+      Observable.never<BloodPressureEntryEvent>()
+    }
+  }
+}

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryInit.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryInit.kt
@@ -1,0 +1,13 @@
+package org.simple.clinic.bp.entry
+
+import com.spotify.mobius.First
+import com.spotify.mobius.First.first
+import com.spotify.mobius.Init
+
+class BloodPressureEntryInit : Init<BloodPressureEntryModel, BloodPressureEntryEffect> {
+  override fun init(
+      model: BloodPressureEntryModel
+  ): First<BloodPressureEntryModel, BloodPressureEntryEffect> {
+    return first(model)
+  }
+}

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryModel.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryModel.kt
@@ -1,0 +1,4 @@
+package org.simple.clinic.bp.entry
+
+class BloodPressureEntryModel {
+}

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryUpdate.kt
@@ -1,0 +1,14 @@
+package org.simple.clinic.bp.entry
+
+import com.spotify.mobius.Next
+import com.spotify.mobius.Next.noChange
+import com.spotify.mobius.Update
+
+class BloodPressureEntryUpdate : Update<BloodPressureEntryModel, BloodPressureEntryEvent, BloodPressureEntryEffect> {
+  override fun update(
+      model: BloodPressureEntryModel,
+      event: BloodPressureEntryEvent
+  ): Next<BloodPressureEntryModel, BloodPressureEntryEffect> {
+    return noChange()
+  }
+}

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryViewRenderer.kt
@@ -1,0 +1,11 @@
+package org.simple.clinic.bp.entry
+
+import org.simple.clinic.mobius.ViewRenderer
+
+class BloodPressureEntryViewRenderer(
+    val ui: BloodPressureEntryUi
+) : ViewRenderer<BloodPressureEntryModel> {
+  override fun render(model: BloodPressureEntryModel) {
+    // Do nothing!
+  }
+}

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -211,7 +211,7 @@ class BloodPressureEntrySheetControllerTest {
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.never())
 
     uiEvents.run {
-      onNext(SheetCreated(openAs = openAs))
+      onNext(SheetCreated(openAs)) // TODO(rj) 15/Oct/19 - These need to be extracted into a function that can switch between new / update
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(""))
       onNext(DiastolicChanged(""))
@@ -231,7 +231,7 @@ class BloodPressureEntrySheetControllerTest {
       whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(bloodPressureMeasurement!!))
     }
 
-    uiEvents.onNext(SheetCreated(openAs))
+    uiEvents.onNext(SheetCreated(openAs)) // TODO(rj) 15/Oct/19 - These need to be extracted into a function that can switch between new / update
 
     if (openAs is Update) {
       val verify = verify(ui)
@@ -261,7 +261,7 @@ class BloodPressureEntrySheetControllerTest {
   ) {
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(PatientMocker.bp()))
 
-    uiEvents.onNext(SheetCreated(openAs))
+    uiEvents.onNext(SheetCreated(openAs)) // TODO(rj) 15/Oct/19 - These need to be extracted into a function that can switch between new / update
 
     if (shouldShowRemoveBpButton) {
       verify(ui).showRemoveBpButton()
@@ -285,7 +285,7 @@ class BloodPressureEntrySheetControllerTest {
   ) {
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(PatientMocker.bp()))
 
-    uiEvents.onNext(SheetCreated(openAs))
+    uiEvents.onNext(SheetCreated(openAs)) // TODO(rj) 15/Oct/19 - These need to be extracted into a function that can switch between new / update
 
     if (showEntryTitle) {
       verify(ui).showEnterNewBloodPressureTitle()
@@ -333,7 +333,7 @@ class BloodPressureEntrySheetControllerTest {
   ) {
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.never())
 
-    uiEvents.onNext(SheetCreated(openAs))
+    uiEvents.onNext(SheetCreated(openAs)) // TODO(rj) 15/Oct/19 - These need to be extracted into a function that can switch between new / update
     uiEvents.onNext(ScreenChanged(DATE_ENTRY))
     uiEvents.onNext(DayChanged("invalid"))
     uiEvents.onNext(MonthChanged("4"))
@@ -469,7 +469,7 @@ class BloodPressureEntrySheetControllerTest {
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.never())
 
     uiEvents.run {
-      onNext(SheetCreated(openAs = openAs))
+      onNext(SheetCreated(openAs)) // TODO(rj) 15/Oct/19 - These need to be extracted into a function that can switch between new / update
       onNext(ScreenChanged(DATE_ENTRY))
       onNext(DayChanged(day))
       onNext(MonthChanged(month))
@@ -520,7 +520,7 @@ class BloodPressureEntrySheetControllerTest {
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.never())
 
     uiEvents.run {
-      onNext(SheetCreated(openAs = openAs))
+      onNext(SheetCreated(openAs)) // TODO(rj) 15/Oct/19 - These need to be extracted into a function that can switch between new / update
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged("120"))
       onNext(DiastolicChanged("110"))

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -131,7 +131,7 @@ class BloodPressureEntrySheetControllerTest {
     "44|false"
   ])
   fun `when valid systolic value is entered, move cursor to diastolic field`(sampleSystolicBp: String, shouldMove: Boolean) {
-    sheetCreatedForNew()
+    sheetCreatedForNew(patientUuid)
     uiEvents.onNext(SystolicChanged(sampleSystolicBp))
     uiEvents.onNext(SystolicChanged(""))
     uiEvents.onNext(SystolicChanged(sampleSystolicBp))
@@ -174,7 +174,7 @@ class BloodPressureEntrySheetControllerTest {
 
   @Test
   fun `when systolic or diastolic values change, hide any error message`() {
-    sheetCreatedForNew()
+    sheetCreatedForNew(patientUuid)
     uiEvents.onNext(SystolicChanged("12"))
     uiEvents.onNext(SystolicChanged("120"))
     uiEvents.onNext(SystolicChanged("130"))
@@ -193,7 +193,7 @@ class BloodPressureEntrySheetControllerTest {
       systolic: String,
       diastolic: String
   ) {
-    sheetCreatedForNew()
+    sheetCreatedForNew(patientUuid)
     uiEvents.onNext(SystolicChanged(systolic))
     uiEvents.onNext(DiastolicChanged(diastolic))
     uiEvents.onNext(SaveClicked)
@@ -366,7 +366,7 @@ class BloodPressureEntrySheetControllerTest {
         .doReturn(Single.just(PatientMocker.bp()))
     whenever(appointmentRepository.markAppointmentsCreatedBeforeTodayAsVisited(patientUuid)).doReturn(Completable.complete())
 
-    sheetCreatedForNew()
+    sheetCreatedForNew(patientUuid)
     uiEvents.run {
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged("13"))
@@ -565,7 +565,7 @@ class BloodPressureEntrySheetControllerTest {
     val currentDate = LocalDate.of(2018, 4, 23)
     testUserClock.advanceBy(Duration.ofSeconds(currentDate.atStartOfDay().toEpochSecond(UTC)))
 
-    sheetCreatedForNew()
+    sheetCreatedForNew(patientUuid)
 
     verify(ui).setDate(
         dayOfMonth = "23",
@@ -601,7 +601,7 @@ class BloodPressureEntrySheetControllerTest {
   fun `whenever the BP sheet is shown to add a new BP, then show today's date`() {
     val today = LocalDate.now(testUserClock)
 
-    sheetCreatedForNew()
+    sheetCreatedForNew(patientUuid)
     uiEvents.onNext(ScreenChanged(BP_ENTRY))
 
     verify(ui).showDate(today)
@@ -644,7 +644,7 @@ class BloodPressureEntrySheetControllerTest {
     val systolic = 120.toString()
     val diastolic = 110.toString()
 
-    sheetCreatedForNew()
+    sheetCreatedForNew(patientUuid)
     with(uiEvents) {
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
@@ -668,7 +668,7 @@ class BloodPressureEntrySheetControllerTest {
     val systolic = 120.toString()
     val diastolic = 110.toString()
 
-    sheetCreatedForNew()
+    sheetCreatedForNew(patientUuid)
     with(uiEvents) {
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
@@ -747,7 +747,7 @@ class BloodPressureEntrySheetControllerTest {
     val diastolic = 110.toString()
     val localDate = LocalDate.of(1916, 5, 10)
 
-    sheetCreatedForNew()
+    sheetCreatedForNew(patientUuid)
     with(uiEvents) {
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
@@ -773,7 +773,7 @@ class BloodPressureEntrySheetControllerTest {
     val diastolic = 110.toString()
     val localDate = LocalDate.of(1916, 5, 10)
 
-    sheetCreatedForNew()
+    sheetCreatedForNew(patientUuid)
     with(uiEvents) {
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
@@ -804,7 +804,7 @@ class BloodPressureEntrySheetControllerTest {
     whenever(appointmentRepository.markAppointmentsCreatedBeforeTodayAsVisited(patientUuid)).doReturn(Completable.complete())
     whenever(patientRepository.compareAndUpdateRecordedAt(any(), any())).doReturn(Completable.complete())
 
-    sheetCreatedForNew()
+    sheetCreatedForNew(patientUuid)
     with(uiEvents) {
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
@@ -899,7 +899,7 @@ class BloodPressureEntrySheetControllerTest {
     verifyNoMoreInteractions(ui)
   }
 
-  private fun sheetCreatedForNew() {
+  private fun sheetCreatedForNew(patientUuid: UUID) {
     uiEvents.onNext(SheetCreated(New(patientUuid)))
   }
 

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -14,6 +14,7 @@ import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.rxkotlin.ofType
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
@@ -48,6 +49,7 @@ import org.simple.clinic.util.toUtcInstant
 import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result.Invalid.InvalidPattern
+import org.simple.mobius.migration.MobiusTestFixture
 import org.threeten.bp.Duration
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
@@ -92,12 +94,24 @@ class BloodPressureEntrySheetControllerTest {
       userSession = userSession,
       facilityRepository = facilityRepository)
 
+  private lateinit var fixture: MobiusTestFixture<BloodPressureEntryModel, BloodPressureEntryEvent, BloodPressureEntryEffect>
+  private val viewRenderer = BloodPressureEntryViewRenderer(ui)
+
   @Before
   fun setUp() {
     RxJavaPlugins.setIoSchedulerHandler { Schedulers.trampoline() }
 
     whenever(userSession.requireLoggedInUser()).doReturn(userSubject)
     whenever(facilityRepository.currentFacility(user)).doReturn(Observable.just(facility))
+
+    fixture = MobiusTestFixture(
+        uiEvents.ofType(),
+        BloodPressureEntryModel(),
+        BloodPressureEntryInit(),
+        BloodPressureEntryUpdate(),
+        BloodPressureEntryEffectHandler.create(),
+        viewRenderer::render
+    )
 
     uiEvents
         .compose(controller)

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -306,7 +306,7 @@ class BloodPressureEntrySheetControllerTest {
     val bloodPressure = PatientMocker.bp()
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(bloodPressure))
 
-    sheetCreatedForUpdate(bloodPressure)
+    sheetCreatedForUpdate(bloodPressure.uuid)
     uiEvents.onNext(RemoveClicked)
 
     verify(ui).showConfirmRemoveBloodPressureDialog(bloodPressure.uuid)
@@ -318,7 +318,7 @@ class BloodPressureEntrySheetControllerTest {
     val bloodPressureSubject = BehaviorSubject.createDefault<BloodPressureMeasurement>(bloodPressure)
     whenever(bloodPressureRepository.measurement(bloodPressure.uuid)).doReturn(bloodPressureSubject)
 
-    sheetCreatedForUpdate(bloodPressure)
+    sheetCreatedForUpdate(bloodPressure.uuid)
     verify(ui, never()).setBpSavedResultAndFinish()
 
     bloodPressureSubject.onNext(bloodPressure.copy(deletedAt = Instant.now()))
@@ -413,7 +413,7 @@ class BloodPressureEntrySheetControllerTest {
     whenever(bloodPressureRepository.updateMeasurement(any())).doReturn(Completable.complete())
     whenever(patientRepository.compareAndUpdateRecordedAt(any(), any())).doReturn(Completable.complete())
 
-    sheetCreatedForUpdate(existingBp)
+    sheetCreatedForUpdate(existingBp.uuid)
     uiEvents.run {
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged("120"))
@@ -581,7 +581,7 @@ class BloodPressureEntrySheetControllerTest {
 
     whenever(bloodPressureRepository.measurement(existingBp.uuid)).doReturn(Observable.just(existingBp, existingBp))
 
-    sheetCreatedForUpdate(existingBp)
+    sheetCreatedForUpdate(existingBp.uuid)
 
     verify(ui, times(1)).setDate(
         dayOfMonth = "23",
@@ -622,7 +622,7 @@ class BloodPressureEntrySheetControllerTest {
     val recordedDate = bp.recordedAt.toLocalDateAtZone(testUserClock.zone)
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(bp))
 
-    sheetCreatedForUpdate(bp)
+    sheetCreatedForUpdate(bp.uuid)
     uiEvents.onNext(ScreenChanged(BP_ENTRY))
 
     verify(ui).showDate(recordedDate)
@@ -695,7 +695,7 @@ class BloodPressureEntrySheetControllerTest {
     val bp = PatientMocker.bp(patientUuid = patientUuid)
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(bp))
 
-    sheetCreatedForUpdate(bp)
+    sheetCreatedForUpdate(bp.uuid)
     with(uiEvents) {
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
@@ -722,7 +722,7 @@ class BloodPressureEntrySheetControllerTest {
     val bp = PatientMocker.bp(patientUuid = patientUuid)
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(bp))
 
-    sheetCreatedForUpdate(bp)
+    sheetCreatedForUpdate(bp.uuid)
     with(uiEvents) {
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
@@ -864,7 +864,7 @@ class BloodPressureEntrySheetControllerTest {
 
     userSubject.onNext(newUser)
 
-    sheetCreatedForUpdate(existingBp)
+    sheetCreatedForUpdate(existingBp.uuid)
     with(uiEvents) {
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
@@ -903,7 +903,7 @@ class BloodPressureEntrySheetControllerTest {
     uiEvents.onNext(SheetCreated(New(patientUuid)))
   }
 
-  private fun sheetCreatedForUpdate(existingBp: BloodPressureMeasurement) {
-    uiEvents.onNext(SheetCreated(Update(existingBp.uuid)))
+  private fun sheetCreatedForUpdate(existingBpUuid: UUID) {
+    uiEvents.onNext(SheetCreated(Update(existingBpUuid)))
   }
 }

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -306,7 +306,7 @@ class BloodPressureEntrySheetControllerTest {
     val bloodPressure = PatientMocker.bp()
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(bloodPressure))
 
-    uiEvents.onNext(SheetCreated(Update(bloodPressure.uuid)))
+    sheetCreatedForUpdate(bloodPressure)
     uiEvents.onNext(RemoveClicked)
 
     verify(ui).showConfirmRemoveBloodPressureDialog(bloodPressure.uuid)
@@ -318,7 +318,7 @@ class BloodPressureEntrySheetControllerTest {
     val bloodPressureSubject = BehaviorSubject.createDefault<BloodPressureMeasurement>(bloodPressure)
     whenever(bloodPressureRepository.measurement(bloodPressure.uuid)).doReturn(bloodPressureSubject)
 
-    uiEvents.onNext(SheetCreated(Update(bpUuid = bloodPressure.uuid)))
+    sheetCreatedForUpdate(bloodPressure)
     verify(ui, never()).setBpSavedResultAndFinish()
 
     bloodPressureSubject.onNext(bloodPressure.copy(deletedAt = Instant.now()))
@@ -413,8 +413,8 @@ class BloodPressureEntrySheetControllerTest {
     whenever(bloodPressureRepository.updateMeasurement(any())).doReturn(Completable.complete())
     whenever(patientRepository.compareAndUpdateRecordedAt(any(), any())).doReturn(Completable.complete())
 
+    sheetCreatedForUpdate(existingBp)
     uiEvents.run {
-      onNext(SheetCreated(Update(existingBp.uuid)))
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged("120"))
       onNext(DiastolicChanged("110"))
@@ -581,7 +581,7 @@ class BloodPressureEntrySheetControllerTest {
 
     whenever(bloodPressureRepository.measurement(existingBp.uuid)).doReturn(Observable.just(existingBp, existingBp))
 
-    uiEvents.onNext(SheetCreated(Update(existingBp.uuid)))
+    sheetCreatedForUpdate(existingBp)
 
     verify(ui, times(1)).setDate(
         dayOfMonth = "23",
@@ -622,7 +622,7 @@ class BloodPressureEntrySheetControllerTest {
     val recordedDate = bp.recordedAt.toLocalDateAtZone(testUserClock.zone)
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(bp))
 
-    uiEvents.onNext(SheetCreated(Update(bpUuid = bp.uuid)))
+    sheetCreatedForUpdate(bp)
     uiEvents.onNext(ScreenChanged(BP_ENTRY))
 
     verify(ui).showDate(recordedDate)
@@ -695,8 +695,8 @@ class BloodPressureEntrySheetControllerTest {
     val bp = PatientMocker.bp(patientUuid = patientUuid)
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(bp))
 
+    sheetCreatedForUpdate(bp)
     with(uiEvents) {
-      onNext(SheetCreated(Update(bp.uuid)))
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
       onNext(DiastolicChanged(diastolic))
@@ -722,8 +722,8 @@ class BloodPressureEntrySheetControllerTest {
     val bp = PatientMocker.bp(patientUuid = patientUuid)
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(bp))
 
+    sheetCreatedForUpdate(bp)
     with(uiEvents) {
-      onNext(SheetCreated(Update(bp.uuid)))
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
       onNext(DiastolicChanged(diastolic))
@@ -864,8 +864,8 @@ class BloodPressureEntrySheetControllerTest {
 
     userSubject.onNext(newUser)
 
+    sheetCreatedForUpdate(existingBp)
     with(uiEvents) {
-      onNext(SheetCreated(Update(existingBp.uuid)))
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
       onNext(DiastolicChanged(diastolic))
@@ -901,5 +901,9 @@ class BloodPressureEntrySheetControllerTest {
 
   private fun sheetCreatedForNew() {
     uiEvents.onNext(SheetCreated(New(patientUuid)))
+  }
+
+  private fun sheetCreatedForUpdate(existingBp: BloodPressureMeasurement) {
+    uiEvents.onNext(SheetCreated(Update(existingBp.uuid)))
   }
 }

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -131,7 +131,7 @@ class BloodPressureEntrySheetControllerTest {
     "44|false"
   ])
   fun `when valid systolic value is entered, move cursor to diastolic field`(sampleSystolicBp: String, shouldMove: Boolean) {
-    uiEvents.onNext(SheetCreated(New(patientUuid)))
+    sheetCreatedForNew()
     uiEvents.onNext(SystolicChanged(sampleSystolicBp))
     uiEvents.onNext(SystolicChanged(""))
     uiEvents.onNext(SystolicChanged(sampleSystolicBp))
@@ -174,7 +174,7 @@ class BloodPressureEntrySheetControllerTest {
 
   @Test
   fun `when systolic or diastolic values change, hide any error message`() {
-    uiEvents.onNext(SheetCreated(New(patientUuid)))
+    sheetCreatedForNew()
     uiEvents.onNext(SystolicChanged("12"))
     uiEvents.onNext(SystolicChanged("120"))
     uiEvents.onNext(SystolicChanged("130"))
@@ -193,7 +193,7 @@ class BloodPressureEntrySheetControllerTest {
       systolic: String,
       diastolic: String
   ) {
-    uiEvents.onNext(SheetCreated(New(patientUuid)))
+    sheetCreatedForNew()
     uiEvents.onNext(SystolicChanged(systolic))
     uiEvents.onNext(DiastolicChanged(diastolic))
     uiEvents.onNext(SaveClicked)
@@ -366,8 +366,8 @@ class BloodPressureEntrySheetControllerTest {
         .doReturn(Single.just(PatientMocker.bp()))
     whenever(appointmentRepository.markAppointmentsCreatedBeforeTodayAsVisited(patientUuid)).doReturn(Completable.complete())
 
+    sheetCreatedForNew()
     uiEvents.run {
-      onNext(SheetCreated(openAs = New(patientUuid)))
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged("13"))
       onNext(DiastolicChanged("11"))
@@ -565,7 +565,7 @@ class BloodPressureEntrySheetControllerTest {
     val currentDate = LocalDate.of(2018, 4, 23)
     testUserClock.advanceBy(Duration.ofSeconds(currentDate.atStartOfDay().toEpochSecond(UTC)))
 
-    uiEvents.onNext(SheetCreated(New(patientUuid)))
+    sheetCreatedForNew()
 
     verify(ui).setDate(
         dayOfMonth = "23",
@@ -589,17 +589,19 @@ class BloodPressureEntrySheetControllerTest {
         twoDigitYear = "18")
   }
 
-  // TODO(rj): 2019-10-10 This supplier has only one parameter. This can be removed and params can be made as part of the actual test.
   @Suppress("Unused")
-  private fun `params for OpenAs types`(): List<Any> {
-    return listOf(New(patientUuid), Update(UUID.fromString("d9d0050a-7fa1-4293-868a-7640ebc93cd8")))
+  private fun `params for OpenAs types`(): List<OpenAs> {
+    return listOf(
+        New(patientUuid),
+        Update(UUID.fromString("d9d0050a-7fa1-4293-868a-7640ebc93cd8"))
+    )
   }
 
   @Test
   fun `whenever the BP sheet is shown to add a new BP, then show today's date`() {
     val today = LocalDate.now(testUserClock)
 
-    uiEvents.onNext(SheetCreated(New(patientUuid)))
+    sheetCreatedForNew()
     uiEvents.onNext(ScreenChanged(BP_ENTRY))
 
     verify(ui).showDate(today)
@@ -642,8 +644,8 @@ class BloodPressureEntrySheetControllerTest {
     val systolic = 120.toString()
     val diastolic = 110.toString()
 
+    sheetCreatedForNew()
     with(uiEvents) {
-      onNext(SheetCreated(New(patientUuid)))
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
       onNext(DiastolicChanged(diastolic))
@@ -666,8 +668,8 @@ class BloodPressureEntrySheetControllerTest {
     val systolic = 120.toString()
     val diastolic = 110.toString()
 
+    sheetCreatedForNew()
     with(uiEvents) {
-      onNext(SheetCreated(New(patientUuid)))
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
       onNext(DiastolicChanged(diastolic))
@@ -745,8 +747,8 @@ class BloodPressureEntrySheetControllerTest {
     val diastolic = 110.toString()
     val localDate = LocalDate.of(1916, 5, 10)
 
+    sheetCreatedForNew()
     with(uiEvents) {
-      onNext(SheetCreated(New(patientUuid)))
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
       onNext(DiastolicChanged(diastolic))
@@ -771,8 +773,8 @@ class BloodPressureEntrySheetControllerTest {
     val diastolic = 110.toString()
     val localDate = LocalDate.of(1916, 5, 10)
 
+    sheetCreatedForNew()
     with(uiEvents) {
-      onNext(SheetCreated(New(patientUuid)))
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
       onNext(DiastolicChanged(diastolic))
@@ -802,8 +804,8 @@ class BloodPressureEntrySheetControllerTest {
     whenever(appointmentRepository.markAppointmentsCreatedBeforeTodayAsVisited(patientUuid)).doReturn(Completable.complete())
     whenever(patientRepository.compareAndUpdateRecordedAt(any(), any())).doReturn(Completable.complete())
 
+    sheetCreatedForNew()
     with(uiEvents) {
-      onNext(SheetCreated(New(patientUuid)))
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(systolic))
       onNext(DiastolicChanged(diastolic))
@@ -895,5 +897,9 @@ class BloodPressureEntrySheetControllerTest {
     verify(ui).setBpSavedResultAndFinish()
 
     verifyNoMoreInteractions(ui)
+  }
+
+  private fun sheetCreatedForNew() {
+    uiEvents.onNext(SheetCreated(New(patientUuid)))
   }
 }

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -210,8 +210,8 @@ class BloodPressureEntrySheetControllerTest {
   ) {
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.never())
 
+    sheetCreated(openAs)
     uiEvents.run {
-      onNext(SheetCreated(openAs)) // TODO(rj) 15/Oct/19 - These need to be extracted into a function that can switch between new / update
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged(""))
       onNext(DiastolicChanged(""))
@@ -231,7 +231,7 @@ class BloodPressureEntrySheetControllerTest {
       whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(bloodPressureMeasurement!!))
     }
 
-    uiEvents.onNext(SheetCreated(openAs)) // TODO(rj) 15/Oct/19 - These need to be extracted into a function that can switch between new / update
+    sheetCreated(openAs)
 
     if (openAs is Update) {
       val verify = verify(ui)
@@ -261,7 +261,7 @@ class BloodPressureEntrySheetControllerTest {
   ) {
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(PatientMocker.bp()))
 
-    uiEvents.onNext(SheetCreated(openAs)) // TODO(rj) 15/Oct/19 - These need to be extracted into a function that can switch between new / update
+    sheetCreated(openAs)
 
     if (shouldShowRemoveBpButton) {
       verify(ui).showRemoveBpButton()
@@ -285,7 +285,7 @@ class BloodPressureEntrySheetControllerTest {
   ) {
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(PatientMocker.bp()))
 
-    uiEvents.onNext(SheetCreated(openAs)) // TODO(rj) 15/Oct/19 - These need to be extracted into a function that can switch between new / update
+    sheetCreated(openAs)
 
     if (showEntryTitle) {
       verify(ui).showEnterNewBloodPressureTitle()
@@ -333,7 +333,7 @@ class BloodPressureEntrySheetControllerTest {
   ) {
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.never())
 
-    uiEvents.onNext(SheetCreated(openAs)) // TODO(rj) 15/Oct/19 - These need to be extracted into a function that can switch between new / update
+    sheetCreated(openAs)
     uiEvents.onNext(ScreenChanged(DATE_ENTRY))
     uiEvents.onNext(DayChanged("invalid"))
     uiEvents.onNext(MonthChanged("4"))
@@ -468,8 +468,8 @@ class BloodPressureEntrySheetControllerTest {
 
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.never())
 
+    sheetCreated(openAs)
     uiEvents.run {
-      onNext(SheetCreated(openAs)) // TODO(rj) 15/Oct/19 - These need to be extracted into a function that can switch between new / update
       onNext(ScreenChanged(DATE_ENTRY))
       onNext(DayChanged(day))
       onNext(MonthChanged(month))
@@ -519,8 +519,8 @@ class BloodPressureEntrySheetControllerTest {
   ) {
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.never())
 
+    sheetCreated(openAs)
     uiEvents.run {
-      onNext(SheetCreated(openAs)) // TODO(rj) 15/Oct/19 - These need to be extracted into a function that can switch between new / update
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged("120"))
       onNext(DiastolicChanged("110"))
@@ -905,5 +905,13 @@ class BloodPressureEntrySheetControllerTest {
 
   private fun sheetCreatedForUpdate(existingBpUuid: UUID) {
     uiEvents.onNext(SheetCreated(Update(existingBpUuid)))
+  }
+
+  private fun sheetCreated(openAs: OpenAs) {
+    when(openAs) {
+      is New -> sheetCreatedForNew(openAs.patientUuid)
+      is Update -> sheetCreatedForUpdate(openAs.bpUuid)
+      else -> throw IllegalStateException("Unknown `openAs`: $openAs")
+    }
   }
 }

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -306,7 +306,7 @@ class BloodPressureEntrySheetControllerTest {
     val bloodPressure = PatientMocker.bp()
     whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.just(bloodPressure))
 
-    uiEvents.onNext(SheetCreated(openAs = Update(bloodPressure.uuid)))
+    uiEvents.onNext(SheetCreated(Update(bloodPressure.uuid)))
     uiEvents.onNext(RemoveClicked)
 
     verify(ui).showConfirmRemoveBloodPressureDialog(bloodPressure.uuid)
@@ -318,7 +318,7 @@ class BloodPressureEntrySheetControllerTest {
     val bloodPressureSubject = BehaviorSubject.createDefault<BloodPressureMeasurement>(bloodPressure)
     whenever(bloodPressureRepository.measurement(bloodPressure.uuid)).doReturn(bloodPressureSubject)
 
-    uiEvents.onNext(SheetCreated(openAs = Update(bpUuid = bloodPressure.uuid)))
+    uiEvents.onNext(SheetCreated(Update(bpUuid = bloodPressure.uuid)))
     verify(ui, never()).setBpSavedResultAndFinish()
 
     bloodPressureSubject.onNext(bloodPressure.copy(deletedAt = Instant.now()))
@@ -414,7 +414,7 @@ class BloodPressureEntrySheetControllerTest {
     whenever(patientRepository.compareAndUpdateRecordedAt(any(), any())).doReturn(Completable.complete())
 
     uiEvents.run {
-      onNext(SheetCreated(openAs = Update(existingBp.uuid)))
+      onNext(SheetCreated(Update(existingBp.uuid)))
       onNext(ScreenChanged(BP_ENTRY))
       onNext(SystolicChanged("120"))
       onNext(DiastolicChanged("110"))


### PR DESCRIPTION
The `SheetCreated` events are instrumental in bringing in Mobius. I have extracted these event dispatches as a function so that we can create and call the `fixture.start()` function in either `New` or `Update` mode.