### PR TITLE
Introduce Assisted Injection for effect handlers

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -295,6 +295,9 @@ dependencies {
   implementation "com.fasterxml.uuid:java-uuid-generator:$versions.uuidGenerator"
   implementation project(":simple-platform")
   implementation project(":simple-visuals")
+
+  compileOnly "com.squareup.inject:assisted-inject-annotations-dagger2:$versions.assistedInject"
+  kapt "com.squareup.inject:assisted-inject-processor-dagger2:$versions.assistedInject"
 }
 
 // This must always be present at the bottom of this file, as per:

--- a/app/src/main/java/org/simple/clinic/di/AssistedInjectModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/AssistedInjectModule.kt
@@ -1,0 +1,8 @@
+package org.simple.clinic.di
+
+import com.squareup.inject.assisted.dagger2.AssistedModule
+import dagger.Module
+
+@AssistedModule
+@Module(includes = [AssistedInject_AssistedInjectModule::class])
+class AssistedInjectModule

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientEffectHandler.kt
@@ -1,6 +1,8 @@
 package org.simple.clinic.editpatient
 
 import com.spotify.mobius.rx2.RxMobius
+import com.squareup.inject.assisted.Assisted
+import com.squareup.inject.assisted.AssistedInject
 import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
 import io.reactivex.Scheduler
@@ -24,14 +26,19 @@ import org.threeten.bp.LocalDate
 import org.threeten.bp.format.DateTimeFormatter
 import java.util.UUID
 
