### PR TITLE
Change code formatting action run timings

### DIFF
--- a/.github/workflows/code_formatting_checks.yml
+++ b/.github/workflows/code_formatting_checks.yml
@@ -1,9 +1,10 @@
 name: Code formatting
 
-# Scheduled at 11:30 PM UTC (05:00 AM IST)
+# Scheduled at 11:30 PM UTC (Sunday to Thursday)
+# Scheduled at 05:00 AM IST (Monday to Friday)
 on:
   schedule:
-    - cron: "30 23 * * *"
+    - cron: "30 23 * * 0-4"
 
 jobs:
   fix_code_formatting:

--- a/.github/workflows/code_formatting_checks.yml
+++ b/.github/workflows/code_formatting_checks.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           branch_name: ${{steps.commit_and_push.outputs.branch_name}}
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.GITHUB_ACCESS_TOKEN}}
           script: |
             const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
             const branchName = process.env.branch_name


### PR DESCRIPTION
- Run code formatting action only on weekdays
- Use `GITHUB_ACCESS_TOKEN` instead of `GITHUB_TOKEN`

**Required**
- Create `GITHUB_ACCESS_TOKEN` secret with a personal access token with repo scope. 