### PR TITLE
Rename `editButton` -> `editPatientButton` in patient summary screen

### DIFF
--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -173,7 +173,7 @@ class PatientSummaryScreen(
   }
 
   private fun setupEditButtonClicks() {
-    editButton.setOnClickListener {
+    editPatientButton.setOnClickListener {
       screenRouter.push(createEditPatientScreenKey(mobiusDelegate.model.patientSummaryProfile!!))
     }
   }
@@ -326,7 +326,7 @@ class PatientSummaryScreen(
   }
 
   override fun showEditButton() {
-    editButton.visibility = View.VISIBLE
+    editPatientButton.visibility = View.VISIBLE
   }
 }
 

--- a/app/src/main/res/layout/screen_patient_summary.xml
+++ b/app/src/main/res/layout/screen_patient_summary.xml
@@ -28,7 +28,7 @@
       android:tint="@color/white" />
 
     <Button
-      android:id="@+id/editButton"
+      android:id="@+id/editPatientButton"
       style="@style/Clinic.V2.ToolbarButton"
       android:layout_alignParentEnd="true"
       android:layout_marginTop="@dimen/spacing_4"


### PR DESCRIPTION
After merging in the new BP summary view, the UI tests in the screen
started breaking because there were two views on the screen with the
same ID: the patient edit button and the button on the BP item to
edit it.

This commit renames the button used to open the Edit patient screen so
that the clashes of the IDs will no longer happen.