-class EditPatientEffectHandler(
-    private val ui: EditPatientUi,
+class EditPatientEffectHandler @AssistedInject constructor(
+    @Assisted private val ui: EditPatientUi,
     private val userClock: UserClock,
     private val patientRepository: PatientRepository,
     private val utcClock: UtcClock,
     private val dateOfBirthFormatter: DateTimeFormatter,
     private val schedulersProvider: SchedulersProvider
 ) {
+
+  @AssistedInject.Factory
+  interface Factory {
+    fun create(ui: EditPatientUi): EditPatientEffectHandler
+  }
 
   companion object {
     fun createEffectHandler(

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientEffectHandler.kt
@@ -40,19 +40,6 @@ class EditPatientEffectHandler @AssistedInject constructor(
     fun create(ui: EditPatientUi): EditPatientEffectHandler
   }
 
-  companion object {
-    fun createEffectHandler(
-        ui: EditPatientUi,
-        userClock: UserClock,
-        patientRepository: PatientRepository,
-        utcClock: UtcClock,
-        dateOfBirthFormatter: DateTimeFormatter,
-        schedulersProvider: SchedulersProvider
-    ): ObservableTransformer<EditPatientEffect, EditPatientEvent> {
-      return EditPatientEffectHandler(ui, userClock, patientRepository, utcClock, dateOfBirthFormatter, schedulersProvider).build()
-    }
-  }
-
   fun build(): ObservableTransformer<EditPatientEffect, EditPatientEvent> {
     return RxMobius
         .subtypeEffectHandler<EditPatientEffect, EditPatientEvent>()

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientEffectHandler.kt
@@ -24,15 +24,29 @@ import org.threeten.bp.LocalDate
 import org.threeten.bp.format.DateTimeFormatter
 import java.util.UUID
 
-object EditPatientEffectHandler {
-  fun createEffectHandler(
-      ui: EditPatientUi,
-      userClock: UserClock,
-      patientRepository: PatientRepository,
-      utcClock: UtcClock,
-      dateOfBirthFormatter: DateTimeFormatter,
-      schedulersProvider: SchedulersProvider
-  ): ObservableTransformer<EditPatientEffect, EditPatientEvent> {
+class EditPatientEffectHandler(
+    private val ui: EditPatientUi,
+    private val userClock: UserClock,
+    private val patientRepository: PatientRepository,
+    private val utcClock: UtcClock,
+    private val dateOfBirthFormatter: DateTimeFormatter,
+    private val schedulersProvider: SchedulersProvider
+) {
+
+  companion object {
+    fun createEffectHandler(
+        ui: EditPatientUi,
+        userClock: UserClock,
+        patientRepository: PatientRepository,
+        utcClock: UtcClock,
+        dateOfBirthFormatter: DateTimeFormatter,
+        schedulersProvider: SchedulersProvider
+    ): ObservableTransformer<EditPatientEffect, EditPatientEvent> {
+      return EditPatientEffectHandler(ui, userClock, patientRepository, utcClock, dateOfBirthFormatter, schedulersProvider).build()
+    }
+  }
+
+  fun build(): ObservableTransformer<EditPatientEffect, EditPatientEvent> {
     return RxMobius
         .subtypeEffectHandler<EditPatientEffect, EditPatientEvent>()
         .addConsumer(PrefillFormEffect::class.java, { prefillFormFields(it, ui, userClock) }, schedulersProvider.ui())

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
@@ -116,12 +116,13 @@ class EditPatientScreen(context: Context, attributeSet: AttributeSet) : Relative
 
   private val delegate by unsafeLazy {
     val (patient, address, phoneNumber) = screenKey
+    val effectHandler = EditPatientEffectHandler.createEffectHandler(this, userClock, patientRepository, utcClock, dateOfBirthFormat, schedulersProvider)
     MobiusDelegate(
         events,
         EditPatientModel.from(patient, address, phoneNumber, dateOfBirthFormat),
         EditPatientInit(patient, address, phoneNumber),
         EditPatientUpdate(numberValidator, dateOfBirthValidator),
-        EditPatientEffectHandler.createEffectHandler(this, userClock, patientRepository, utcClock, dateOfBirthFormat, schedulersProvider),
+        effectHandler,
         viewRenderer::render,
         crashReporter
     )

--- a/app/src/main/java/org/simple/clinic/main/TheActivityComponent.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityComponent.kt
@@ -18,6 +18,7 @@ import org.simple.clinic.allpatientsinfacility.AllPatientsInFacilityView
 import org.simple.clinic.bp.entry.BloodPressureEntrySheet
 import org.simple.clinic.bp.entry.confirmremovebloodpressure.ConfirmRemoveBloodPressureDialog
 import org.simple.clinic.bp.entry.di.BloodPressureEntryModule
+import org.simple.clinic.di.AssistedInjectModule
 import org.simple.clinic.drugs.selection.PrescribedDrugScreen
 import org.simple.clinic.drugs.selection.dosage.DosagePickerSheet
 import org.simple.clinic.drugs.selection.entry.CustomPrescriptionEntrySheet
@@ -146,7 +147,8 @@ interface TheActivityComponent : OnboardingScreenInjector {
 @Module(includes = [
   PatientsModule::class,
   SearchResultsModule::class,
-  BloodPressureEntryModule::class
+  BloodPressureEntryModule::class,
+  AssistedInjectModule::class
 ])
 class TheActivityModule {
 

--- a/app/src/main/java/org/simple/clinic/setup/SetupActivityEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/setup/SetupActivityEffectHandler.kt
@@ -2,6 +2,8 @@ package org.simple.clinic.setup
 
 import com.f2prateek.rx.preferences2.Preference
 import com.spotify.mobius.rx2.RxMobius
+import com.squareup.inject.assisted.Assisted
+import com.squareup.inject.assisted.AssistedInject
 import io.reactivex.ObservableTransformer
 import io.reactivex.Scheduler
 import io.reactivex.Single
@@ -11,15 +13,21 @@ import org.simple.clinic.user.User
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.scheduler.SchedulersProvider
 import org.simple.clinic.util.toOptional
+import javax.inject.Named
 
-class SetupActivityEffectHandler(
-    private val onboardingCompletePreference: Preference<Boolean>,
-    private val uiActions: UiActions,
+class SetupActivityEffectHandler @AssistedInject constructor(
+    @Named("onboarding_complete") private val onboardingCompletePreference: Preference<Boolean>,
+    @Assisted private val uiActions: UiActions,
     private val userDao: User.RoomDao,
     private val appConfigRepository: AppConfigRepository,
-    private val fallbackCountry: Country,
+    @Named("fallback") private val fallbackCountry: Country,
     private val schedulersProvider: SchedulersProvider
 ) {
+
+  @AssistedInject.Factory
+  interface Factory {
+    fun create(uiActions: UiActions): SetupActivityEffectHandler
+  }
 
   companion object {
     fun create(
@@ -41,7 +49,7 @@ class SetupActivityEffectHandler(
     }
   }
 
-  private fun build(): ObservableTransformer<SetupActivityEffect, SetupActivityEvent> {
+  fun build(): ObservableTransformer<SetupActivityEffect, SetupActivityEvent> {
     return RxMobius
         .subtypeEffectHandler<SetupActivityEffect, SetupActivityEvent>()
         .addTransformer(FetchUserDetails::class.java, fetchUserDetails(schedulersProvider.io()))

--- a/app/src/main/java/org/simple/clinic/setup/SetupActivityEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/setup/SetupActivityEffectHandler.kt
@@ -29,26 +29,6 @@ class SetupActivityEffectHandler @AssistedInject constructor(
     fun create(uiActions: UiActions): SetupActivityEffectHandler
   }
 
-  companion object {
-    fun create(
-        onboardingCompletePreference: Preference<Boolean>,
-        uiActions: UiActions,
-        userDao: User.RoomDao,
-        appConfigRepository: AppConfigRepository,
-        fallbackCountry: Country,
-        schedulersProvider: SchedulersProvider
-    ): ObservableTransformer<SetupActivityEffect, SetupActivityEvent> {
-      return SetupActivityEffectHandler(
-          onboardingCompletePreference = onboardingCompletePreference,
-          uiActions = uiActions,
-          userDao = userDao,
-          appConfigRepository = appConfigRepository,
-          fallbackCountry = fallbackCountry,
-          schedulersProvider = schedulersProvider
-      ).build()
-    }
-  }
-
   fun build(): ObservableTransformer<SetupActivityEffect, SetupActivityEvent> {
     return RxMobius
         .subtypeEffectHandler<SetupActivityEffect, SetupActivityEvent>()

--- a/app/src/main/java/org/simple/clinic/setup/SetupActivityModule.kt
+++ b/app/src/main/java/org/simple/clinic/setup/SetupActivityModule.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.setup
 
+import com.squareup.inject.assisted.dagger2.AssistedModule
 import dagger.Module
 import dagger.Provides
 import org.simple.clinic.BuildConfig
@@ -7,7 +8,8 @@ import org.simple.clinic.appconfig.Country
 import java.net.URI
 import javax.inject.Named
 
-@Module
+@AssistedModule
+@Module(includes = [AssistedInject_SetupActivityModule::class])
 class SetupActivityModule {
 
   @Provides

--- a/app/src/main/java/org/simple/clinic/setup/SetupActivityModule.kt
+++ b/app/src/main/java/org/simple/clinic/setup/SetupActivityModule.kt
@@ -1,15 +1,14 @@
 package org.simple.clinic.setup
 
-import com.squareup.inject.assisted.dagger2.AssistedModule
 import dagger.Module
 import dagger.Provides
 import org.simple.clinic.BuildConfig
 import org.simple.clinic.appconfig.Country
+import org.simple.clinic.di.AssistedInjectModule
 import java.net.URI
 import javax.inject.Named
 
-@AssistedModule
-@Module(includes = [AssistedInject_SetupActivityModule::class])
+@Module(includes = [AssistedInjectModule::class])
 class SetupActivityModule {
 
   @Provides

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenCreatedTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenCreatedTest.kt
@@ -144,7 +144,7 @@ class EditPatientScreenCreatedTest {
         EditPatientModel.from(patient, address, phoneNumber, dateOfBirthFormat),
         EditPatientInit(patient, address, phoneNumber),
         EditPatientUpdate(IndianPhoneNumberValidator(), UserInputDateValidator(userClock, dateOfBirthFormat)),
-        EditPatientEffectHandler.createEffectHandler(ui, TestUserClock(), mock(), utcClock, dateOfBirthFormat, TrampolineSchedulersProvider()),
+        EditPatientEffectHandler(ui, TestUserClock(), mock(), utcClock, dateOfBirthFormat, TrampolineSchedulersProvider()).build(),
         { /* nothing here */ }
     ).start()
   }

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenFormTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenFormTest.kt
@@ -775,7 +775,7 @@ class EditPatientScreenFormTest {
         EditPatientModel.from(patient, address, phoneNumber, dateOfBirthFormat),
         EditPatientInit(patient, address, phoneNumber),
         EditPatientUpdate(IndianPhoneNumberValidator(), UserInputDateValidator(userClock, dateOfBirthFormat)),
-        EditPatientEffectHandler.createEffectHandler(ui, TestUserClock(), patientRepository, utcClock, dateOfBirthFormat, TrampolineSchedulersProvider()),
+        EditPatientEffectHandler(ui, TestUserClock(), patientRepository, utcClock, dateOfBirthFormat, TrampolineSchedulersProvider()).build(),
         viewRenderer::render
     )
 

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenSaveTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenSaveTest.kt
@@ -890,7 +890,7 @@ class EditPatientScreenSaveTest {
         EditPatientModel.from(patient, address, phoneNumber, dateOfBirthFormat),
         EditPatientInit(patient, address, phoneNumber),
         EditPatientUpdate(IndianPhoneNumberValidator(), UserInputDateValidator(userClock, dateOfBirthFormat)),
-        EditPatientEffectHandler.createEffectHandler(ui, TestUserClock(), patientRepository, utcClock, dateOfBirthFormat, TrampolineSchedulersProvider()),
+        EditPatientEffectHandler(ui, TestUserClock(), patientRepository, utcClock, dateOfBirthFormat, TrampolineSchedulersProvider()).build(),
         viewRenderer::render
     )
 

--- a/app/src/test/java/org/simple/clinic/setup/SetupActivityEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/setup/SetupActivityEffectHandlerTest.kt
@@ -28,13 +28,15 @@ class SetupActivityEffectHandlerTest {
   private val appConfigRepository = mock<AppConfigRepository>()
   private val fallbackCountry = PatientMocker.country()
 
-  private val effectHandler = SetupActivityEffectHandler.create(
+  private val effectHandler = SetupActivityEffectHandler(
       onboardingCompletePreference,
       uiActions,
       userDao,
       appConfigRepository,
       fallbackCountry,
-      TrampolineSchedulersProvider())
+      TrampolineSchedulersProvider()
+  ).build()
+
   private val testCase = EffectHandlerTestCase(effectHandler)
 
   @After

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,8 @@ buildscript {
       mixpanel            : '5.6.4',
       mobius              : '1.3.0',
       guava               : '28.1-jre', // Used by the 'mobius-migration' library ONLY in tests
-      uuidGenerator       : '3.2.0'
+      uuidGenerator       : '3.2.0',
+      assistedInject      : '0.5.2'
   ]
 
   repositories {


### PR DESCRIPTION
Until now, we were manually creating effect handlers in the screen when connecting the Mobius loop. This is cumbersome since it requires us to inject the dependencies which the effect handler requires into the screen first and then construct the effect handler.

We should inject the effect handlers directly, but in most cases, the effect handler also needs dynamic dependencies at runtime (for example, a reference to the view to perform UI actions), which prevents us from doing constructor injection.

This PR uses [AssistedInject](https://github.com/square/AssistedInject) as a way to reduce this boilerplate around constructing effect handlers. This PR does not convert all the effect handlers at the moment, only one for an `Activity` and another for a `Screen` to show how this integration would work.