### PR TITLE
Fix flaky test when recording a patient

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/TestData.kt
+++ b/app/src/androidTest/java/org/simple/clinic/TestData.kt
@@ -654,7 +654,7 @@ class TestData @Inject constructor(
   fun ongoingPatientEntry(
       fullName: String = faker.name.name(),
       dateOfBirth: String? = null,
-      age: String? = faker.number.between(0, 100).toString(),
+      age: String? = faker.number.between(MIN_ALLOWED_PATIENT_AGE, MAX_ALLOWED_PATIENT_AGE).toString(),
       gender: Gender = randomGender(),
       colony: String = faker.address.streetName(),
       district: String = faker.address.city(),

--- a/app/src/main/java/org/simple/clinic/Globals.kt
+++ b/app/src/main/java/org/simple/clinic/Globals.kt
@@ -1,3 +1,5 @@
 package org.simple.clinic
 
 const val SHORT_CODE_REQUIRED_LENGTH: Int = 7
+const val MAX_ALLOWED_PATIENT_AGE: Int = 120
+const val MIN_ALLOWED_PATIENT_AGE: Int = 1

--- a/app/src/main/java/org/simple/clinic/widgets/ageanddateofbirth/UserInputAgeValidator.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/ageanddateofbirth/UserInputAgeValidator.kt
@@ -1,5 +1,7 @@
 package org.simple.clinic.widgets.ageanddateofbirth
 
+import org.simple.clinic.MAX_ALLOWED_PATIENT_AGE
+import org.simple.clinic.MIN_ALLOWED_PATIENT_AGE
 import org.simple.clinic.util.UserClock
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputAgeValidator.Result.Invalid.ExceedsMaxAgeLimit
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputAgeValidator.Result.Invalid.ExceedsMinAgeLimit
@@ -23,8 +25,8 @@ class UserInputAgeValidator @Inject constructor(
 
   fun validate(age: Int): Result {
     return when {
-      age > 120 -> ExceedsMaxAgeLimit
-      age == 0 -> ExceedsMinAgeLimit
+      age > MAX_ALLOWED_PATIENT_AGE -> ExceedsMaxAgeLimit
+      age < MIN_ALLOWED_PATIENT_AGE -> ExceedsMinAgeLimit
       else -> Valid
     }
   }
@@ -33,7 +35,7 @@ class UserInputAgeValidator @Inject constructor(
     val nowDate: LocalDate = LocalDate.now(userClock)
     val parsedDate = dateOfBirthFormat.parse(dateText, LocalDate::from)
     return when {
-      parsedDate < nowDate.minusYears(120) -> ExceedsMaxAgeLimit
+      parsedDate < nowDate.minusYears(MAX_ALLOWED_PATIENT_AGE.toLong()) -> ExceedsMaxAgeLimit
       parsedDate == nowDate -> ExceedsMinAgeLimit
       else -> Valid
     }


### PR DESCRIPTION
The test generator would use a random number in the range [0, 100] for the age when creating a patient. However, we changed the age limit to have a minimum value of 1. This
ended up causing flakiness in some test runs where the random age
generator would create a patient with an age = 0.

This commit fixes the issue by extracting the minimum and maximum age
limits to global constants and using that in the test data generation.