### PR TITLE
Fix empty blood pressures state in BP history screen

### DIFF
--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenModel.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenModel.kt
@@ -18,7 +18,7 @@ data class BloodPressureHistoryScreenModel(
   }
 
   val hasBloodPressures: Boolean
-    get() = bloodPressures.isNullOrEmpty().not()
+    get() = bloodPressures != null
 
   val hasPatient: Boolean
     get() = patient != null


### PR DESCRIPTION
- If we check for both null and empty list, edge case of removing all the BPs is not being handled. In order to fix that only null check is being made and the empty list is being rendered on the UI.