### PR TITLE
Remove GitHub Actions gradle cache

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,27 +16,6 @@ jobs:
         with:
           java-version: 1.8
 
-      - uses: actions/cache@v1.0.3
-        with:
-          path: ~/.gradle/caches/jars-3
-          key: ${{ runner.os }}-gradle-jars-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-jars-
-
-      - uses: actions/cache@v1.0.3
-        with:
-          path: ~/.gradle/caches/modules-2
-          key: ${{ runner.os }}-gradle-modules-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-modules-
-
-      - uses: actions/cache@v1.0.3
-        with:
-          path: ~/.gradle/wrapper/dists
-          key: ${{ runner.os }}-gradle-dists-${{ hashFiles('**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-dists-
-
       - name: QA Lint
         run: ./gradlew lintQaDebug
 
@@ -50,27 +29,6 @@ jobs:
         with:
           java-version: 1.8
 
-      - uses: actions/cache@v1.0.3
-        with:
-          path: ~/.gradle/caches/jars-3
-          key: ${{ runner.os }}-gradle-jars-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-jars-
-
-      - uses: actions/cache@v1.0.3
-        with:
-          path: ~/.gradle/caches/modules-2
-          key: ${{ runner.os }}-gradle-modules-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-modules-
-
-      - uses: actions/cache@v1.0.3
-        with:
-          path: ~/.gradle/wrapper/dists
-          key: ${{ runner.os }}-gradle-dists-${{ hashFiles('**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-dists-
-
       - name: QA Unit Tests
         run: ./gradlew testQaDebugUnitTest
 
@@ -83,13 +41,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-
-      - uses: actions/cache@v1.0.3
-        with:
-          path: ~/.gradle/wrapper/dists
-          key: ${{ runner.os }}-gradle-dists-${{ hashFiles('**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-dists-
 
       - name: QA Android Tests
         uses: reactivecircus/android-emulator-runner@v2
@@ -106,27 +57,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-
-      - uses: actions/cache@v1.0.3
-        with:
-          path: ~/.gradle/caches/jars-3
-          key: ${{ runner.os }}-gradle-jars-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-jars-
-
-      - uses: actions/cache@v1.0.3
-        with:
-          path: ~/.gradle/caches/modules-2
-          key: ${{ runner.os }}-gradle-modules-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-modules-
-
-      - uses: actions/cache@v1.0.3
-        with:
-          path: ~/.gradle/wrapper/dists
-          key: ${{ runner.os }}-gradle-dists-${{ hashFiles('**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-dists-
 
       - name: QA Debug Build
         run: ./gradlew assembleQaDebug


### PR DESCRIPTION
This would decrease the actions run time by 2~3 minutes and also the cache is not doing anything significant