### PR TITLE
Get branch name from `Commit and Push` step

### DIFF
--- a/.github/scripts/commit_and_push.sh
+++ b/.github/scripts/commit_and_push.sh
@@ -23,7 +23,5 @@ if [[ ${GIT_DIFF_STATUS} -eq ${GIT_HAS_CHANGES} ]]; then
     git commit -am "[BOT] Code formatting fixes"
     git push -u origin "$BRANCH_NAME"
 
-    echo "Git changes pushed to $BRANCH_NAME"
-else
-    echo "No git changes"
+    echo "::set-output name=branch_name::${BRANCH_NAME}"
 fi

--- a/.github/workflows/code_formatting_checks.yml
+++ b/.github/workflows/code_formatting_checks.yml
@@ -20,28 +20,33 @@ jobs:
         run: ./gradlew spotlessApply
 
       - name: Commit and Push
+        id: commit_and_push
         run: .github/scripts/commit_and_push.sh "${{secrets.USER_NAME}}" "${{secrets.USER_EMAIL}}"
 
       - name: Create PR
         uses: actions/github-script@0.3.0
+        env:
+          branch_name: ${{steps.commit_and_push.outputs.branch_name}}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            var monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-            var date = new Date();
-            var monthName = monthNames[date.getMonth()];
-            var day = `${date.getDate()}`.padStart(2, 0);
-            day = `${monthName}-${day}-${date.getFullYear()}`
-            var branchName = `bot/${day}/code-formatting`
+            const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+            const branchName = process.env.branch_name
+            const date = new Date();
+            const month = monthNames[date.getMonth()];
+            const day = `${date.getDate()}`.padStart(2, '0');
+            const year = `${date.getFullYear()}`
+            const prTitle = `[BOT] Code formatting fixes ${month}-${day}-${year}`
 
-            const branch = await github.repos.getBranch({
-                ...context.repo,
-                branch: branchName
-            });
-            await github.pulls.create({
-                ...context.repo,
-                title: `[BOT] Code formatting fixes ${day}`,
-                head: branch.data.name,
-                base: 'master'
-            });
-
+            if (branchName) {
+                const branch = await github.repos.getBranch({
+                    ...context.repo,
+                    branch: branchName
+                });
+                await github.pulls.create({
+                    ...context.repo,
+                    title: prTitle,
+                    head: branch.data.name,
+                    base: 'master'
+                });
+            }


### PR DESCRIPTION
Instead of creating the branch name in `Create PR` step. Get the already created branch name from `Commit and Push` step and set it as env variable for `Create PR` step.