### PR TITLE
Bump facility resync token to 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Use the diabetes management flag from the facility instead of the remote config flag to toggle the diabetes view on patient summary
 - Updated to the new visual styling of the CV history, Blood pressure, and Blood sugar widgets on the patient summary screen
 - Bump the resync token for CV history sync to 2
+- Bump the resync token for facility sync to 2
 
 ### Fixes
 - Fix issue where the street and zone address fields would not be synced to the servers

--- a/app/src/main/java/org/simple/clinic/facility/FacilitySyncApi.kt
+++ b/app/src/main/java/org/simple/clinic/facility/FacilitySyncApi.kt
@@ -7,7 +7,7 @@ import retrofit2.http.Query
 
 interface FacilitySyncApi {
 
-  @Headers(value = ["X-RESYNC-TOKEN: 1"])
+  @Headers(value = ["X-RESYNC-TOKEN: 2"])
   @GET("facilities/sync")
   fun pull(
       @Query("limit") recordsToPull: Int,


### PR DESCRIPTION
This is so that the `diabetesManagementEnabled` flag can get synced.