### PR TITLE
Provide alternate injection method for screens

### DIFF
--- a/app/src/main/java/org/simple/clinic/activity/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/activity/TheActivity.kt
@@ -77,7 +77,7 @@ class TheActivity : AppCompatActivity() {
     val contextWithRouter = wrapContextWithRouter(contextWithOverriddenLocale)
     val contextWithInjectorProvider = InjectorProviderContextWrapper.wrap(
         contextWithRouter,
-        mapOf(OnboardingScreenInjector.INJECTOR_KEY to component)
+        mapOf(OnboardingScreenInjector::class.java to component)
     )
     super.attachBaseContext(ViewPumpContextWrapper.wrap(contextWithInjectorProvider))
   }

--- a/app/src/main/java/org/simple/clinic/activity/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/activity/TheActivity.kt
@@ -16,8 +16,10 @@ import org.simple.clinic.R
 import org.simple.clinic.activity.ActivityLifecycle.Destroyed
 import org.simple.clinic.activity.ActivityLifecycle.Started
 import org.simple.clinic.analytics.Analytics
+import org.simple.clinic.di.InjectorProviderContextWrapper
 import org.simple.clinic.home.patients.LoggedOutOnOtherDeviceDialog
 import org.simple.clinic.login.applock.AppLockScreenKey
+import org.simple.clinic.onboarding.OnboardingScreenInjector
 import org.simple.clinic.registration.phone.RegistrationPhoneScreenKey
 import org.simple.clinic.router.ScreenResultBus
 import org.simple.clinic.router.screen.ActivityPermissionResult
