### PR TITLE
Migrate more functionality to Mobius

### DIFF
--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryEffect.kt
@@ -41,3 +41,5 @@ object Dismiss : BloodPressureEntryEffect()
 object HideDateErrorMessage : BloodPressureEntryEffect()
 
 data class ShowBpValidationError(val result: Validation) : BloodPressureEntryEffect()
+
+object ShowDateEntryScreen : BloodPressureEntryEffect()

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryEffect.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.bp.entry
 
+import org.simple.clinic.bp.entry.BpValidator.Validation
 import org.threeten.bp.Instant
 import java.util.UUID
 
@@ -38,3 +39,5 @@ data class ShowConfirmRemoveBloodPressureDialog(
 object Dismiss : BloodPressureEntryEffect()
 
 object HideDateErrorMessage : BloodPressureEntryEffect()
+
+data class ShowBpValidationError(val result: Validation) : BloodPressureEntryEffect()

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryEffect.kt
@@ -1,10 +1,21 @@
 package org.simple.clinic.bp.entry
 
+import org.threeten.bp.Instant
 import java.util.UUID
 
 sealed class BloodPressureEntryEffect
 
-object PrefillDateForNewEntry : BloodPressureEntryEffect()
+data class PrefillDate(val date: Instant? = null) : BloodPressureEntryEffect() {
+  companion object {
+    fun forNewEntry(): PrefillDate {
+      return PrefillDate()
+    }
+
+    fun forUpdateEntry(date: Instant): PrefillDate {
+      return PrefillDate(date)
+    }
+  }
+}
 
 object HideBpErrorMessage : BloodPressureEntryEffect()
 

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryEffectHandler.kt
@@ -40,6 +40,7 @@ object BloodPressureEntryEffectHandler {
         .addAction(Dismiss::class.java, ui::dismiss, schedulersProvider.ui())
         .addAction(HideDateErrorMessage::class.java, ui::hideDateErrorMessage, schedulersProvider.ui())
         .addConsumer(ShowBpValidationError::class.java, { showBpValidationError(ui, it) }, schedulersProvider.ui())
+        .addAction(ShowDateEntryScreen::class.java, ui::showDateEntryScreen, schedulersProvider.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryEffectHandler.kt
@@ -20,7 +20,7 @@ object BloodPressureEntryEffectHandler {
   ): ObservableTransformer<BloodPressureEntryEffect, BloodPressureEntryEvent> {
     return RxMobius
         .subtypeEffectHandler<BloodPressureEntryEffect, BloodPressureEntryEvent>()
-        .addAction(PrefillDateForNewEntry::class.java, { prefillDateForNewEntry(ui, userClock, inputDatePaddingCharacter) }, schedulersProvider.ui())
+        .addConsumer(PrefillDate::class.java, { prefillDate(ui, it.date, userClock, inputDatePaddingCharacter) }, schedulersProvider.ui())
         .addAction(HideBpErrorMessage::class.java, ui::hideBpErrorMessage, schedulersProvider.ui())
         .addAction(ChangeFocusToDiastolic::class.java, ui::changeFocusToDiastolic, schedulersProvider.ui())
         .addAction(ChangeFocusToSystolic::class.java, ui::changeFocusToSystolic, schedulersProvider.ui())
@@ -33,14 +33,16 @@ object BloodPressureEntryEffectHandler {
         .build()
   }
 
-  private fun prefillDateForNewEntry(
+  private fun prefillDate(
       ui: BloodPressureEntryUi,
+      instant: Instant?,
       userClock: UserClock,
-      inputDatePaddingCharacter: UserInputDatePaddingCharacter
+      paddingCharacter: UserInputDatePaddingCharacter
   ) {
-    val date = Instant.now(userClock).toLocalDateAtZone(userClock.zone)
-    val dayString = date.dayOfMonth.toString().padStart(length = 2, padChar = inputDatePaddingCharacter.value)
-    val monthString = date.monthValue.toString().padStart(length = 2, padChar = inputDatePaddingCharacter.value)
+    val prefillInstant = instant ?: Instant.now(userClock)
+    val date = prefillInstant.toLocalDateAtZone(userClock.zone)
+    val dayString = date.dayOfMonth.toString().padStart(length = 2, padChar = paddingCharacter.value)
+    val monthString = date.monthValue.toString().padStart(length = 2, padChar = paddingCharacter.value)
     val yearString = date.year.toString().substring(startIndex = 2, endIndex = 4)
     ui.setDateOnInputFields(dayString, monthString, yearString)
     ui.showDateOnDateButton(date)

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryInit.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryInit.kt
@@ -11,7 +11,7 @@ class BloodPressureEntryInit : Init<BloodPressureEntryModel, BloodPressureEntryE
       model: BloodPressureEntryModel
   ): First<BloodPressureEntryModel, BloodPressureEntryEffect> {
     return when {
-      model.openAs is New -> first(model, setOf(PrefillDateForNewEntry))
+      model.openAs is New -> first(model, setOf(PrefillDate.forNewEntry()))
       model.openAs is Update -> first(model, setOf(FetchBloodPressureMeasurement(model.openAs.bpUuid) as BloodPressureEntryEffect))
       else -> first(model)
     }

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
@@ -109,6 +109,9 @@ class BloodPressureEntrySheet : BottomSheetActivity(), BloodPressureEntryUi {
   lateinit var crashReporter: CrashReporter
 
   @Inject
+  lateinit var bpValidator: BpValidator
+
+  @Inject
   lateinit var bloodPressureRepository: BloodPressureRepository
 
   private val viewRenderer = BloodPressureEntryViewRenderer(this)
@@ -126,7 +129,7 @@ class BloodPressureEntrySheet : BottomSheetActivity(), BloodPressureEntryUi {
         events.ofType(),
         defaultModel,
         BloodPressureEntryInit(),
-        BloodPressureEntryUpdate(),
+        BloodPressureEntryUpdate(bpValidator),
         effectHandler,
         viewRenderer::render,
         crashReporter

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
@@ -69,7 +69,6 @@ class BloodPressureEntrySheetController @Inject constructor(
 
     return Observable.mergeArray(
         showBpValidationErrors(replayedEvents),
-        proceedToDateEntryWhenBpEntryIsDone(replayedEvents),
         showBpEntry(replayedEvents),
         closeSheetWhenEditedBpIsDeleted(replayedEvents),
         showDateValidationErrors(replayedEvents),
@@ -122,22 +121,6 @@ class BloodPressureEntrySheetController @Inject constructor(
             }.exhaustive()
           }
         }
-  }
-
-  private fun proceedToDateEntryWhenBpEntryIsDone(events: Observable<UiEvent>): Observable<UiChange> {
-    val screenChanges = events
-        .ofType<ScreenChanged>()
-        .map { it.type }
-
-    val validations = events
-        .ofType<BloodPressureReadingsValidated>()
-        .map { it.result }
-
-    return events
-        .ofType<BloodPressureDateClicked>()
-        .withLatestFrom(screenChanges, validations)
-        .filter { (_, screen, result) -> screen == BP_ENTRY && result is Success }
-        .map { Ui::showDateEntryScreen }
   }
 
   private fun showBpEntry(events: Observable<UiEvent>): Observable<UiChange> {

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
@@ -168,9 +168,10 @@ class BloodPressureEntrySheetController @Inject constructor(
   }
 
   private fun validateBpInput() = ObservableTransformer<UiEvent, UiEvent> { events ->
-    val screenChanges = events
+    val bpEntryScreenChanges = events
         .ofType<ScreenChanged>()
         .map { it.type }
+        .filter { it == BP_ENTRY }
 
     val systolicChanges = events
         .ofType<SystolicChanged>()
@@ -180,8 +181,7 @@ class BloodPressureEntrySheetController @Inject constructor(
         .ofType<DiastolicChanged>()
         .map { it.diastolic }
 
-    val validations = Observables.combineLatest(systolicChanges, diastolicChanges, screenChanges)
-        .filter { (_, _, screen) -> screen == BP_ENTRY }
+    val validations = Observables.combineLatest(systolicChanges, diastolicChanges, bpEntryScreenChanges)
         .map { (systolic, diastolic, _) -> bpValidator.validate(systolic, diastolic) }
         .map(::BloodPressureReadingsValidated)
 

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
@@ -11,13 +11,6 @@ import org.simple.clinic.ReplayUntilScreenIsDestroyed
 import org.simple.clinic.bp.BloodPressureRepository
 import org.simple.clinic.bp.entry.BloodPressureEntrySheet.ScreenType.BP_ENTRY
 import org.simple.clinic.bp.entry.BloodPressureEntrySheet.ScreenType.DATE_ENTRY
-import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorDiastolicEmpty
-import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorDiastolicTooHigh
-import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorDiastolicTooLow
-import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorSystolicEmpty
-import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorSystolicLessThanDiastolic
-import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorSystolicTooHigh
-import org.simple.clinic.bp.entry.BpValidator.Validation.ErrorSystolicTooLow
 import org.simple.clinic.bp.entry.BpValidator.Validation.Success
 import org.simple.clinic.bp.entry.OpenAs.New
 import org.simple.clinic.bp.entry.OpenAs.Update
@@ -30,7 +23,6 @@ import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.UserClock
 import org.simple.clinic.util.UserInputDatePaddingCharacter
-import org.simple.clinic.util.exhaustive
 import org.simple.clinic.util.toUtcInstant
 import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
@@ -68,7 +60,6 @@ class BloodPressureEntrySheetController @Inject constructor(
         .replay()
 
     return Observable.mergeArray(
-        showBpValidationErrors(replayedEvents),
         showBpEntry(replayedEvents),
         showDateValidationErrors(replayedEvents),
         dismissSheetWhenBpIsSaved(replayedEvents)
@@ -95,31 +86,6 @@ class BloodPressureEntrySheetController @Inject constructor(
         .map { DateToPrefillCalculated(it) }
 
     events.mergeWith(prefillDateEvent)
-  }
-
-  private fun showBpValidationErrors(events: Observable<UiEvent>): Observable<UiChange> {
-    val saveClicks = events.ofType<SaveClicked>()
-
-    val validations = events
-        .ofType<BloodPressureReadingsValidated>()
-        .map { it.result }
-
-    return saveClicks
-        .withLatestFrom(validations)
-        .map { (_, result) ->
-          { ui: Ui ->
-            when (result) {
-              is ErrorSystolicLessThanDiastolic -> ui.showSystolicLessThanDiastolicError()
-              is ErrorSystolicTooHigh -> ui.showSystolicHighError()
-              is ErrorSystolicTooLow -> ui.showSystolicLowError()
-              is ErrorDiastolicTooHigh -> ui.showDiastolicHighError()
-              is ErrorDiastolicTooLow -> ui.showDiastolicLowError()
-              is ErrorSystolicEmpty -> ui.showSystolicEmptyError()
-              is ErrorDiastolicEmpty -> ui.showDiastolicEmptyError()
-              is Success -> { /* Nothing to do here. */ }
-            }.exhaustive()
-          }
-        }
   }
 
   private fun showBpEntry(events: Observable<UiEvent>): Observable<UiChange> {

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
@@ -100,9 +100,7 @@ class BloodPressureEntrySheetController @Inject constructor(
   }
 
   private fun showBpValidationErrors(events: Observable<UiEvent>): Observable<UiChange> {
-    val saveClicks = Observable.merge(
-        events.ofType<BloodPressureDateClicked>(),
-        events.ofType<SaveClicked>())
+    val saveClicks = events.ofType<SaveClicked>()
 
     val validations = events
         .ofType<BloodPressureReadingsValidated>()
@@ -120,9 +118,7 @@ class BloodPressureEntrySheetController @Inject constructor(
               is ErrorDiastolicTooLow -> ui.showDiastolicLowError()
               is ErrorSystolicEmpty -> ui.showSystolicEmptyError()
               is ErrorDiastolicEmpty -> ui.showDiastolicEmptyError()
-              is Success -> {
-                // Nothing to do here.
-              }
+              is Success -> { /* Nothing to do here. */ }
             }.exhaustive()
           }
         }

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
@@ -68,7 +68,6 @@ class BloodPressureEntrySheetController @Inject constructor(
         .replay()
 
     return Observable.mergeArray(
-        prefillDate(replayedEvents),
         showBpValidationErrors(replayedEvents),
         proceedToDateEntryWhenBpEntryIsDone(replayedEvents),
         showBpEntry(replayedEvents),
@@ -98,28 +97,6 @@ class BloodPressureEntrySheetController @Inject constructor(
         .map { DateToPrefillCalculated(it) }
 
     events.mergeWith(prefillDateEvent)
-  }
-
-  private fun prefillDate(events: Observable<UiEvent>): Observable<UiChange> {
-    val localDates = events
-        .ofType<DateToPrefillCalculated>()
-        .map { it.date }
-
-    val updates = events
-        .ofType<SheetCreated>()
-        .filter { it.openAs is Update }
-
-    return Observables
-        .combineLatest(localDates, updates) { date, _ -> date }
-        .map { date ->
-          { ui: Ui ->
-            val dayString = date.dayOfMonth.toString().padStart(length = 2, padChar = inputDatePaddingCharacter.value)
-            val monthString = date.monthValue.toString().padStart(length = 2, padChar = inputDatePaddingCharacter.value)
-            val yearString = date.year.toString().substring(startIndex = 2, endIndex = 4)
-            ui.setDateOnInputFields(dayString, monthString, yearString)
-            ui.showDateOnDateButton(date)
-          }
-        }.take(1)
   }
 
   private fun showBpValidationErrors(events: Observable<UiEvent>): Observable<UiChange> {

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetController.kt
@@ -70,7 +70,6 @@ class BloodPressureEntrySheetController @Inject constructor(
     return Observable.mergeArray(
         showBpValidationErrors(replayedEvents),
         showBpEntry(replayedEvents),
-        closeSheetWhenEditedBpIsDeleted(replayedEvents),
         showDateValidationErrors(replayedEvents),
         dismissSheetWhenBpIsSaved(replayedEvents)
     )
@@ -165,20 +164,6 @@ class BloodPressureEntrySheetController @Inject constructor(
         .map(::BloodPressureReadingsValidated)
 
     events.mergeWith(validations)
-  }
-
-  private fun closeSheetWhenEditedBpIsDeleted(events: Observable<UiEvent>): Observable<UiChange> {
-    val bloodPressureMeasurementUuidStream = events
-        .ofType<SheetCreated>()
-        .map { it.openAs }
-        .ofType<Update>()
-        .map { it.bpUuid }
-
-    return bloodPressureMeasurementUuidStream
-        .flatMap(bloodPressureRepository::measurement)
-        .filter { it.deletedAt != null }
-        .take(1)
-        .map { { ui: Ui -> ui.setBpSavedResultAndFinish() } }
   }
 
   private fun combineDateInputs() = ObservableTransformer<UiEvent, UiEvent> { events ->

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryUpdate.kt
@@ -4,10 +4,13 @@ import com.spotify.mobius.Next
 import com.spotify.mobius.Next.noChange
 import com.spotify.mobius.Update
 import org.simple.clinic.bp.entry.BloodPressureEntrySheet.ScreenType.BP_ENTRY
+import org.simple.clinic.bp.entry.BpValidator.Validation.Success
 import org.simple.clinic.mobius.dispatch
 import org.simple.clinic.mobius.next
 
-class BloodPressureEntryUpdate : Update<BloodPressureEntryModel, BloodPressureEntryEvent, BloodPressureEntryEffect> {
+class BloodPressureEntryUpdate(
+    private val bpValidator: BpValidator
+) : Update<BloodPressureEntryModel, BloodPressureEntryEvent, BloodPressureEntryEffect> {
   override fun update(
       model: BloodPressureEntryModel,
       event: BloodPressureEntryEvent
@@ -62,6 +65,15 @@ class BloodPressureEntryUpdate : Update<BloodPressureEntryModel, BloodPressureEn
       is MonthChanged -> dispatch(HideDateErrorMessage)
 
       is YearChanged -> dispatch(HideDateErrorMessage)
+
+      is BloodPressureDateClicked -> {
+        val result = bpValidator.validate(model.systolic, model.diastolic)
+        return if (result is Success) {
+          noChange()
+        } else {
+          dispatch(ShowBpValidationError(result))
+        }
+      }
 
       else -> noChange()
     }

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryUpdate.kt
@@ -75,6 +75,15 @@ class BloodPressureEntryUpdate(
         }
       }
 
+      is SaveClicked -> {
+        val result = bpValidator.validate(model.systolic, model.diastolic)
+        return if (result !is Success) {
+          dispatch(ShowBpValidationError(result))
+        } else {
+          noChange()
+        }
+      }
+
       else -> noChange()
     }
   }

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryUpdate.kt
@@ -37,7 +37,12 @@ class BloodPressureEntryUpdate : Update<BloodPressureEntryModel, BloodPressureEn
             .withSystolic(systolicString)
             .withDiastolic(diastolicString)
 
-        next(modelWithSystolicAndDiastolic, SetSystolic(systolicString), SetDiastolic(diastolicString))
+        next(
+            modelWithSystolicAndDiastolic,
+            SetSystolic(systolicString),
+            SetDiastolic(diastolicString),
+            PrefillDate.forUpdateEntry(bloodPressureMeasurement.recordedAt)
+        )
       }
 
       is RemoveClicked -> dispatch(

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntryUpdate.kt
@@ -69,7 +69,7 @@ class BloodPressureEntryUpdate(
       is BloodPressureDateClicked -> {
         val result = bpValidator.validate(model.systolic, model.diastolic)
         return if (result is Success) {
-          noChange()
+          dispatch(ShowDateEntryScreen)
         } else {
           dispatch(ShowBpValidationError(result))
         }

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntryEffectHandlerTest.kt
@@ -28,7 +28,7 @@ class BloodPressureEntryEffectHandlerTest {
     // when
     val entryDate = LocalDate.of(1992, 6, 7)
     userClock.setDate(LocalDate.of(1992, 6, 7), UTC)
-    testCase.dispatch(PrefillDateForNewEntry)
+    testCase.dispatch(PrefillDate.forNewEntry())
 
     // then
     verify(ui).setDateOnInputFields("07", "06", "92")

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -179,7 +179,6 @@ class BloodPressureEntrySheetControllerTest {
     verify(ui, times(5)).hideBpErrorMessage()
   }
 
-  // TODO Migrate logic to Mobius
   @Test
   @Parameters(value = [
     ",",
@@ -198,7 +197,6 @@ class BloodPressureEntrySheetControllerTest {
     verify(ui, never()).setBpSavedResultAndFinish()
   }
 
-  // TODO Migrate logic to Mobius
   @Test
   @Parameters(method = "params for OpenAs and bp validation errors")
   fun `when BP entry is active, BP readings are invalid and save is clicked then date entry should not be shown`(

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -518,7 +518,6 @@ class BloodPressureEntrySheetControllerTest {
     verify(ui, atLeastOnce()).hideDateErrorMessage()
   }
 
-  // TODO Migrate logic to Mobius
   @Test
   @Parameters(method = "params for OpenAs types")
   fun `when BP entry is active, BP readings are valid and next arrow is pressed then date entry should be shown`(

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -570,6 +570,21 @@ class BloodPressureEntrySheetControllerTest {
   }
 
   @Test
+  fun `when BP entry is active and BP readings are invalid and blood pressure date is clicked, then show BP validation errors`() {
+    whenever(bloodPressureRepository.measurement(any())).doReturn(Observable.never())
+
+    sheetCreatedForNew(patientUuid)
+    uiEvents.run {
+      onNext(ScreenChanged(BP_ENTRY))
+      onNext(SystolicChanged(""))
+      onNext(DiastolicChanged("80"))
+      onNext(BloodPressureDateClicked)
+    }
+
+    verify(ui).showSystolicEmptyError()
+  }
+
+  @Test
   fun `when screen is opened for a new BP, then the date should be prefilled with the current date`() {
     val currentDate = LocalDate.of(2018, 4, 23)
     testUserClock.setDate(currentDate, UTC)

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -968,7 +968,7 @@ class BloodPressureEntrySheetControllerTest {
         uiEvents.ofType(),
         defaultModel,
         BloodPressureEntryInit(),
-        BloodPressureEntryUpdate(),
+        BloodPressureEntryUpdate(bpValidator),
         effectHandler,
         viewRenderer::render
     ).also { it.start() }

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -17,7 +17,6 @@ import io.reactivex.Single
 import io.reactivex.plugins.RxJavaPlugins
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.schedulers.Schedulers
-import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
@@ -54,7 +53,6 @@ import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result.Invalid.InvalidPattern
 import org.simple.mobius.migration.MobiusTestFixture
-import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
 import org.threeten.bp.ZoneOffset.UTC
 import org.threeten.bp.format.DateTimeFormatter
@@ -309,20 +307,6 @@ class BloodPressureEntrySheetControllerTest {
     uiEvents.onNext(RemoveClicked)
 
     verify(ui).showConfirmRemoveBloodPressureDialog(bloodPressure.uuid)
-  }
-
-  // TODO Migrate logic to Mobius
-  @Test
-  fun `when a blood pressure being edited is removed, the sheet should be closed`() {
-    val bloodPressure = PatientMocker.bp()
-    val bloodPressureSubject = BehaviorSubject.createDefault<BloodPressureMeasurement>(bloodPressure)
-    whenever(bloodPressureRepository.measurement(bloodPressure.uuid)).doReturn(bloodPressureSubject)
-
-    sheetCreatedForUpdate(bloodPressure.uuid)
-    verify(ui, never()).setBpSavedResultAndFinish()
-
-    bloodPressureSubject.onNext(bloodPressure.copy(deletedAt = Instant.now()))
-    verify(ui).setBpSavedResultAndFinish()
   }
 
   // TODO Migrate logic to Mobius

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntrySheetControllerTest.kt
@@ -569,7 +569,6 @@ class BloodPressureEntrySheetControllerTest {
     verify(ui).dismiss()
   }
 
-  // TODO Migrate logic to Mobius
   @Test
   fun `when screen is opened for a new BP, then the date should be prefilled with the current date`() {
     val currentDate = LocalDate.of(2018, 4, 23)
@@ -583,7 +582,6 @@ class BloodPressureEntrySheetControllerTest {
         twoDigitYear = "18")
   }
 
-  // TODO Migrate logic to Mobius
   @Test
   fun `when screen is opened for updating an existing BP, then the date should be prefilled with the BP's recorded date`() {
     val recordedAtDate = LocalDate.of(2018, 4, 23)
@@ -627,7 +625,6 @@ class BloodPressureEntrySheetControllerTest {
     verifyNoMoreInteractions(ui)
   }
 
-  // TODO Migrate logic to Mobius
   @Test
   fun `whenever the BP sheet is shown to update an existing BP, then show the BP date`() {
     val bp = PatientMocker.bp(patientUuid = patientUuid)


### PR DESCRIPTION
- Prefill date when updating a BP entry
- Move BP validation when date button / save button is clicked
- Remove auto-dismiss BP entry sheet when synced BP was removed
- Go to date entry screen