### PR TITLE
Hide the Edit button in patient summary until the profile is populated

### DIFF
--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -26,7 +26,6 @@ import io.reactivex.subjects.PublishSubject
 import kotlinx.android.parcel.Parcelize
 import kotterknife.bindView
 import org.simple.clinic.R
-import org.simple.clinic.main.TheActivity
 import org.simple.clinic.analytics.Analytics
 import org.simple.clinic.bindUiToController
 import org.simple.clinic.bp.entry.BloodPressureEntrySheet
@@ -34,6 +33,7 @@ import org.simple.clinic.drugs.selection.PrescribedDrugsScreenKey
 import org.simple.clinic.editpatient.EditPatientScreenKey
 import org.simple.clinic.editpatient_old.PatientEditScreenKey
 import org.simple.clinic.home.HomeScreenKey
+import org.simple.clinic.main.TheActivity
 import org.simple.clinic.mobius.migration.Architecture
 import org.simple.clinic.mobius.migration.MobiusMigrationConfig
 import org.simple.clinic.patient.DateOfBirth
@@ -399,6 +399,10 @@ class PatientSummaryScreen(context: Context, attrs: AttributeSet) : RelativeLayo
 
   fun hideLinkIdWithPatientView() {
     linkIdWithPatientView.hide { linkIdWithPatientView.visibility = View.GONE }
+  }
+
+  fun showEditButton() {
+    editButton.visibility = View.VISIBLE
   }
 }
 

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreenController.kt
@@ -127,7 +127,14 @@ class PatientSummaryScreenController @Inject constructor(
 
     return Observables
         .combineLatest(sharedPatients, addresses, phoneNumbers, bpPassport, ::PatientSummaryProfile)
-        .map { { ui: Ui -> ui.populatePatientProfile(it) } }
+        .map { patientSummaryProfile -> { ui: Ui -> showPatientSummaryProfile(ui, patientSummaryProfile) } }
+  }
+
+  private fun showPatientSummaryProfile(ui: Ui, patientSummaryProfile: PatientSummaryProfile) {
+    with(ui) {
+      populatePatientProfile(patientSummaryProfile)
+      showEditButton()
+    }
   }
 
   private fun mergeWithPatientSummaryChanges(): ObservableTransformer<UiEvent, UiEvent> {

--- a/app/src/main/res/layout/screen_patient_summary.xml
+++ b/app/src/main/res/layout/screen_patient_summary.xml
@@ -35,6 +35,8 @@
       android:layout_marginEnd="@dimen/spacing_8"
       android:text="@string/patientsummary_edit"
       android:textAppearance="@style/Clinic.V2.TextAppearance.Button2.White100"
+      android:visibility="invisible"
+      tools:visibility="visible"
       tools:ignore="RelativeOverlap" />
 
     <RelativeLayout

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenControllerTest.kt
@@ -156,6 +156,7 @@ class PatientSummaryScreenControllerTest {
     uiEvents.onNext(PatientSummaryScreenCreated(patientUuid, openIntention = intention, screenCreatedTimestamp = Instant.now(utcClock)))
 
     verify(screen).populatePatientProfile(PatientSummaryProfile(patient, address, phoneNumber, optionalBpPassport))
+    verify(screen).showEditButton()
   }
 
   @Suppress("Unused")


### PR DESCRIPTION
This fixes these crashes (i.e. Kotlin NPE when **Edit** button is clicked before the profile is populated).

https://sentry.io/organizations/resolve-to-save-lives/issues/searches/2487760/?project=1212614&statsPeriod=14d