@@ -73,7 +75,11 @@ class TheActivity : AppCompatActivity() {
     setupDiGraph()
     val contextWithOverriddenLocale = LocaleOverrideContextWrapper.wrap(baseContext, locale)
     val contextWithRouter = wrapContextWithRouter(contextWithOverriddenLocale)
-    super.attachBaseContext(ViewPumpContextWrapper.wrap(contextWithRouter))
+    val contextWithInjectorProvider = InjectorProviderContextWrapper.wrap(
+        contextWithRouter,
+        mapOf(OnboardingScreenInjector.INJECTOR_KEY to component)
+    )
+    super.attachBaseContext(ViewPumpContextWrapper.wrap(contextWithInjectorProvider))
   }
 
   private fun wrapContextWithRouter(baseContext: Context): Context {

--- a/app/src/main/java/org/simple/clinic/activity/TheActivityComponent.kt
+++ b/app/src/main/java/org/simple/clinic/activity/TheActivityComponent.kt
@@ -40,7 +40,7 @@ import org.simple.clinic.login.applock.ConfirmResetPinDialog
 import org.simple.clinic.login.pin.LoginPinScreen
 import org.simple.clinic.medicalhistory.newentry.NewMedicalHistoryScreen
 import org.simple.clinic.newentry.PatientEntryScreen
-import org.simple.clinic.onboarding.OnboardingScreen
+import org.simple.clinic.onboarding.OnboardingScreenInjector
 import org.simple.clinic.recentpatient.RecentPatientsScreen
 import org.simple.clinic.recentpatientsview.RecentPatientsView
 import org.simple.clinic.registration.confirmpin.RegistrationConfirmPinScreen
@@ -73,7 +73,7 @@ import org.threeten.bp.Instant
 import javax.inject.Named
 
 @Subcomponent(modules = [TheActivityModule::class])
-interface TheActivityComponent {
+interface TheActivityComponent: OnboardingScreenInjector {
 
   fun inject(target: TheActivity)
   fun inject(target: HomeScreen)
@@ -81,7 +81,6 @@ interface TheActivityComponent {
   fun inject(target: LoginPinScreen)
   fun inject(target: AppLockScreen)
   fun inject(target: OverdueScreen)
-  fun inject(target: OnboardingScreen)
   fun inject(target: PatientEntryScreen)
   fun inject(target: PatientSearchScreen)
   fun inject(target: PatientSearchResultsScreen)

--- a/app/src/main/java/org/simple/clinic/di/InjectorProviderContextWrapper.kt
+++ b/app/src/main/java/org/simple/clinic/di/InjectorProviderContextWrapper.kt
@@ -11,11 +11,15 @@ class InjectorProviderContextWrapper(
   companion object {
     fun wrap(
         base: Context,
-        injectors: Map<String, Any>
-    ): Context = InjectorProviderContextWrapper(base, injectors)
+        injectors: Map<Class<*>, Any>
+    ): Context = InjectorProviderContextWrapper(base, injectors.mapKeys { it.key.name })
   }
 
   override fun getSystemService(name: String): Any? {
-    return if (name !in injectors) super.getSystemService(name) else injectors.getValue(name)
+    return if (name in injectors) injectors.getValue(name) else super.getSystemService(name)
   }
 }
+
+
+@Suppress("UNCHECKED_CAST")
+inline fun <reified T> Context.injector() = getSystemService(T::class.java.name) as T

--- a/app/src/main/java/org/simple/clinic/di/InjectorProviderContextWrapper.kt
+++ b/app/src/main/java/org/simple/clinic/di/InjectorProviderContextWrapper.kt
@@ -1,0 +1,21 @@
+package org.simple.clinic.di
+
+import android.content.Context
+import android.content.ContextWrapper
+
+class InjectorProviderContextWrapper(
+    base: Context,
+    private val injectors: Map<String, Any>
+) : ContextWrapper(base) {
+
+  companion object {
+    fun wrap(
+        base: Context,
+        injectors: Map<String, Any>
+    ): Context = InjectorProviderContextWrapper(base, injectors)
+  }
+
+  override fun getSystemService(name: String): Any? {
+    return if (name !in injectors) super.getSystemService(name) else injectors.getValue(name)
+  }
+}

--- a/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreen.kt
@@ -10,6 +10,7 @@ import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
 import kotlinx.android.synthetic.main.screen_onboarding.view.*
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.platform.crash.CrashReporter
 import org.simple.clinic.registration.phone.RegistrationPhoneScreenKey
@@ -17,7 +18,6 @@ import org.simple.clinic.router.screen.RouterDirection
 import org.simple.clinic.router.screen.ScreenRouter
 import org.simple.clinic.util.clamp
 import org.simple.clinic.util.scheduler.SchedulersProvider
-import org.simple.clinic.util.service
 import org.simple.clinic.util.unsafeLazy
 import javax.inject.Inject
 import javax.inject.Named
@@ -60,7 +60,7 @@ class OnboardingScreen(context: Context, attributeSet: AttributeSet) : RelativeL
       return
     }
 
-    context.service<OnboardingScreenInjector>(OnboardingScreenInjector.INJECTOR_KEY).inject(this)
+    context.injector<OnboardingScreenInjector>().inject(this)
 
     fadeLogoWithContentScroll()
     delegate.prepare()

--- a/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreen.kt
@@ -10,7 +10,6 @@ import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
 import kotlinx.android.synthetic.main.screen_onboarding.view.*
 import org.simple.clinic.ReportAnalyticsEvents
-import org.simple.clinic.activity.TheActivity
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.platform.crash.CrashReporter
 import org.simple.clinic.registration.phone.RegistrationPhoneScreenKey
@@ -18,6 +17,7 @@ import org.simple.clinic.router.screen.RouterDirection
 import org.simple.clinic.router.screen.ScreenRouter
 import org.simple.clinic.util.clamp
 import org.simple.clinic.util.scheduler.SchedulersProvider
+import org.simple.clinic.util.service
 import org.simple.clinic.util.unsafeLazy
 import javax.inject.Inject
 import javax.inject.Named
@@ -60,7 +60,7 @@ class OnboardingScreen(context: Context, attributeSet: AttributeSet) : RelativeL
       return
     }
 
-    TheActivity.component.inject(this)
+    context.service<OnboardingScreenInjector>(OnboardingScreenInjector.INJECTOR_KEY).inject(this)
 
     fadeLogoWithContentScroll()
     delegate.prepare()

--- a/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreenInjector.kt
+++ b/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreenInjector.kt
@@ -1,5 +1,9 @@
 package org.simple.clinic.onboarding
 
 interface OnboardingScreenInjector {
+  companion object {
+    const val INJECTOR_KEY = "OnboardingScreenInjector"
+  }
+
   fun inject(target: OnboardingScreen)
 }

--- a/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreenInjector.kt
+++ b/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreenInjector.kt
@@ -1,9 +1,5 @@
 package org.simple.clinic.onboarding
 
 interface OnboardingScreenInjector {
-  companion object {
-    const val INJECTOR_KEY = "OnboardingScreenInjector"
-  }
-
   fun inject(target: OnboardingScreen)
 }

--- a/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreenInjector.kt
+++ b/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreenInjector.kt
@@ -1,0 +1,5 @@
+package org.simple.clinic.onboarding
+
+interface OnboardingScreenInjector {
+  fun inject(target: OnboardingScreen)
+}

--- a/app/src/main/java/org/simple/clinic/util/KotlinFoo.kt
+++ b/app/src/main/java/org/simple/clinic/util/KotlinFoo.kt
@@ -1,11 +1,6 @@
 package org.simple.clinic.util
 
-import android.content.Context
-
 // Forces when blocks to be exhaustive.
 fun Unit.exhaustive() {}
 
 fun <T> unsafeLazy(initializer: () -> T) = lazy(LazyThreadSafetyMode.NONE, initializer)
-
-@Suppress("UNCHECKED_CAST")
-fun <T> Context.service(name: String) = getSystemService(name) as T

--- a/app/src/main/java/org/simple/clinic/util/KotlinFoo.kt
+++ b/app/src/main/java/org/simple/clinic/util/KotlinFoo.kt
@@ -1,6 +1,11 @@
 package org.simple.clinic.util
 
+import android.content.Context
+
 // Forces when blocks to be exhaustive.
 fun Unit.exhaustive() {}
 
 fun <T> unsafeLazy(initializer: () -> T) = lazy(LazyThreadSafetyMode.NONE, initializer)
+
+@Suppress("UNCHECKED_CAST")
+fun <T> Context.service(name: String) = getSystemService(name) as T


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/169253555

The current injection method for screens does not allow us to use alternate injectors for a given Screen and couples it tightly to a specific activity. This PR is meant to give us a way to abstract the injector from the screen so we can move a Screen to a different activity in stages.