### PR TITLE
Add more comprehensive types to the http error resolver

### DIFF
--- a/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
+++ b/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
@@ -10,6 +10,7 @@ import org.simple.clinic.sync.SyncGroup
 import org.simple.clinic.sync.SyncInterval
 import org.simple.clinic.util.ErrorResolver
 import org.simple.clinic.util.ResolvedError.NetworkRelated
+import org.simple.clinic.util.ResolvedError.ServerError
 import org.simple.clinic.util.ResolvedError.Unauthorized
 import org.simple.clinic.util.ResolvedError.Unexpected
 import org.simple.clinic.util.exhaustive
@@ -34,7 +35,7 @@ class RemoteConfigSync @Inject constructor(
   private fun logError(error: Throwable) {
     val resolvedError = ErrorResolver.resolve(error)
     when (resolvedError) {
-      is Unexpected -> {
+      is Unexpected, is ServerError -> {
         crashReporter.report(resolvedError.actualCause)
         Timber.e(resolvedError.actualCause)
       }

--- a/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
+++ b/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
@@ -11,7 +11,7 @@ import org.simple.clinic.sync.SyncInterval
 import org.simple.clinic.util.ErrorResolver
 import org.simple.clinic.util.ResolvedError.NetworkRelated
 import org.simple.clinic.util.ResolvedError.ServerError
-import org.simple.clinic.util.ResolvedError.Unauthorized
+import org.simple.clinic.util.ResolvedError.Unauthenticated
 import org.simple.clinic.util.ResolvedError.Unexpected
 import org.simple.clinic.util.exhaustive
 import timber.log.Timber
@@ -39,7 +39,7 @@ class RemoteConfigSync @Inject constructor(
         crashReporter.report(resolvedError.actualCause)
         Timber.e(resolvedError.actualCause)
       }
-      is NetworkRelated, is Unauthorized -> Timber.e(error)
+      is NetworkRelated, is Unauthenticated -> Timber.e(error)
     }.exhaustive()
   }
 

--- a/app/src/main/java/org/simple/clinic/sync/DataSync.kt
+++ b/app/src/main/java/org/simple/clinic/sync/DataSync.kt
@@ -8,6 +8,7 @@ import org.simple.clinic.platform.crash.CrashReporter
 import org.simple.clinic.util.ErrorResolver
 import org.simple.clinic.util.ResolvedError
 import org.simple.clinic.util.ResolvedError.NetworkRelated
+import org.simple.clinic.util.ResolvedError.ServerError
 import org.simple.clinic.util.ResolvedError.Unauthorized
 import org.simple.clinic.util.ResolvedError.Unexpected
 import org.simple.clinic.util.exhaustive
@@ -61,14 +62,12 @@ class DataSync @Inject constructor(
     syncErrors.onNext(resolvedError)
 
     when (resolvedError) {
-      is Unexpected -> {
+      is Unexpected, is ServerError -> {
         Timber.i("(breadcrumb) Reporting to sentry. Error: $e. Resolved error: $resolvedError")
         crashReporter.report(resolvedError.actualCause)
         Timber.e(resolvedError.actualCause)
       }
-      is NetworkRelated, is Unauthorized -> {
-        Timber.e(e)
-      }
+      is NetworkRelated, is Unauthorized -> Timber.e(e)
     }.exhaustive()
   }
 

--- a/app/src/main/java/org/simple/clinic/sync/DataSync.kt
+++ b/app/src/main/java/org/simple/clinic/sync/DataSync.kt
@@ -9,7 +9,7 @@ import org.simple.clinic.util.ErrorResolver
 import org.simple.clinic.util.ResolvedError
 import org.simple.clinic.util.ResolvedError.NetworkRelated
 import org.simple.clinic.util.ResolvedError.ServerError
-import org.simple.clinic.util.ResolvedError.Unauthorized
+import org.simple.clinic.util.ResolvedError.Unauthenticated
 import org.simple.clinic.util.ResolvedError.Unexpected
 import org.simple.clinic.util.exhaustive
 import timber.log.Timber
@@ -67,7 +67,7 @@ class DataSync @Inject constructor(
         crashReporter.report(resolvedError.actualCause)
         Timber.e(resolvedError.actualCause)
       }
-      is NetworkRelated, is Unauthorized -> Timber.e(e)
+      is NetworkRelated, is Unauthenticated -> Timber.e(e)
     }.exhaustive()
   }
 

--- a/app/src/main/java/org/simple/clinic/sync/indicator/SyncIndicatorView.kt
+++ b/app/src/main/java/org/simple/clinic/sync/indicator/SyncIndicatorView.kt
@@ -14,8 +14,8 @@ import com.jakewharton.rxbinding2.view.RxView
 import io.reactivex.Observable
 import kotterknife.bindView
 import org.simple.clinic.R
-import org.simple.clinic.main.TheActivity
 import org.simple.clinic.bindUiToController
+import org.simple.clinic.main.TheActivity
 import org.simple.clinic.sync.indicator.SyncIndicatorState.ConnectToSync
 import org.simple.clinic.sync.indicator.SyncIndicatorState.SyncPending
 import org.simple.clinic.sync.indicator.SyncIndicatorState.Synced
@@ -23,6 +23,7 @@ import org.simple.clinic.sync.indicator.SyncIndicatorState.Syncing
 import org.simple.clinic.sync.indicator.dialog.SyncIndicatorFailureDialog
 import org.simple.clinic.util.ResolvedError
 import org.simple.clinic.util.ResolvedError.NetworkRelated
+import org.simple.clinic.util.ResolvedError.ServerError
 import org.simple.clinic.util.ResolvedError.Unauthorized
 import org.simple.clinic.util.ResolvedError.Unexpected
 import org.simple.clinic.widgets.ScreenDestroyed
@@ -95,7 +96,8 @@ class SyncIndicatorView(context: Context, attrs: AttributeSet) : LinearLayout(co
   fun showErrorDialog(errorType: ResolvedError) {
     val message = when (errorType) {
       is NetworkRelated -> context.getString(R.string.syncindicator_dialog_error_network)
-      is Unexpected, is Unauthorized -> context.getString(R.string.syncindicator_dialog_error_server)
+      // TODO(vs): 2019-10-31 Add a separate error message for server errors
+      is Unexpected, is Unauthorized, is ServerError -> context.getString(R.string.syncindicator_dialog_error_server)
     }
     SyncIndicatorFailureDialog.show(fragmentManager = activity.supportFragmentManager, message = message)
   }

--- a/app/src/main/java/org/simple/clinic/sync/indicator/SyncIndicatorView.kt
+++ b/app/src/main/java/org/simple/clinic/sync/indicator/SyncIndicatorView.kt
@@ -24,7 +24,7 @@ import org.simple.clinic.sync.indicator.dialog.SyncIndicatorFailureDialog
 import org.simple.clinic.util.ResolvedError
 import org.simple.clinic.util.ResolvedError.NetworkRelated
 import org.simple.clinic.util.ResolvedError.ServerError
-import org.simple.clinic.util.ResolvedError.Unauthorized
+import org.simple.clinic.util.ResolvedError.Unauthenticated
 import org.simple.clinic.util.ResolvedError.Unexpected
 import org.simple.clinic.widgets.ScreenDestroyed
 import org.simple.clinic.widgets.setCompoundDrawableStart
@@ -97,7 +97,7 @@ class SyncIndicatorView(context: Context, attrs: AttributeSet) : LinearLayout(co
     val message = when (errorType) {
       is NetworkRelated -> context.getString(R.string.syncindicator_dialog_error_network)
       // TODO(vs): 2019-10-31 Add a separate error message for server errors
-      is Unexpected, is Unauthorized, is ServerError -> context.getString(R.string.syncindicator_dialog_error_server)
+      is Unexpected, is Unauthenticated, is ServerError -> context.getString(R.string.syncindicator_dialog_error_server)
     }
     SyncIndicatorFailureDialog.show(fragmentManager = activity.supportFragmentManager, message = message)
   }

--- a/app/src/main/java/org/simple/clinic/sync/indicator/SyncIndicatorViewController.kt
+++ b/app/src/main/java/org/simple/clinic/sync/indicator/SyncIndicatorViewController.kt
@@ -22,7 +22,9 @@ import org.simple.clinic.sync.indicator.SyncIndicatorState.ConnectToSync
 import org.simple.clinic.sync.indicator.SyncIndicatorState.SyncPending
 import org.simple.clinic.sync.indicator.SyncIndicatorState.Synced
 import org.simple.clinic.sync.indicator.SyncIndicatorState.Syncing
-import org.simple.clinic.util.ResolvedError
+import org.simple.clinic.util.ResolvedError.NetworkRelated
+import org.simple.clinic.util.ResolvedError.ServerError
+import org.simple.clinic.util.ResolvedError.Unexpected
 import org.simple.clinic.util.UtcClock
 import org.simple.clinic.widgets.UiEvent
 import org.threeten.bp.Duration
@@ -43,8 +45,9 @@ class SyncIndicatorViewController @Inject constructor(
 ) : ObservableTransformer<UiEvent, UiChange> {
 
   private val errorTypesToShowErrorFor = setOf(
-      ResolvedError.NetworkRelated::class,
-      ResolvedError.Unexpected::class
+      NetworkRelated::class,
+      Unexpected::class,
+      ServerError::class
   )
 
   override fun apply(events: Observable<UiEvent>): ObservableSource<UiChange> {

--- a/app/src/main/java/org/simple/clinic/user/UnauthorizeUser.kt
+++ b/app/src/main/java/org/simple/clinic/user/UnauthorizeUser.kt
@@ -3,7 +3,7 @@ package org.simple.clinic.user
 import io.reactivex.Scheduler
 import io.reactivex.rxkotlin.ofType
 import org.simple.clinic.sync.DataSync
-import org.simple.clinic.util.ResolvedError.Unauthorized
+import org.simple.clinic.util.ResolvedError.Unauthenticated
 import javax.inject.Inject
 
 class UnauthorizeUser @Inject constructor(
@@ -15,7 +15,7 @@ class UnauthorizeUser @Inject constructor(
     dataSync
         .streamSyncErrors()
         .observeOn(scheduler)
-        .ofType<Unauthorized>()
+        .ofType<Unauthenticated>()
         .flatMapCompletable { userSession.unauthorize() }
         .subscribe()
   }

--- a/app/src/main/java/org/simple/clinic/util/ErrorResolver.kt
+++ b/app/src/main/java/org/simple/clinic/util/ErrorResolver.kt
@@ -3,7 +3,9 @@ package org.simple.clinic.util
 import io.reactivex.exceptions.CompositeException
 import okhttp3.internal.http2.ConnectionShutdownException
 import okhttp3.internal.http2.StreamResetException
-import org.simple.clinic.util.ResolvedError.*
+import org.simple.clinic.util.ResolvedError.NetworkRelated
+import org.simple.clinic.util.ResolvedError.Unauthorized
+import org.simple.clinic.util.ResolvedError.Unexpected
 import retrofit2.HttpException
 import java.io.IOException
 import java.net.ConnectException
@@ -54,4 +56,6 @@ sealed class ResolvedError(val actualCause: Throwable) {
   class Unexpected(actualCause: Throwable) : ResolvedError(actualCause)
 
   class Unauthorized(actualCause: Throwable) : ResolvedError(actualCause)
+
+  class ServerError(actualCause: Throwable) : ResolvedError(actualCause)
 }

--- a/app/src/main/java/org/simple/clinic/util/ErrorResolver.kt
+++ b/app/src/main/java/org/simple/clinic/util/ErrorResolver.kt
@@ -5,7 +5,7 @@ import okhttp3.internal.http2.ConnectionShutdownException
 import okhttp3.internal.http2.StreamResetException
 import org.simple.clinic.util.ResolvedError.NetworkRelated
 import org.simple.clinic.util.ResolvedError.ServerError
-import org.simple.clinic.util.ResolvedError.Unauthorized
+import org.simple.clinic.util.ResolvedError.Unauthenticated
 import org.simple.clinic.util.ResolvedError.Unexpected
 import retrofit2.HttpException
 import java.io.IOException
@@ -51,7 +51,7 @@ object ErrorResolver {
 
   private fun mapHttpExceptionToResolvedError(actualCause: HttpException): ResolvedError {
     return when (actualCause.code()) {
-      401 -> Unauthorized(actualCause)
+      401 -> Unauthenticated(actualCause)
       in 500..599 -> ServerError(actualCause)
       else -> Unexpected(actualCause)
     }
@@ -64,7 +64,7 @@ sealed class ResolvedError(val actualCause: Throwable) {
 
   class Unexpected(actualCause: Throwable) : ResolvedError(actualCause)
 
-  class Unauthorized(actualCause: Throwable) : ResolvedError(actualCause)
+  class Unauthenticated(actualCause: Throwable) : ResolvedError(actualCause)
 
   class ServerError(actualCause: Throwable) : ResolvedError(actualCause)
 }

--- a/app/src/test/java/org/simple/clinic/sync/indicator/SyncIndicatorViewControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/indicator/SyncIndicatorViewControllerTest.kt
@@ -30,6 +30,7 @@ import org.simple.clinic.sync.indicator.SyncIndicatorState.Synced
 import org.simple.clinic.sync.indicator.SyncIndicatorState.Syncing
 import org.simple.clinic.util.ResolvedError
 import org.simple.clinic.util.ResolvedError.NetworkRelated
+import org.simple.clinic.util.ResolvedError.ServerError
 import org.simple.clinic.util.ResolvedError.Unauthorized
 import org.simple.clinic.util.ResolvedError.Unexpected
 import org.simple.clinic.util.RxErrorsRule
@@ -158,6 +159,7 @@ class SyncIndicatorViewControllerTest {
         ShowFailureDialogParams(NetworkRelated(UnknownHostException()), true),
         ShowFailureDialogParams(NetworkRelated(UnknownHostException()), true),
         ShowFailureDialogParams(Unexpected(RuntimeException()), true),
+        ShowFailureDialogParams(ServerError(RuntimeException()), true),
         ShowFailureDialogParams(Unauthorized(RuntimeException()), false)
     )
   }

--- a/app/src/test/java/org/simple/clinic/sync/indicator/SyncIndicatorViewControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/indicator/SyncIndicatorViewControllerTest.kt
@@ -31,7 +31,7 @@ import org.simple.clinic.sync.indicator.SyncIndicatorState.Syncing
 import org.simple.clinic.util.ResolvedError
 import org.simple.clinic.util.ResolvedError.NetworkRelated
 import org.simple.clinic.util.ResolvedError.ServerError
-import org.simple.clinic.util.ResolvedError.Unauthorized
+import org.simple.clinic.util.ResolvedError.Unauthenticated
 import org.simple.clinic.util.ResolvedError.Unexpected
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestUtcClock
@@ -160,7 +160,7 @@ class SyncIndicatorViewControllerTest {
         ShowFailureDialogParams(NetworkRelated(UnknownHostException()), true),
         ShowFailureDialogParams(Unexpected(RuntimeException()), true),
         ShowFailureDialogParams(ServerError(RuntimeException()), true),
-        ShowFailureDialogParams(Unauthorized(RuntimeException()), false)
+        ShowFailureDialogParams(Unauthenticated(RuntimeException()), false)
     )
   }
 

--- a/app/src/test/java/org/simple/clinic/user/UnauthorizeUserTest.kt
+++ b/app/src/test/java/org/simple/clinic/user/UnauthorizeUserTest.kt
@@ -19,7 +19,7 @@ import org.simple.clinic.sync.DataSync
 import org.simple.clinic.util.ResolvedError
 import org.simple.clinic.util.ResolvedError.NetworkRelated
 import org.simple.clinic.util.ResolvedError.ServerError
-import org.simple.clinic.util.ResolvedError.Unauthorized
+import org.simple.clinic.util.ResolvedError.Unauthenticated
 import org.simple.clinic.util.ResolvedError.Unexpected
 import org.simple.clinic.util.toOptional
 
@@ -68,8 +68,8 @@ class UnauthorizeUserTest {
     }
 
     return listOf(
-        testCase(error = Unauthorized(RuntimeException()), shouldUnauthorizeUser = true),
-        testCase(error = Unauthorized(NullPointerException()), shouldUnauthorizeUser = true),
+        testCase(error = Unauthenticated(RuntimeException()), shouldUnauthorizeUser = true),
+        testCase(error = Unauthenticated(NullPointerException()), shouldUnauthorizeUser = true),
         testCase(error = NetworkRelated(RuntimeException()), shouldUnauthorizeUser = false),
         testCase(error = Unexpected(RuntimeException()), shouldUnauthorizeUser = false),
         testCase(error = ServerError(RuntimeException()), shouldUnauthorizeUser = false)

--- a/app/src/test/java/org/simple/clinic/user/UnauthorizeUserTest.kt
+++ b/app/src/test/java/org/simple/clinic/user/UnauthorizeUserTest.kt
@@ -17,6 +17,10 @@ import org.junit.runner.RunWith
 import org.simple.clinic.patient.PatientMocker
 import org.simple.clinic.sync.DataSync
 import org.simple.clinic.util.ResolvedError
+import org.simple.clinic.util.ResolvedError.NetworkRelated
+import org.simple.clinic.util.ResolvedError.ServerError
+import org.simple.clinic.util.ResolvedError.Unauthorized
+import org.simple.clinic.util.ResolvedError.Unexpected
 import org.simple.clinic.util.toOptional
 
 @RunWith(JUnitParamsRunner::class)
@@ -64,10 +68,11 @@ class UnauthorizeUserTest {
     }
 
     return listOf(
-        testCase(error = ResolvedError.Unauthorized(RuntimeException()), shouldUnauthorizeUser = true),
-        testCase(error = ResolvedError.Unauthorized(NullPointerException()), shouldUnauthorizeUser = true),
-        testCase(error = ResolvedError.NetworkRelated(RuntimeException()), shouldUnauthorizeUser = false),
-        testCase(error = ResolvedError.Unexpected(RuntimeException()), shouldUnauthorizeUser = false)
+        testCase(error = Unauthorized(RuntimeException()), shouldUnauthorizeUser = true),
+        testCase(error = Unauthorized(NullPointerException()), shouldUnauthorizeUser = true),
+        testCase(error = NetworkRelated(RuntimeException()), shouldUnauthorizeUser = false),
+        testCase(error = Unexpected(RuntimeException()), shouldUnauthorizeUser = false),
+        testCase(error = ServerError(RuntimeException()), shouldUnauthorizeUser = false)
     )
   }
 }

--- a/app/src/test/java/org/simple/clinic/util/ErrorResolverTest.kt
+++ b/app/src/test/java/org/simple/clinic/util/ErrorResolverTest.kt
@@ -15,7 +15,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.simple.clinic.util.ResolvedError.NetworkRelated
 import org.simple.clinic.util.ResolvedError.ServerError
-import org.simple.clinic.util.ResolvedError.Unauthorized
+import org.simple.clinic.util.ResolvedError.Unauthenticated
 import org.simple.clinic.util.ResolvedError.Unexpected
 import retrofit2.HttpException
 import retrofit2.Response
@@ -115,7 +115,7 @@ class ErrorResolverTest {
 
     // then
     with(resolvedError) {
-      assertThat(this::class).isSameAs(Unauthorized::class)
+      assertThat(this::class).isSameAs(Unauthenticated::class)
       assertThat(actualCause).isSameAs(exception)
     }
   }

--- a/app/src/test/java/org/simple/clinic/util/ErrorResolverTest.kt
+++ b/app/src/test/java/org/simple/clinic/util/ErrorResolverTest.kt
@@ -115,27 +115,27 @@ class ErrorResolverTest {
 
   @Suppress("Unused")
   private fun `params for http unauthorized errors`(): List<List<Any>> {
-    fun exception(responseCode: Int): HttpException {
-      val response = Response.error<String>(
-          responseCode,
-          ResponseBody.create(MediaType.parse("text/plain"), "FAIL")
-      )
-      return HttpException(response)
-    }
-
     return listOf(
-        exception(401).let { httpException ->
+        httpException(401).let { httpException ->
           listOf(httpException, Unauthorized(httpException))
         },
-        exception(404).let { httpException ->
+        httpException(404).let { httpException ->
           listOf(httpException, Unexpected(httpException))
         },
-        exception(500).let { httpException ->
+        httpException(500).let { httpException ->
           listOf(httpException, Unexpected(httpException))
         },
-        exception(502).let { httpException ->
+        httpException(502).let { httpException ->
           listOf(httpException, Unexpected(httpException))
         }
     )
+  }
+
+  private fun httpException(responseCode: Int): HttpException {
+    val response = Response.error<String>(
+        responseCode,
+        ResponseBody.create(MediaType.parse("text/plain"), "FAIL")
+    )
+    return HttpException(response)
   }
 }

--- a/app/src/test/java/org/simple/clinic/util/ErrorResolverTest.kt
+++ b/app/src/test/java/org/simple/clinic/util/ErrorResolverTest.kt
@@ -13,7 +13,9 @@ import okhttp3.internal.http2.ErrorCode
 import okhttp3.internal.http2.StreamResetException
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.simple.clinic.util.ResolvedError.*
+import org.simple.clinic.util.ResolvedError.NetworkRelated
+import org.simple.clinic.util.ResolvedError.Unauthorized
+import org.simple.clinic.util.ResolvedError.Unexpected
 import retrofit2.HttpException
 import retrofit2.Response
 import java.net.SocketException
@@ -103,32 +105,18 @@ class ErrorResolverTest {
   }
 
   @Test
-  @Parameters(method = "params for http unauthorized errors")
-  fun `http unauthorized errors must be identified correctly`(
-      httpException: HttpException,
-      expectedResolvedError: ResolvedError
-  ) {
-    val resolvedError = ErrorResolver.resolve(httpException)
-    assertThat(resolvedError::class).isSameAs(expectedResolvedError::class)
-    assertThat(resolvedError.actualCause).isSameAs(httpException)
-  }
+  fun `http unauthorized errors must be identified correctly`() {
+    // given
+    val exception = httpException(401)
 
-  @Suppress("Unused")
-  private fun `params for http unauthorized errors`(): List<List<Any>> {
-    return listOf(
-        httpException(401).let { httpException ->
-          listOf(httpException, Unauthorized(httpException))
-        },
-        httpException(404).let { httpException ->
-          listOf(httpException, Unexpected(httpException))
-        },
-        httpException(500).let { httpException ->
-          listOf(httpException, Unexpected(httpException))
-        },
-        httpException(502).let { httpException ->
-          listOf(httpException, Unexpected(httpException))
-        }
-    )
+    // when
+    val resolvedError = ErrorResolver.resolve(exception)
+
+    // then
+    with(resolvedError) {
+      assertThat(this::class).isSameAs(Unauthorized::class)
+      assertThat(actualCause).isSameAs(exception)
+    }
   }
 
   @Test

--- a/app/src/test/java/org/simple/clinic/util/ErrorResolverTest.kt
+++ b/app/src/test/java/org/simple/clinic/util/ErrorResolverTest.kt
@@ -131,6 +131,22 @@ class ErrorResolverTest {
     )
   }
 
+  @Test
+  @Parameters(value = ["403", "404", "500", "502"])
+  fun `other http errors must be changed to unexpected errors`(responseCode: Int) {
+    // given
+    val exception = httpException(responseCode)
+
+    // when
+    val resolvedError = ErrorResolver.resolve(exception)
+
+    // then
+    with(resolvedError) {
+      assertThat(this::class).isSameAs(Unexpected::class)
+      assertThat(actualCause).isSameAs(exception)
+    }
+  }
+
   private fun httpException(responseCode: Int): HttpException {
     val response = Response.error<String>(
         responseCode,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/168980808

This is needed to show appropriate errors when the app manifest fails to be fetched.