### PR TITLE
Replace Stetho with Flipper

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -296,6 +296,7 @@ dependencies {
   kapt "com.squareup.inject:assisted-inject-processor-dagger2:$versions.assistedInject"
 
   debugImplementation "com.facebook.flipper:flipper:$versions.flipper"
+  debugImplementation "com.facebook.flipper:flipper-network-plugin:$versions.flipper"
   debugImplementation "com.facebook.soloader:soloader:$versions.soloader"
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -294,6 +294,9 @@ dependencies {
 
   compileOnly "com.squareup.inject:assisted-inject-annotations-dagger2:$versions.assistedInject"
   kapt "com.squareup.inject:assisted-inject-processor-dagger2:$versions.assistedInject"
+
+  debugImplementation "com.facebook.flipper:flipper:$versions.flipper"
+  debugImplementation "com.facebook.soloader:soloader:$versions.soloader"
 }
 
 // This must always be present at the bottom of this file, as per:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -210,9 +210,6 @@ dependencies {
   androidTestImplementation "androidx.arch.core:core-testing:$versions.coreTesting"
   kaptAndroidTest "com.google.dagger:dagger-compiler:$versions.dagger"
 
-  debugImplementation "com.facebook.stetho:stetho:$versions.stetho"
-  debugImplementation "com.facebook.stetho:stetho-okhttp3:$versions.stetho"
-
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlin"
   testImplementation "org.jetbrains.kotlin:kotlin-reflect:$versions.kotlin"
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -2,7 +2,6 @@
 -dontobfuscate
 
 # Debug app only, will never be in release builds
-#-dontwarn com.facebook.stetho.**
 #-dontwarn org.apache.commons.cli.CommandLineParser
 -dontwarn org.apache.log4j.**
 -dontwarn org.hamcrest.**

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.simple.clinic"
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  package="org.simple.clinic">
 
   <application
     android:name=".DebugClinicApp"
@@ -13,7 +13,10 @@
 
     <activity
       android:name=".playground.AwaitActivity"
-      android:exported="true"
-      />
+      android:exported="true" />
+
+    <activity
+      android:name="com.facebook.flipper.android.diagnostics.FlipperDiagnosticActivity"
+      android:exported="true" />
   </application>
 </manifest>

--- a/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
+++ b/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
@@ -63,9 +63,9 @@ class DebugClinicApp : ClinicApp() {
   }
 
   private fun setupFlipper() {
-    with(AndroidFlipperClient.getInstance(this)) {
-      val context = this@DebugClinicApp
+    val context = this
 
+    with(AndroidFlipperClient.getInstance(this)) {
       addPlugin(InspectorFlipperPlugin(context, DescriptorMapping.withDefaults()))
       addPlugin(networkFlipperPlugin)
 

--- a/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
+++ b/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
@@ -3,6 +3,10 @@ package org.simple.clinic
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.os.StrictMode
+import com.facebook.flipper.android.AndroidFlipperClient
+import com.facebook.flipper.plugins.inspector.DescriptorMapping
+import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
+import com.facebook.soloader.SoLoader
 import com.tspoon.traceur.Traceur
 import io.github.inflationx.viewpump.ViewPump
 import org.simple.clinic.activity.SimpleActivityLifecycleCallbacks
@@ -31,6 +35,9 @@ class DebugClinicApp : ClinicApp() {
     Traceur.enableLogging()
     super.onCreate()
 
+    SoLoader.init(this, false)
+    setupFlipper()
+
     appComponent().inject(this)
 
     Timber.plant(Timber.DebugTree())
@@ -41,6 +48,13 @@ class DebugClinicApp : ClinicApp() {
         .build())
 
     signature = AppSignature(this)
+  }
+
+  private fun setupFlipper() {
+    with(AndroidFlipperClient.getInstance(this)) {
+      addPlugin(InspectorFlipperPlugin(this@DebugClinicApp, DescriptorMapping.withDefaults()))
+      start()
+    }
   }
 
   private fun showDebugNotification() {

--- a/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
+++ b/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
@@ -3,7 +3,6 @@ package org.simple.clinic
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.os.StrictMode
-import com.facebook.stetho.Stetho
 import com.tspoon.traceur.Traceur
 import io.github.inflationx.viewpump.ViewPump
 import org.simple.clinic.activity.SimpleActivityLifecycleCallbacks
@@ -35,7 +34,6 @@ class DebugClinicApp : ClinicApp() {
     appComponent().inject(this)
 
     Timber.plant(Timber.DebugTree())
-    Stetho.initializeWithDefaults(this)
     showDebugNotification()
 
     ViewPump.init(ViewPump.builder()

--- a/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
+++ b/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
@@ -8,6 +8,7 @@ import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin
 import com.facebook.flipper.plugins.inspector.DescriptorMapping
 import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
+import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin
 import com.facebook.soloader.SoLoader
 import com.tspoon.traceur.Traceur
 import io.github.inflationx.viewpump.ViewPump
@@ -70,6 +71,8 @@ class DebugClinicApp : ClinicApp() {
 
       val databasePlugin = DatabasesFlipperPlugin(ReadOnlySqliteDatabaseDriver(context))
       addPlugin(databasePlugin)
+
+      addPlugin(SharedPreferencesFlipperPlugin(context, "${context.packageName}_preferences"))
 
       start()
     }

--- a/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
+++ b/app/src/debug/java/org/simple/clinic/DebugClinicApp.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.os.StrictMode
 import com.facebook.flipper.android.AndroidFlipperClient
+import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin
 import com.facebook.flipper.plugins.inspector.DescriptorMapping
 import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
 import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
@@ -62,8 +63,14 @@ class DebugClinicApp : ClinicApp() {
 
   private fun setupFlipper() {
     with(AndroidFlipperClient.getInstance(this)) {
-      addPlugin(InspectorFlipperPlugin(this@DebugClinicApp, DescriptorMapping.withDefaults()))
+      val context = this@DebugClinicApp
+
+      addPlugin(InspectorFlipperPlugin(context, DescriptorMapping.withDefaults()))
       addPlugin(networkFlipperPlugin)
+
+      val databasePlugin = DatabasesFlipperPlugin(ReadOnlySqliteDatabaseDriver(context))
+      addPlugin(databasePlugin)
+
       start()
     }
   }

--- a/app/src/debug/java/org/simple/clinic/ReadOnlySqliteDatabaseDriver.kt
+++ b/app/src/debug/java/org/simple/clinic/ReadOnlySqliteDatabaseDriver.kt
@@ -1,0 +1,54 @@
+package org.simple.clinic
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import com.facebook.flipper.plugins.databases.impl.SqliteDatabaseConnectionProvider
+import com.facebook.flipper.plugins.databases.impl.SqliteDatabaseDriver
+import com.facebook.flipper.plugins.databases.impl.SqliteDatabaseProvider
+import java.io.File
+
+class ReadOnlySqliteDatabaseDriver(
+    context: Context
+) : SqliteDatabaseDriver(
+    context,
+    ContextBasedDatabaseProvider(context),
+    ReadOnlySqliteDatabaseConnectionProvider()
+)
+
+private class ContextBasedDatabaseProvider(private val context: Context) : SqliteDatabaseProvider {
+
+  override fun getDatabaseFiles(): MutableList<File> {
+    return context
+        .databaseList()
+        .map(context::getDatabasePath)
+        .toMutableList()
+  }
+}
+
+private class ReadOnlySqliteDatabaseConnectionProvider : SqliteDatabaseConnectionProvider {
+
+  override fun openDatabase(databaseFile: File): SQLiteDatabase {
+    // We are setting this to READONLY for a couple of reasons:
+    //
+    // Room sets all databases to WAL by default, which means that they need to
+    // share a connection to the underlying database via Room's SQLiteOpenHelper.
+    //
+    // However, the Flipper database plugin tries to open and manage its own
+    // connection to the database. This causes weird problems like writes to the
+    // database to fail silently.
+    //
+    // We could potentially write a custom connection provider for Flipper which
+    // would let us use the open helper to create the connection, but the problem
+    // is that the interface expects the `android.database.sqlite.SQLiteDatabase`
+    // class, while Room uses the `android.arch.persistence.db.SupportSQLiteDatabase`
+    // class.
+    //
+    // This is a temporary workaround until we can implement a new database driver
+    // for Flipper which is aware of this alternate class.
+    // TODO(vs): 2020-01-01 Implement RoomDatabaseDriver for Flipper
+
+    val flags = SQLiteDatabase.OPEN_READONLY
+
+    return SQLiteDatabase.openDatabase(databaseFile.absolutePath, null, flags)
+  }
+}

--- a/app/src/debug/java/org/simple/clinic/di/FlipperModule.kt
+++ b/app/src/debug/java/org/simple/clinic/di/FlipperModule.kt
@@ -1,0 +1,15 @@
+package org.simple.clinic.di
+
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
+import dagger.Module
+import dagger.Provides
+
+@Module
+class FlipperModule {
+
+  @Provides
+  @AppScope
+  fun provideFlipperNetworkPlugin(): NetworkFlipperPlugin {
+    return NetworkFlipperPlugin()
+  }
+}

--- a/app/src/debug/java/org/simple/clinic/di/network/HttpInterceptorsModule.kt
+++ b/app/src/debug/java/org/simple/clinic/di/network/HttpInterceptorsModule.kt
@@ -1,5 +1,7 @@
 package org.simple.clinic.di.network
 
+import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
 import dagger.Module
 import dagger.Provides
 import okhttp3.Interceptor
@@ -13,12 +15,18 @@ class HttpInterceptorsModule {
   @Provides
   fun providerInterceptors(
       loggedInInterceptor: LoggedInUserHttpInterceptor,
-      appInfoHttpInterceptor: AppInfoHttpInterceptor
+      appInfoHttpInterceptor: AppInfoHttpInterceptor,
+      networkPlugin: NetworkFlipperPlugin
   ): List<Interceptor> {
     val loggingInterceptor = HttpLoggingInterceptor().apply {
       level = BODY
     }
 
-    return listOf(loggedInInterceptor, appInfoHttpInterceptor, loggingInterceptor)
+    return listOf(
+        loggedInInterceptor,
+        appInfoHttpInterceptor,
+        loggingInterceptor,
+        FlipperOkhttpInterceptor(networkPlugin)
+    )
   }
 }

--- a/app/src/main/java/org/simple/clinic/bp/entry/confirmremovebloodpressure/ConfirmRemoveBloodPressureDialog.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/confirmremovebloodpressure/ConfirmRemoveBloodPressureDialog.kt
@@ -87,7 +87,7 @@ class ConfirmRemoveBloodPressureDialog : AppCompatDialogFragment() {
     screenDestroys.onNext(ScreenDestroyed())
   }
 
-  override fun onAttach(context: Context?) {
+  override fun onAttach(context: Context) {
     super.onAttach(context)
     removeBloodPressureListener = context as? RemoveBloodPressureListener
     if (removeBloodPressureListener == null) {

--- a/app/src/main/java/org/simple/clinic/di/AppModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/AppModule.kt
@@ -78,7 +78,8 @@ import javax.inject.Named
   HttpInterceptorsModule::class,
   RetrofitModule::class,
   ClearPatientDataModule::class,
-  PatientEntryModule::class
+  PatientEntryModule::class,
+  FlipperModule::class
 ])
 class AppModule(private val appContext: Application) {
 

--- a/app/src/main/java/org/simple/clinic/home/patients/LoggedOutOnOtherDeviceDialog.kt
+++ b/app/src/main/java/org/simple/clinic/home/patients/LoggedOutOnOtherDeviceDialog.kt
@@ -27,7 +27,7 @@ class LoggedOutOnOtherDeviceDialog : AppCompatDialogFragment() {
         .setTitle(R.string.patients_loggedoutalert_title)
         .setMessage(R.string.patients_loggedoutalert_message)
         .setPositiveButton(R.string.patients_loggedoutalert_dismiss) { _, _ ->
-          val view = dialog.ownerActivity!!.findViewById<View>(android.R.id.content)
+          val view = dialog!!.ownerActivity!!.findViewById<View>(android.R.id.content)
           Snackbar.make(view, R.string.patients_you_are_now_logged_in, Snackbar.LENGTH_LONG).show()
         }
         .create()

--- a/app/src/release/java/org/simple/clinic/di/FlipperModule.kt
+++ b/app/src/release/java/org/simple/clinic/di/FlipperModule.kt
@@ -1,0 +1,11 @@
+package org.simple.clinic.di
+
+import dagger.Module
+
+/**
+ * This is necessary only to satisfy compilation. It does not contribute anything
+ * to the production DI graph. See the corresponding file in the debug sourceset to
+ * get an idea of what it actually contributes
+ **/
+@Module
+class FlipperModule

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,9 @@ buildscript {
       mobius              : '1.3.0',
       guava               : '28.1-jre', // Used by the 'mobius-migration' library ONLY in tests
       uuidGenerator       : '3.2.0',
-      assistedInject      : '0.5.2'
+      assistedInject      : '0.5.2',
+      flipper             : '0.30.1',
+      soloader            : '0.5.1'
   ]
 
   repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ buildscript {
       coreTesting         : '2.0.0',
       moshi               : '1.8.0',
       retrofit            : '2.4.0',
-      stetho              : '1.5.0',
       sentry              : '1.7.22',
       slf4j               : '1.7.25',
       groupie             : '2.3.0',


### PR DESCRIPTION
We had integrated [Stetho](http://facebook.github.io/stetho/) for debugging the app during development. Stetho is not being actively developed, and they have an alternate tool called [Flipper](https://fbflipper.com/), which they recommend instead.

This PR replaces the usage of Stetho in the app with Flipper, along with integration for the following plugins:

### Layout Inspector
<img width="1934" alt="layout_inspector" src="https://user-images.githubusercontent.com/1978065/71639344-ec580a80-2c9a-11ea-8223-23fafc795c70.png">

### Network Inspector
<img width="1396" alt="network" src="https://user-images.githubusercontent.com/1978065/71639348-f8dc6300-2c9a-11ea-9a35-b3ddfe1fa5a5.png">

### Database Inspector
<img width="1400" alt="database" src="https://user-images.githubusercontent.com/1978065/71639352-01349e00-2c9b-11ea-8e3d-d3caf5206e6b.png">

### Shared preferences Inspector
<img width="1400" alt="shared_preferences" src="https://user-images.githubusercontent.com/1978065/71639355-098cd900-2c9b-11ea-9ec9-4a69d762daaf.png">
