### PR TITLE
Bump AGP to 3.6.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'io.sentry.android.gradle'
 
 apply from: "../quality/install-git-hook.gradle"
+apply from: "ndk-versions.gradle"
 
 repositories {
   maven { url 'https://jitpack.io' }
@@ -55,6 +56,14 @@ tasks.withType(Test) {
 
 android {
   compileSdkVersion versions.compileSdk
+  // Needed to switch NDK versions on the CI server since they have different
+  // NDK versions on macOS and Linux environments. Gradle plugin 3.6+ requires
+  // us to pin an NDK version if we package native libs.
+  // https://developer.android.com/studio/releases/gradle-plugin#default-ndk-version
+  //
+  // Currently, this is only used for assembling the APK where the build process
+  // strips debug symbols from the APK.
+  ndkVersion installedNdkVersion()
 
   defaultConfig {
     applicationId "org.simple.clinic"

--- a/app/ndk-versions.gradle
+++ b/app/ndk-versions.gradle
@@ -1,0 +1,12 @@
+def installedNdkVersion() {
+  def androidNdkPropertiesLocation = "$System.env.ANDROID_HOME/ndk-bundle/source.properties"
+
+  def ndkProperties = new Properties()
+  ndkProperties.load(file(androidNdkPropertiesLocation).newInputStream())
+
+  return ndkProperties["Pkg.Revision"]
+}
+
+ext {
+  installedNdkVersion = this.&installedNdkVersion
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -57,3 +57,22 @@
 
 # RxJava
 -dontwarn java.util.concurrent.Flow*
+
+# GMS
+-dontwarn org.checkerframework.checker.nullness.qual.PolyNull
+
+# Firebase
+-dontwarn com.google.firebase.components.*
+
+# Protobuf
+-dontwarn sun.misc.Unsafe
+
+# Mixpanel
+-dontwarn javax.servlet.http.HttpServletRequest
+-dontwarn com.google.firebase.messaging.*
+-dontwarn com.mixpanel.android.mpmetrics.MixpanelFCMMessagingService
+
+# Sentry
+-dontwarn javax.naming.*
+-dontwarn javax.servlet.*
+-dontwarn javax.servlet.http.Cookie

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryCardView.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryCardView.kt
@@ -138,11 +138,11 @@ class PinEntryCardView(context: Context, attrs: AttributeSet) : CardView(context
   }
 
   fun showIncorrectPinErrorOnSubsequentAttempts(remaining: Int) {
-    showError(resources.getString(R.string.pinentry_error_incorrect_pin_attempts_remaining, "$remaining"))
+    showError(resources.getString(R.string.pinentry_error_incorrect_pin_attempts_remaining, remaining.toString()))
   }
 
   fun showIncorrectAttemptsLimitReachedError(attemptsMade: Int) {
-    showError(resources.getString(R.string.pinentry_error_incorrect_pin_attempts_limit_reached, "$attemptsMade"))
+    showError(resources.getString(R.string.pinentry_error_incorrect_pin_attempts_limit_reached, attemptsMade.toString()))
   }
 
   fun clearPin() {

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.5.3'
+    classpath 'com.android.tools.build:gradle:3.6.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
     classpath "io.sentry:sentry-android-gradle-plugin:$versions.sentry"
     classpath "com.google.gms:google-services:$versions.googleServices"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
- Bump gradle wrapper to 5.6.4
- Fix lint issues in `PinEntryCardView`
- Add new proguard rules