### PR TITLE
Add support for targeting API level 29

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/TestData.kt
+++ b/app/src/androidTest/java/org/simple/clinic/TestData.kt
@@ -62,7 +62,7 @@ import javax.inject.Inject
 import kotlin.reflect.KClass
 
 private fun <T : Enum<T>> randomOfEnum(enumClass: KClass<T>): T {
-  return enumClass.java.enumConstants.asList().shuffled().first()
+  return enumClass.java.enumConstants!!.asList().shuffled().first()
 }
 
 @AppScope

--- a/app/src/debug/java/org/simple/clinic/widgets/ProxySystemKeyboardEnterToImeOption.kt
+++ b/app/src/debug/java/org/simple/clinic/widgets/ProxySystemKeyboardEnterToImeOption.kt
@@ -25,7 +25,7 @@ class ProxySystemKeyboardEnterToImeOption : Interceptor {
 
   override fun intercept(chain: Interceptor.Chain): InflateResult {
     val inflateResult = chain.proceed(chain.request())
-    val inflatedView = inflateResult.view()
+    val inflatedView = inflateResult.view
 
     if (inflatedView is EditText) {
       inflatedView.setOnKeyListener(enterToImeMapper)

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
@@ -117,7 +117,7 @@ class BloodPressureEntrySheet : BottomSheetActivity(), BloodPressureEntryUi {
   private val viewRenderer = BloodPressureEntryViewRenderer(this)
 
   private val delegate by unsafeLazy {
-    val defaultModel = when (val openAs = intent.extras!!.getParcelable(KEY_OPEN_AS) as OpenAs) {
+    val defaultModel = when (val openAs = intent.extras!!.getParcelable<OpenAs>(KEY_OPEN_AS)!!) {
       is New -> BloodPressureEntryModel.newBloodPressureEntry(New(openAs.patientUuid))
       is Update -> BloodPressureEntryModel.updateBloodPressureEntry(Update(openAs.bpUuid))
     }
@@ -201,7 +201,7 @@ class BloodPressureEntrySheet : BottomSheetActivity(), BloodPressureEntryUi {
   }
 
   private fun sheetCreates(): Observable<UiEvent> {
-    val openAs = intent.extras!!.getParcelable(KEY_OPEN_AS) as OpenAs
+    val openAs = intent.extras!!.getParcelable<OpenAs>(KEY_OPEN_AS)!!
     return Observable
         .just(SheetCreated(openAs))
         // TODO: Update: Now that we've moved to ReplayUntilScreenIsDestroyed, is this still required?

--- a/app/src/main/java/org/simple/clinic/home/overdue/appointmentreminder/AppointmentReminderSheet.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/appointmentreminder/AppointmentReminderSheet.kt
@@ -27,7 +27,7 @@ class AppointmentReminderSheet : BottomSheetActivity() {
 
     fun intent(context: Context, appointmentUuid: UUID) =
         Intent(context, AppointmentReminderSheet::class.java)
-            .putExtra(AppointmentReminderSheet.KEY_APPOINTMENT_UUID, appointmentUuid)!!
+            .putExtra(KEY_APPOINTMENT_UUID, appointmentUuid)!!
   }
 
   private val possibleDates = listOf(
@@ -83,7 +83,7 @@ class AppointmentReminderSheet : BottomSheetActivity() {
   }
 
   private fun sheetCreates(): Observable<UiEvent> {
-    val uuid = intent.extras.getSerializable(AppointmentReminderSheet.KEY_APPOINTMENT_UUID) as UUID
+    val uuid = intent.extras!!.getSerializable(KEY_APPOINTMENT_UUID) as UUID
     return Observable.just(AppointmentReminderSheetCreated(initialIndex = 6, appointmentUuid = uuid))
   }
 

--- a/app/src/main/java/org/simple/clinic/home/patients/LoggedOutOnOtherDeviceDialog.kt
+++ b/app/src/main/java/org/simple/clinic/home/patients/LoggedOutOnOtherDeviceDialog.kt
@@ -27,7 +27,7 @@ class LoggedOutOnOtherDeviceDialog : AppCompatDialogFragment() {
         .setTitle(R.string.patients_loggedoutalert_title)
         .setMessage(R.string.patients_loggedoutalert_message)
         .setPositiveButton(R.string.patients_loggedoutalert_dismiss) { _, _ ->
-          val view = dialog.ownerActivity.findViewById<View>(android.R.id.content)
+          val view = dialog.ownerActivity!!.findViewById<View>(android.R.id.content)
           Snackbar.make(view, R.string.patients_you_are_now_logged_in, Snackbar.LENGTH_LONG).show()
         }
         .create()

--- a/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheet.kt
+++ b/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheet.kt
@@ -77,7 +77,7 @@ class ScheduleAppointmentSheet : BottomSheetActivity() {
   }
 
   private fun screenCreates(): Observable<UiEvent> {
-    val patientUuid = intent.extras.getSerializable(KEY_PATIENT_UUID) as UUID
+    val patientUuid = intent.extras!!.getSerializable(KEY_PATIENT_UUID) as UUID
     return Observable.just(ScheduleAppointmentSheetCreated(
         patientUuid = patientUuid
     ))

--- a/app/src/test/java/org/simple/clinic/patient/PatientMocker.kt
+++ b/app/src/test/java/org/simple/clinic/patient/PatientMocker.kt
@@ -32,7 +32,7 @@ import java.util.UUID
 import kotlin.reflect.KClass
 
 private fun <T : Enum<T>> randomOfEnum(enumClass: KClass<T>): T {
-  return enumClass.java.enumConstants.asList().shuffled().first()
+  return enumClass.java.enumConstants!!.asList().shuffled().first()
 }
 
 object PatientMocker {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.versions = [
       minSdk              : 21,
-      compileSdk          : 28,
+      compileSdk          : 29,
       kotlin              : '1.3.50',
       supportLib          : '1.0.0',
       recyclerView        : '1.0.0',
@@ -46,7 +46,7 @@ buildscript {
       sqliteAndroid       : '3.24.0',
       playServicesAuth    : '16.0.1',
       playServicesVision  : '16.2.0',
-      viewPump            : '1.0.0',
+      viewPump            : '2.0.3',
       heap                : '1.2.0',
       pinEntryEditText    : '2.0.6',
       fbShimmer           : '0.3.0',


### PR DESCRIPTION
# Changes
- Bump target SDK to 29
- This version added a bunch of nullability and type parameters to the platform, so had to fix compilation errors related to those
- Bumped version of the ViewPump library to the latest version since the version we were using did not support API level 29 and would crash.

Tested on the following API levels:
- Lollipop (21)
- Android 10 (29)