### PR TITLE
Fix `contactTextView` overlapping 

### DIFF
--- a/app/src/main/res/layout/screen_patient_summary.xml
+++ b/app/src/main/res/layout/screen_patient_summary.xml
@@ -67,40 +67,46 @@
         android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.White72"
         tools:text="House No. 14, Street No. 10/11, Guru Gobind Singh Nagar, Bathinda, Punjab" />
 
-      <TextView
-        android:id="@+id/bpPassportTextView"
+      <LinearLayout
+        android:id="@+id/identifiersContainer"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/addressTextView"
         android:layout_alignStart="@id/addressTextView"
         android:layout_marginTop="@dimen/spacing_4"
-        android:layout_marginEnd="@dimen/spacing_8"
-        android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Numeric.White72"
-        android:visibility="gone"
-        tools:text="BP Passport: 512 9856"
-        tools:visibility="visible" />
+        android:orientation="horizontal">
 
-      <TextView
-        android:id="@+id/bangladeshNationalIdTextView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/addressTextView"
-        android:layout_marginTop="@dimen/spacing_4"
-        android:layout_toEndOf="@id/bpPassportTextView"
-        android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.White72"
-        tools:text="\u2022 ID: 123456789012" />
+        <TextView
+          android:id="@+id/bpPassportTextView"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Numeric.White72"
+          android:visibility="gone"
+          tools:text="BP Passport: 512 9856"
+          tools:visibility="visible" />
+
+        <TextView
+          android:id="@+id/bangladeshNationalIdTextView"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.White72"
+          tools:text="\u2022 ID: 123456789012" />
+
+      </LinearLayout>
 
       <TextView
         android:id="@+id/contactTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/bpPassportTextView"
+        android:layout_below="@id/identifiersContainer"
+        android:layout_alignStart="@id/identifiersContainer"
         android:layout_marginTop="@dimen/spacing_4"
         android:drawableStart="@drawable/ic_call_16dp"
         android:drawablePadding="@dimen/spacing_4"
         android:drawableTint="@color/white72"
         android:textAppearance="@style/Clinic.V2.TextAppearance.Body2Left.Numeric.White72"
         tools:text="1111111111" />
+
     </RelativeLayout>
   </RelativeLayout>
 


### PR DESCRIPTION
https://github.com/simpledotorg/simple-android/pull/1127 introduced a bug where `contactTextView` overlaps with `bpPassportTextView` or `bangladeshNationalIdTextView` depending on the visibility. 

In order to fix this I have moved the `bpPassportTextView` & `bangladeshNationalIdTextView` into a container `identifiersContainer` and use that as anchor for `contactTextView`.