### PR TITLE
Fix broken threentenbp imports in tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -296,7 +296,6 @@ dependencies {
     exclude group: "io.reactivex.rxjava2"
     because "Traceur is incompatible with the version of RxJava this artifact pulls in transitively"
   }
-  testImplementation "org.threeten:threetenbp:$versions.threeTenBp"
   implementation "com.fasterxml.uuid:java-uuid-generator:$versions.uuidGenerator"
   implementation project(":simple-platform")
   implementation project(":simple-visuals")

--- a/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
@@ -54,6 +54,7 @@ import org.simple.clinic.util.Just
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.RxErrorsRule
+import org.simple.clinic.util.TestUserClock
 import org.simple.clinic.util.TestUtcClock
 import org.simple.clinic.util.toOptional
 import org.simple.clinic.util.unwrapJust
@@ -101,6 +102,9 @@ class PatientRepositoryAndroidTest {
   lateinit var clock: TestUtcClock
 
   @Inject
+  lateinit var userClock: TestUserClock
+
+  @Inject
   lateinit var configProvider: Observable<PatientConfig>
 
   @Inject
@@ -125,6 +129,7 @@ class PatientRepositoryAndroidTest {
   fun setUp() {
     TestClinicApp.appComponent().inject(this)
     clock.setDate(LocalDate.parse("2018-01-01"))
+    userClock.setDate(LocalDate.parse("2018-01-01"))
   }
 
   @After

--- a/app/src/main/java/org/simple/clinic/widgets/ageanddateofbirth/UserInputDateValidator.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/ageanddateofbirth/UserInputDateValidator.kt
@@ -1,6 +1,7 @@
 package org.simple.clinic.widgets.ageanddateofbirth
 
 import androidx.annotation.VisibleForTesting
+import org.simple.clinic.util.UserClock
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result.Invalid.DateIsInFuture
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result.Invalid.InvalidPattern
 import org.threeten.bp.LocalDate
@@ -11,7 +12,7 @@ import javax.inject.Inject
 import javax.inject.Named
 
 class UserInputDateValidator @Inject constructor(
-    val userTimeZone: ZoneId,
+    private val userClock: UserClock,
     @Named("date_for_user_input") private val dateOfBirthFormat: DateTimeFormatter
 ) {
 
@@ -37,6 +38,6 @@ class UserInputDateValidator @Inject constructor(
 
   @VisibleForTesting
   fun dateInUserTimeZone(): LocalDate {
-    return LocalDate.now(userTimeZone)
+    return LocalDate.now(userClock)
   }
 }

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntryLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntryLogicTest.kt
@@ -73,13 +73,13 @@ class BloodPressureEntrySheetLogicTest {
   private val bloodPressureRepository = mock<BloodPressureRepository>()
   private val appointmentRepository = mock<AppointmentRepository>()
   private val patientRepository = mock<PatientRepository>()
-  private val dateValidator = UserInputDateValidator(UTC, DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH))
+  private val testUserClock = TestUserClock()
+  private val dateValidator = UserInputDateValidator(testUserClock, DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH))
   private val bpValidator = BpValidator()
 
   private val uiEvents = PublishSubject.create<UiEvent>()
   private val patientUuid = UUID.fromString("79145baf-7a5c-4442-ab30-2da564a32944")
 
-  private val testUserClock = TestUserClock()
   private val userSession = mock<UserSession>()
 
   private val facilityRepository = mock<FacilityRepository>()

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureValidationTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureValidationTest.kt
@@ -59,13 +59,13 @@ class BloodPressureValidationTest {
   private val bloodPressureRepository = mock<BloodPressureRepository>()
   private val appointmentRepository = mock<AppointmentRepository>()
   private val patientRepository = mock<PatientRepository>()
-  private val dateValidator = UserInputDateValidator(UTC, DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH))
+  private val testUserClock = TestUserClock()
+  private val dateValidator = UserInputDateValidator(testUserClock, DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH))
   private val bpValidator = BpValidator()
 
   private val uiEvents = PublishSubject.create<UiEvent>()
   private val patientUuid = UUID.fromString("79145baf-7a5c-4442-ab30-2da564a32944")
 
-  private val testUserClock = TestUserClock()
   private val userSession = mock<UserSession>()
 
   private val facilityRepository = mock<FacilityRepository>()

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenCreatedTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenCreatedTest.kt
@@ -24,7 +24,6 @@ import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
 import org.simple.mobius.migration.MobiusTestFixture
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
-import org.threeten.bp.ZoneOffset
 import org.threeten.bp.format.DateTimeFormatter
 import java.util.Locale
 
@@ -36,6 +35,7 @@ class EditPatientScreenCreatedTest {
 
   private val ui: EditPatientUi = mock()
   private val utcClock: TestUtcClock = TestUtcClock()
+  private val userClock: TestUserClock = TestUserClock()
   private val dateOfBirthFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH)
 
   @Test
@@ -143,7 +143,7 @@ class EditPatientScreenCreatedTest {
         Observable.never<EditPatientEvent>(),
         EditPatientModel.from(patient, address, phoneNumber, dateOfBirthFormat),
         EditPatientInit(patient, address, phoneNumber),
-        EditPatientUpdate(IndianPhoneNumberValidator(), UserInputDateValidator(ZoneOffset.UTC, dateOfBirthFormat)),
+        EditPatientUpdate(IndianPhoneNumberValidator(), UserInputDateValidator(userClock, dateOfBirthFormat)),
         EditPatientEffectHandler.createEffectHandler(ui, TestUserClock(), mock(), utcClock, dateOfBirthFormat, TrampolineSchedulersProvider()),
         { /* nothing here */ }
     ).start()

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenFormTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenFormTest.kt
@@ -49,7 +49,6 @@ import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
 import org.simple.mobius.migration.MobiusTestFixture
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
-import org.threeten.bp.ZoneOffset
 import org.threeten.bp.format.DateTimeFormatter
 import java.util.Locale
 import java.util.UUID
@@ -65,6 +64,7 @@ class EditPatientScreenFormTest {
   private val viewRenderer = EditPatientViewRenderer(ui)
 
   private val utcClock: TestUtcClock = TestUtcClock()
+  private val userClock: TestUserClock = TestUserClock()
   private val dateOfBirthFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH)
 
   private val patientRepository: PatientRepository = mock()
@@ -774,7 +774,7 @@ class EditPatientScreenFormTest {
         uiEvents,
         EditPatientModel.from(patient, address, phoneNumber, dateOfBirthFormat),
         EditPatientInit(patient, address, phoneNumber),
-        EditPatientUpdate(IndianPhoneNumberValidator(), UserInputDateValidator(ZoneOffset.UTC, dateOfBirthFormat)),
+        EditPatientUpdate(IndianPhoneNumberValidator(), UserInputDateValidator(userClock, dateOfBirthFormat)),
         EditPatientEffectHandler.createEffectHandler(ui, TestUserClock(), patientRepository, utcClock, dateOfBirthFormat, TrampolineSchedulersProvider()),
         viewRenderer::render
     )

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenSaveTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenSaveTest.kt
@@ -63,8 +63,8 @@ class EditPatientScreenSaveTest {
 
   private val utcClock: TestUtcClock = TestUtcClock()
   private val userClock: TestUserClock = TestUserClock(LocalDate.parse("2018-01-01"))
+  private val nextYear = "2019"
   private val dateOfBirthFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH)
-  private val nextYear = LocalDate.now().year + 1
 
   @Test
   fun `when save is clicked, patient name should be validated`() {

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenSaveTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenSaveTest.kt
@@ -46,7 +46,6 @@ import org.threeten.bp.Duration
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
 import org.threeten.bp.Month
-import org.threeten.bp.ZoneOffset
 import org.threeten.bp.format.DateTimeFormatter
 import java.util.Locale
 import java.util.UUID
@@ -63,6 +62,7 @@ class EditPatientScreenSaveTest {
   private val patientRepository: PatientRepository = mock()
 
   private val utcClock: TestUtcClock = TestUtcClock()
+  private val userClock: TestUserClock = TestUserClock(LocalDate.parse("2018-01-01"))
   private val dateOfBirthFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH)
   private val nextYear = LocalDate.now().year + 1
 
@@ -889,7 +889,7 @@ class EditPatientScreenSaveTest {
         uiEvents,
         EditPatientModel.from(patient, address, phoneNumber, dateOfBirthFormat),
         EditPatientInit(patient, address, phoneNumber),
-        EditPatientUpdate(IndianPhoneNumberValidator(), UserInputDateValidator(ZoneOffset.UTC, dateOfBirthFormat)),
+        EditPatientUpdate(IndianPhoneNumberValidator(), UserInputDateValidator(userClock, dateOfBirthFormat)),
         EditPatientEffectHandler.createEffectHandler(ui, TestUserClock(), patientRepository, utcClock, dateOfBirthFormat, TrampolineSchedulersProvider()),
         viewRenderer::render
     )

--- a/app/src/test/java/org/simple/clinic/editpatient/EditablePatientEntryTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditablePatientEntryTest.kt
@@ -6,6 +6,8 @@ import org.simple.clinic.editpatient.EditablePatientEntry.EitherAgeOrDateOfBirth
 import org.simple.clinic.editpatient.EditablePatientEntry.EitherAgeOrDateOfBirth.EntryWithDateOfBirth
 import org.simple.clinic.patient.Age
 import org.simple.clinic.patient.PatientMocker
+import org.simple.clinic.util.TestUtcClock
+import org.threeten.bp.Clock
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
 import org.threeten.bp.format.DateTimeFormatter
@@ -13,11 +15,12 @@ import java.util.Locale
 
 class EditablePatientEntryTest {
   private val dateOfBirthFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH)
+  private val clock: Clock = TestUtcClock()
 
   @Test
   fun `when the patient has an age, then entry object should have age`() {
     val patientEntry = EditablePatientEntry.from(
-        PatientMocker.patient().copy(age = Age(99, Instant.now()), dateOfBirth = null),
+        PatientMocker.patient().copy(age = Age(99, Instant.now(clock)), dateOfBirth = null),
         PatientMocker.address(),
         null,
         dateOfBirthFormat
@@ -30,7 +33,7 @@ class EditablePatientEntryTest {
   @Test
   fun `when the patient has a date of birth, then entry object should have date of birth`() {
     val patientEntry = EditablePatientEntry.from(
-        PatientMocker.patient().copy(age = null, dateOfBirth = LocalDate.now()),
+        PatientMocker.patient().copy(age = null, dateOfBirth = LocalDate.now(clock)),
         PatientMocker.address(),
         null,
         dateOfBirthFormat
@@ -43,7 +46,7 @@ class EditablePatientEntryTest {
   @Test
   fun `when the patient has both age and date of birth, then entry object should pick date of birth`() {
     val patientEntry = EditablePatientEntry.from(
-        PatientMocker.patient().copy(age = Age(99, Instant.now()), dateOfBirth = LocalDate.now()),
+        PatientMocker.patient().copy(age = Age(99, Instant.now(clock)), dateOfBirth = LocalDate.now(clock)),
         PatientMocker.address(),
         null,
         dateOfBirthFormat

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenLogicTest.kt
@@ -42,11 +42,13 @@ import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.Just
 import org.simple.clinic.util.None
 import org.simple.clinic.util.RxErrorsRule
+import org.simple.clinic.util.TestUserClock
+import org.simple.clinic.util.UserClock
 import org.simple.clinic.util.scheduler.TrampolineSchedulersProvider
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
 import org.simple.mobius.migration.MobiusTestFixture
-import org.threeten.bp.ZoneOffset.UTC
+import org.threeten.bp.LocalDate
 import org.threeten.bp.format.DateTimeFormatter
 import java.util.Locale.ENGLISH
 
@@ -61,7 +63,8 @@ class PatientEntryScreenLogicTest {
   private val patientRepository = mock<PatientRepository>()
   private val facilityRepository = mock<FacilityRepository>()
   private val userSession = mock<UserSession>()
-  private val dobValidator = UserInputDateValidator(UTC, DateTimeFormatter.ofPattern("dd/MM/yyyy", ENGLISH))
+  private val userClock: UserClock = TestUserClock(LocalDate.parse("2018-01-01"))
+  private val dobValidator = UserInputDateValidator(userClock, DateTimeFormatter.ofPattern("dd/MM/yyyy", ENGLISH))
   private val numberValidator = IndianPhoneNumberValidator()
   private val patientRegisteredCount = mock<Preference<Int>>()
 

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryUpdateTest.kt
@@ -8,14 +8,16 @@ import org.junit.Test
 import org.simple.clinic.patient.ReminderConsent.Denied
 import org.simple.clinic.patient.ReminderConsent.Granted
 import org.simple.clinic.registration.phone.IndianPhoneNumberValidator
+import org.simple.clinic.util.TestUserClock
+import org.simple.clinic.util.UserClock
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
-import org.threeten.bp.ZoneOffset
 import org.threeten.bp.format.DateTimeFormatter
 import java.util.Locale
 
 class PatientEntryUpdateTest {
   private val phoneNumberValidator = IndianPhoneNumberValidator()
-  private val dobValidator = UserInputDateValidator(ZoneOffset.UTC, DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH))
+  private val userClock: UserClock = TestUserClock()
+  private val dobValidator = UserInputDateValidator(userClock, DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH))
   private val update = PatientEntryUpdate(phoneNumberValidator, dobValidator)
   private val updateSpec = UpdateSpec(update)
 

--- a/app/src/test/java/org/simple/clinic/newentry/UserInputDateValidatorTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/UserInputDateValidatorTest.kt
@@ -5,12 +5,12 @@ import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.simple.clinic.util.TestUserClock
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result.Invalid.DateIsInFuture
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result.Invalid.InvalidPattern
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result.Valid
 import org.threeten.bp.LocalDate
-import org.threeten.bp.ZoneOffset.UTC
 import org.threeten.bp.format.DateTimeFormatter
 import java.util.Locale
 
@@ -18,7 +18,7 @@ import java.util.Locale
 class UserInputDateValidatorTest {
 
   private val validator = UserInputDateValidator(
-      userTimeZone = UTC,
+      userClock = TestUserClock(LocalDate.parse("2018-01-01")),
       dateOfBirthFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH))
 
   @Test

--- a/app/src/test/java/org/simple/clinic/patient/OngoingNewPatientEntryTest.kt
+++ b/app/src/test/java/org/simple/clinic/patient/OngoingNewPatientEntryTest.kt
@@ -13,6 +13,7 @@ import org.simple.clinic.patient.OngoingNewPatientEntry.PhoneNumber
 import org.simple.clinic.registration.phone.PhoneNumberValidator
 import org.simple.clinic.registration.phone.PhoneNumberValidator.Result.VALID
 import org.simple.clinic.registration.phone.PhoneNumberValidator.Type.LANDLINE_OR_MOBILE
+import org.simple.clinic.util.TestUserClock
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator.Result.Invalid.DateIsInFuture
 import org.threeten.bp.LocalDate
@@ -41,7 +42,7 @@ class OngoingNewPatientEntryTest {
         phoneNumber = PhoneNumber(""))
 
     val dobValidator = UserInputDateValidator(
-        userTimeZone = UTC,
+        userClock = TestUserClock(LocalDate.parse("2018-01-01")),
         dateOfBirthFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy", Locale.ENGLISH))
 
     val numValidator = mock<PhoneNumberValidator>()


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/168775283

While this might be an IDE bug, it's still a problem that's slowing us down when we write tests. I fixed it by changing the `UserInputDateValidator` to accept the clock instead of the timezone. I could remove the extra threetenbp import in the tests after that.