### PR TITLE
POC: Detect unsubscribed completables in tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,10 +9,6 @@ apply plugin: 'io.sentry.android.gradle'
 
 apply from: "../quality/install-git-hook.gradle"
 
-repositories {
-  maven { url 'https://jitpack.io' }
-}
-
 sentry {
   autoProguardConfig true
   // We can disable auto upload of proguard mappings since we use -dontobfuscate when running proguard
@@ -212,7 +208,7 @@ dependencies {
 
   testImplementation "junit:junit:$versions.junit"
   testImplementation "com.nhaarman:mockito-kotlin:$versions.mockitoKotlin"
-  testImplementation "pl.pragmatists:JUnitParams:$versions.junitParams"
+  testImplementation "com.github.vinaysshenoy:JUnitParams:$versions.junitParams"
   testImplementation "com.google.truth:truth:$versions.truth"
   testImplementation "com.github.blocoio:faker:$versions.faker"
 

--- a/app/src/androidTest/java/org/simple/clinic/user/UserSessionAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/user/UserSessionAndroidTest.kt
@@ -19,7 +19,6 @@ import org.simple.clinic.util.Just
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.Rules
-import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.toOptional
 import javax.inject.Inject
 
@@ -51,7 +50,6 @@ class UserSessionAndroidTest {
   val ruleChain: RuleChain = Rules
       .global()
       .around(LocalAuthenticationRule())
-      .around(RxErrorsRule())
 
   @Before
   fun setUp() {

--- a/app/src/sharedTest/java/org/simple/clinic/util/ExpectUnsubscribed.kt
+++ b/app/src/sharedTest/java/org/simple/clinic/util/ExpectUnsubscribed.kt
@@ -1,0 +1,5 @@
+package org.simple.clinic.util
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class ExpectUnsubscribed(val completables: Int = 0)

--- a/app/src/sharedTest/java/org/simple/clinic/util/Rules.kt
+++ b/app/src/sharedTest/java/org/simple/clinic/util/Rules.kt
@@ -14,5 +14,6 @@ object Rules {
   fun global(): RuleChain = RuleChain
       .emptyRuleChain()
       .around(QuarantineTestRule(quarantineClassLoader))
+      .around(RxCompletableSubscribedRule())
       .around(RxErrorsRule())
 }

--- a/app/src/sharedTest/java/org/simple/clinic/util/RxCompletableSubscribedRule.kt
+++ b/app/src/sharedTest/java/org/simple/clinic/util/RxCompletableSubscribedRule.kt
@@ -1,0 +1,32 @@
+package org.simple.clinic.util
+
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class RxCompletableSubscribedRule: TestRule {
+
+  override fun apply(base: Statement, description: Description): Statement {
+    return SubscriptionTrackingStatement(base, description)
+  }
+
+  private class SubscriptionTrackingStatement(
+      private val base: Statement,
+      private val description: Description
+  ) : Statement() {
+
+    private val subscriptionTracker = RxJavaSubscriptionTracker()
+
+    override fun evaluate() {
+
+      subscriptionTracker.startTracking()
+
+      try {
+        base.evaluate()
+      } finally {
+        subscriptionTracker.stopTracking()
+        subscriptionTracker.assertAllCompletablesSubscribed(description.getAnnotation(ExpectUnsubscribed::class.java))
+      }
+    }
+  }
+}

--- a/app/src/sharedTest/java/org/simple/clinic/util/RxJavaSubscriptionTracker.kt
+++ b/app/src/sharedTest/java/org/simple/clinic/util/RxJavaSubscriptionTracker.kt
@@ -1,0 +1,73 @@
+package org.simple.clinic.util
+
+import io.reactivex.Completable
+import io.reactivex.CompletableObserver
+import io.reactivex.CompletableSource
+import io.reactivex.plugins.RxJavaPlugins
+
+class RxJavaSubscriptionTracker {
+
+  private var assembledCompletables = mutableListOf<CompletableOnAssembly>()
+
+  fun startTracking() {
+    RxJavaPlugins.setOnCompletableAssembly { source ->
+      val assembly = CompletableOnAssembly(source)
+
+      assembledCompletables.add(assembly)
+
+      assembly
+    }
+  }
+
+  fun stopTracking() {
+    RxJavaPlugins.setOnCompletableAssembly(null)
+  }
+
+  fun assertAllCompletablesSubscribed(
+      expectUnsubscribed: ExpectUnsubscribed? = null
+  ) {
+    val assembledCount = assembledCompletables.size
+    val subscribedCount = assembledCompletables.count { it.hasBeenSubscribedTo }
+    val expectedUnsubscribedCount = expectUnsubscribed?.completables ?: 0
+    val totalUnsubscribedCount = assembledCount - subscribedCount
+
+    if (totalUnsubscribedCount != expectedUnsubscribedCount) {
+      val unsubscribedCompletables = assembledCompletables
+          .filterNot { it.hasBeenSubscribedTo }
+          .mapIndexed { index, assembly -> "#%02d - %s".format(index, assembly.createdAt) }
+          .joinToString("\n")
+
+      val message = """
+        |
+        |Found unsubscribed Completables!
+        |--------------------------------
+        |Assembled: $assembledCount
+        |Subscribed: $subscribedCount
+        |Expected to be not subscribed to: $expectedUnsubscribedCount
+        |--------------------------------
+        |$unsubscribedCompletables
+        |--------------------------------
+      """.trimMargin()
+      throw AssertionError(message)
+    }
+  }
+
+  private class CompletableOnAssembly(
+      private val source: CompletableSource
+  ) : Completable() {
+
+    private val stackTrace = Thread
+        .currentThread()
+        .stackTrace
+
+    val createdAt: String = stackTrace[7].toString()
+
+    var hasBeenSubscribedTo: Boolean = false
+      private set
+
+    override fun subscribeActual(observer: CompletableObserver) {
+      hasBeenSubscribedTo = true
+      source.subscribe(observer)
+    }
+  }
+}

--- a/app/src/test/java/org/simple/clinic/ReportAnalyticsEventsTest.kt
+++ b/app/src/test/java/org/simple/clinic/ReportAnalyticsEventsTest.kt
@@ -15,7 +15,7 @@ import org.simple.clinic.widgets.UiEvent
 class ReportAnalyticsEventsTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private data class UiEvent1(val prop: String) : UiEvent {
     override val analyticsName = "UiEvent 1"

--- a/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
@@ -55,7 +55,7 @@ import java.util.concurrent.TimeUnit
 class TheActivityControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val lockInMinutes = 15L
 

--- a/app/src/test/java/org/simple/clinic/addidtopatient/searchforpatient/AddIdToPatientSearchScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/addidtopatient/searchforpatient/AddIdToPatientSearchScreenControllerTest.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 class AddIdToPatientSearchScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen: AddIdToPatientSearchScreen = mock()
 

--- a/app/src/test/java/org/simple/clinic/addidtopatient/searchresults/AddIdToPatientSearchResultsControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/addidtopatient/searchresults/AddIdToPatientSearchResultsControllerTest.kt
@@ -23,7 +23,7 @@ import java.util.UUID
 class AddIdToPatientSearchResultsControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen: AddIdToPatientSearchResultsScreen = mock()
 

--- a/app/src/test/java/org/simple/clinic/bp/BloodPressureRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/BloodPressureRepositoryTest.kt
@@ -24,7 +24,7 @@ import java.util.UUID
 class BloodPressureRepositoryTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val dao = mock<BloodPressureMeasurement.RoomDao>()
   private val testClock = TestUtcClock()

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntryLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureEntryLogicTest.kt
@@ -67,7 +67,7 @@ typealias UiChange = (Ui) -> Unit
 class BloodPressureEntrySheetLogicTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val ui = mock<BloodPressureEntryUi>()
   private val bloodPressureRepository = mock<BloodPressureRepository>()

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureValidationMockDateValidatorTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureValidationMockDateValidatorTest.kt
@@ -45,7 +45,7 @@ import java.util.UUID
 class BloodPressureValidationMockDateValidatorTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val ui = mock<BloodPressureEntryUi>()
   private val bloodPressureRepository = mock<BloodPressureRepository>()

--- a/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureValidationTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/BloodPressureValidationTest.kt
@@ -53,7 +53,7 @@ import java.util.UUID
 class BloodPressureValidationTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val ui = mock<BloodPressureEntryUi>()
   private val bloodPressureRepository = mock<BloodPressureRepository>()

--- a/app/src/test/java/org/simple/clinic/bp/entry/confirmremovebloodpressure/ConfirmRemoveBloodPressureDialogControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/entry/confirmremovebloodpressure/ConfirmRemoveBloodPressureDialogControllerTest.kt
@@ -20,7 +20,7 @@ import org.simple.clinic.widgets.UiEvent
 class ConfirmRemoveBloodPressureDialogControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val bloodPressureRepository = mock<BloodPressureRepository>()
   private val patientRepository = mock<PatientRepository>()

--- a/app/src/test/java/org/simple/clinic/drugs/PrescriptionRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/PrescriptionRepositoryTest.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 class PrescriptionRepositoryTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val database = mock<AppDatabase>()
   private val dao = mock<PrescribedDrug.RoomDao>()

--- a/app/src/test/java/org/simple/clinic/drugs/selection/DosagePickerSheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/DosagePickerSheetControllerTest.kt
@@ -38,7 +38,7 @@ import java.util.UUID
 class DosagePickerSheetControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val protocolRepository = mock<ProtocolRepository>()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/drugs/selection/PrescribedDrugsScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/PrescribedDrugsScreenControllerTest.kt
@@ -29,7 +29,7 @@ import java.util.UUID
 class PrescribedDrugsScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen = mock<PrescribedDrugScreen>()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/drugs/selection/entry/CustomPrescriptionEntryControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/entry/CustomPrescriptionEntryControllerTest.kt
@@ -30,7 +30,7 @@ import java.util.UUID
 class CustomPrescriptionEntryControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val sheet = mock<CustomPrescriptionEntrySheet>()
   private val prescriptionRepository = mock<PrescriptionRepository>()

--- a/app/src/test/java/org/simple/clinic/drugs/selection/entry/confirmremovedialog/ConfirmRemovePrescriptionDialogControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/entry/confirmremovedialog/ConfirmRemovePrescriptionDialogControllerTest.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 class ConfirmRemovePrescriptionDialogControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val prescriptionRepository = mock<PrescriptionRepository>()
   private val dialog = mock<ConfirmRemovePrescriptionDialog>()

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenCreatedTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenCreatedTest.kt
@@ -37,7 +37,7 @@ import java.util.Locale
 class EditPatientScreenCreatedTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val ui: EditPatientUi = mock()
   private val utcClock: TestUtcClock = TestUtcClock()

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenFormTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenFormTest.kt
@@ -61,7 +61,7 @@ import java.util.UUID
 class EditPatientScreenFormTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val uiEvents = PublishSubject.create<EditPatientEvent>()
   private val ui: EditPatientUi = mock()

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenSaveTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientScreenSaveTest.kt
@@ -59,7 +59,7 @@ import java.util.UUID
 class EditPatientScreenSaveTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val uiEvents = PublishSubject.create<EditPatientEvent>()
   private val ui: EditPatientUi = mock()

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpScreenControllerTest.kt
@@ -41,7 +41,7 @@ import java.util.UUID
 class EnterOtpScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val userSession = mock<UserSession>()
   private val screen = mock<EnterOtpScreen>()

--- a/app/src/test/java/org/simple/clinic/facility/change/FacilityChangeScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/facility/change/FacilityChangeScreenControllerTest.kt
@@ -54,7 +54,7 @@ import java.util.concurrent.TimeUnit.SECONDS
 class FacilityChangeScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val uiEvents = PublishSubject.create<UiEvent>()!!
   private val screen = mock<FacilityChangeScreen>()

--- a/app/src/test/java/org/simple/clinic/facility/change/FacilityListItemBuilderTest.kt
+++ b/app/src/test/java/org/simple/clinic/facility/change/FacilityListItemBuilderTest.kt
@@ -17,7 +17,7 @@ import org.simple.clinic.util.RxErrorsRule
 class FacilityListItemBuilderTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val distanceCalculator = mock<DistanceCalculator>()
   private val listItemBuilder = FacilityListItemBuilder(distanceCalculator)

--- a/app/src/test/java/org/simple/clinic/forgotpin/confirmpin/ForgotPinConfirmPinScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/forgotpin/confirmpin/ForgotPinConfirmPinScreenControllerTest.kt
@@ -35,7 +35,7 @@ import java.util.UUID
 class ForgotPinConfirmPinScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val uiEvents = PublishSubject.create<UiEvent>()
 

--- a/app/src/test/java/org/simple/clinic/forgotpin/createnewpin/ForgotPinCreateNewPinScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/forgotpin/createnewpin/ForgotPinCreateNewPinScreenControllerTest.kt
@@ -21,7 +21,7 @@ import org.simple.clinic.widgets.UiEvent
 class ForgotPinCreateNewPinScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen = mock<ForgotPinCreateNewPinScreen>()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/help/HelpRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/help/HelpRepositoryTest.kt
@@ -18,7 +18,7 @@ import java.io.File
 class HelpRepositoryTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val fileStorage = mock<FileStorage>()
   private val file = mock<File>()

--- a/app/src/test/java/org/simple/clinic/home/HomeScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/HomeScreenControllerTest.kt
@@ -20,7 +20,7 @@ import org.simple.clinic.widgets.UiEvent
 class HomeScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val uiEvents: PublishSubject<UiEvent> = PublishSubject.create()
   private lateinit var controller: HomeScreenController

--- a/app/src/test/java/org/simple/clinic/home/help/HelpScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/help/HelpScreenControllerTest.kt
@@ -25,7 +25,7 @@ import java.net.URI
 class HelpScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   val uiEvents = PublishSubject.create<UiEvent>()
   val screen = mock<HelpScreen>()

--- a/app/src/test/java/org/simple/clinic/home/overdue/OverdueScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/OverdueScreenControllerTest.kt
@@ -34,7 +34,7 @@ import java.util.UUID
 class OverdueScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen = mock<OverdueScreen>()
   private val uiEvents = PublishSubject.create<UiEvent>()

--- a/app/src/test/java/org/simple/clinic/home/overdue/appointmentreminder/AppointmentReminderSheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/appointmentreminder/AppointmentReminderSheetControllerTest.kt
@@ -25,7 +25,7 @@ import java.util.UUID
 class AppointmentReminderSheetControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val sheet = mock<AppointmentReminderSheet>()
   private val repository = mock<AppointmentRepository>()

--- a/app/src/test/java/org/simple/clinic/home/overdue/phonemask/PhoneMaskBottomSheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/phonemask/PhoneMaskBottomSheetControllerTest.kt
@@ -41,7 +41,7 @@ import java.util.UUID
 class PhoneMaskBottomSheetControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val ui = mock<PhoneMaskBottomSheetUi>()
   private val uiEvents = PublishSubject.create<UiEvent>()

--- a/app/src/test/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/removepatient/RemoveAppointmentScreenControllerTest.kt
@@ -32,7 +32,7 @@ import java.util.UUID
 class RemoveAppointmentScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val sheet = mock<RemoveAppointmentScreen>()
   private val repository = mock<AppointmentRepository>()

--- a/app/src/test/java/org/simple/clinic/home/patients/PatientsScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/patients/PatientsScreenControllerTest.kt
@@ -52,7 +52,7 @@ import java.net.SocketTimeoutException
 class PatientsScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen: PatientsScreen = mock()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/home/report/ReportsScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/report/ReportsScreenControllerTest.kt
@@ -21,7 +21,7 @@ import java.net.URI
 class ReportsScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen = mock<ReportsScreen>()
 

--- a/app/src/test/java/org/simple/clinic/login/LoginUserWithOtpTest.kt
+++ b/app/src/test/java/org/simple/clinic/login/LoginUserWithOtpTest.kt
@@ -41,7 +41,7 @@ import java.util.UUID
 class LoginUserWithOtpTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val loginApi: LoginApi = mock()
   private val dataSync: DataSync = mock()

--- a/app/src/test/java/org/simple/clinic/login/applock/AppLockScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/login/applock/AppLockScreenControllerTest.kt
@@ -21,7 +21,7 @@ import org.threeten.bp.Instant
 class AppLockScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen = mock<AppLockScreen>()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/login/pin/LoginPinScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/login/pin/LoginPinScreenControllerTest.kt
@@ -27,7 +27,7 @@ import java.util.UUID
 class LoginPinScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen = mock<LoginPinScreen>()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreenLogicTest.kt
@@ -42,7 +42,7 @@ import java.util.UUID
 class NewMedicalHistoryScreenLogicTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen: NewMedicalHistoryUi = mock()
   private val uiActions: NewMedicalHistoryUiActions = mock()

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenLogicTest.kt
@@ -59,7 +59,7 @@ import java.util.UUID
 class PatientEntryScreenLogicTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val ui = mock<PatientEntryUi>()
   private val validationActions = mock<PatientEntryValidationActions>()

--- a/app/src/test/java/org/simple/clinic/newentry/clearbutton/ClearFieldImageButtonControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/clearbutton/ClearFieldImageButtonControllerTest.kt
@@ -13,7 +13,7 @@ import org.simple.clinic.widgets.UiEvent
 class ClearFieldImageButtonControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val button = mock<ClearFieldImageButton>()
 

--- a/app/src/test/java/org/simple/clinic/onboarding/OnboardingScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/onboarding/OnboardingScreenControllerTest.kt
@@ -15,7 +15,7 @@ import org.simple.mobius.migration.MobiusTestFixture
 class OnboardingScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val onboardingUi = mock<OnboardingUi>()
   private val hasUserCompletedOnboarding = mock<Preference<Boolean>>()

--- a/app/src/test/java/org/simple/clinic/patient/PatientRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/patient/PatientRepositoryTest.kt
@@ -51,7 +51,7 @@ import java.util.UUID
 class PatientRepositoryTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private lateinit var repository: PatientRepository
   private lateinit var config: PatientConfig

--- a/app/src/test/java/org/simple/clinic/phone/PhoneDialerTest.kt
+++ b/app/src/test/java/org/simple/clinic/phone/PhoneDialerTest.kt
@@ -11,7 +11,7 @@ import org.simple.clinic.util.RxErrorsRule
 class PhoneDialerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private lateinit var phoneCaller: PhoneCaller
   private val config: PhoneNumberMaskerConfig = PhoneNumberMaskerConfig(proxyPhoneNumber = "987", phoneMaskingFeatureEnabled = false)

--- a/app/src/test/java/org/simple/clinic/protocol/SyncProtocolsOnLoginTest.kt
+++ b/app/src/test/java/org/simple/clinic/protocol/SyncProtocolsOnLoginTest.kt
@@ -21,7 +21,7 @@ import org.simple.clinic.util.RxErrorsRule
 class SyncProtocolsOnLoginTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val userSession = mock<UserSession>()
   private val protocolSync = mock<ProtocolSync>()

--- a/app/src/test/java/org/simple/clinic/recentpatient/RecentPatientsScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/recentpatient/RecentPatientsScreenControllerTest.kt
@@ -34,7 +34,7 @@ import java.util.UUID
 class RecentPatientsScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen: RecentPatientsScreen = mock()
   private val userSession: UserSession = mock()

--- a/app/src/test/java/org/simple/clinic/recentpatientsview/RecentPatientsViewControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/recentpatientsview/RecentPatientsViewControllerTest.kt
@@ -37,7 +37,7 @@ import java.util.UUID
 class RecentPatientsViewControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen: RecentPatientsView = mock()
   private val userSession: UserSession = mock()

--- a/app/src/test/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinScreenControllerTest.kt
@@ -26,7 +26,7 @@ import java.util.UUID
 class RegistrationConfirmPinScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val uiEvents = PublishSubject.create<UiEvent>()!!
   private val screen = mock<RegistrationConfirmPinScreen>()

--- a/app/src/test/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionScreenControllerTest.kt
@@ -57,7 +57,7 @@ import java.util.concurrent.TimeUnit
 class RegistrationFacilitySelectionScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val uiEvents = PublishSubject.create<UiEvent>()!!
   private val screen = mock<RegistrationFacilitySelectionScreen>()

--- a/app/src/test/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreenControllerTest.kt
@@ -13,7 +13,7 @@ import org.simple.clinic.widgets.UiEvent
 class RegistrationLocationPermissionScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   val uiEvents = PublishSubject.create<UiEvent>()!!
   val screen = mock<RegistrationLocationPermissionScreen>()

--- a/app/src/test/java/org/simple/clinic/registration/name/RegistrationFullNameScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/name/RegistrationFullNameScreenControllerTest.kt
@@ -23,7 +23,7 @@ import org.simple.clinic.widgets.UiEvent
 class RegistrationFullNameScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   val uiEvents = PublishSubject.create<UiEvent>()!!
   val screen = mock<RegistrationFullNameScreen>()

--- a/app/src/test/java/org/simple/clinic/registration/phone/RegistrationPhoneScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/phone/RegistrationPhoneScreenControllerTest.kt
@@ -40,7 +40,7 @@ import org.simple.clinic.widgets.UiEvent
 class RegistrationPhoneScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen = mock<RegistrationPhoneScreen>()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/registration/phone/loggedout/LoggedOutOfDeviceDialogControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/phone/loggedout/LoggedOutOfDeviceDialogControllerTest.kt
@@ -26,7 +26,7 @@ import org.simple.clinic.widgets.UiEvent
 class LoggedOutOfDeviceDialogControllerTest {
 
   @get:Rule
-  val rule: TestRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val dialog = mock<LoggedOutOfDeviceDialog>()
   private val userSession = mock<UserSession>()

--- a/app/src/test/java/org/simple/clinic/registration/pin/RegistrationPinScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/pin/RegistrationPinScreenControllerTest.kt
@@ -20,7 +20,7 @@ import org.simple.clinic.widgets.UiEvent
 class RegistrationPinScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   val uiEvents = PublishSubject.create<UiEvent>()!!
   val screen = mock<RegistrationPinScreen>()

--- a/app/src/test/java/org/simple/clinic/reports/ReportsRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/reports/ReportsRepositoryTest.kt
@@ -18,7 +18,7 @@ import java.io.File
 class ReportsRepositoryTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val fileStorage = mock<FileStorage>()
   private val file = mock<File>()

--- a/app/src/test/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheetControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheetControllerTest.kt
@@ -45,7 +45,7 @@ import java.util.UUID
 class ScheduleAppointmentSheetControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val sheet = mock<ScheduleAppointmentSheet>()
   private val repository = mock<AppointmentRepository>()

--- a/app/src/test/java/org/simple/clinic/scheduleappointment/facilityselection/FacilitySelectionActivityControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/scheduleappointment/facilityselection/FacilitySelectionActivityControllerTest.kt
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit
 class FacilitySelectionActivityControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val uiEvents = PublishSubject.create<UiEvent>()!!
   private val screen = mock<FacilitySelectionActivity>()

--- a/app/src/test/java/org/simple/clinic/search/PatientSearchScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/search/PatientSearchScreenControllerTest.kt
@@ -23,7 +23,7 @@ import java.util.UUID
 class PatientSearchScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen: PatientSearchScreen = mock()
 

--- a/app/src/test/java/org/simple/clinic/search/results/PatientSearchResultsControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/search/results/PatientSearchResultsControllerTest.kt
@@ -21,7 +21,7 @@ import java.util.UUID
 class PatientSearchResultsControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen: PatientSearchResultsScreen = mock()
 

--- a/app/src/test/java/org/simple/clinic/searchresultsview/PatientSearchViewControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/searchresultsview/PatientSearchViewControllerTest.kt
@@ -32,7 +32,7 @@ import java.util.UUID
 class PatientSearchViewControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val ui = mock<PatientSearchUi>()
   private val patientRepository = mock<PatientRepository>()

--- a/app/src/test/java/org/simple/clinic/security/BCryptPasswordHasherTest.kt
+++ b/app/src/test/java/org/simple/clinic/security/BCryptPasswordHasherTest.kt
@@ -7,7 +7,7 @@ import org.simple.clinic.util.RxErrorsRule
 class BCryptPasswordHasherTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   @Test
   fun `comparison test`() {

--- a/app/src/test/java/org/simple/clinic/security/pin/BruteForceProtectionTest.kt
+++ b/app/src/test/java/org/simple/clinic/security/pin/BruteForceProtectionTest.kt
@@ -17,7 +17,7 @@ import org.threeten.bp.Instant
 class BruteForceProtectionTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val clock = TestUtcClock()
   private val state = mock<Preference<BruteForceProtectionState>>()

--- a/app/src/test/java/org/simple/clinic/security/pin/PinEntryCardControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/security/pin/PinEntryCardControllerTest.kt
@@ -33,7 +33,7 @@ import org.threeten.bp.Instant
 class PinEntryCardControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val screen = mock<PinEntryCardView>()
   private val passwordHasher = mock<PasswordHasher>()

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenControllerTest.kt
@@ -53,7 +53,7 @@ import java.util.UUID
 class PatientSummaryScreenControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val ui = mock<PatientSummaryScreenUi>()
   private val uiActions = mock<PatientSummaryUiActions>()

--- a/app/src/test/java/org/simple/clinic/summary/addphone/AddPhoneNumberDialogControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/addphone/AddPhoneNumberDialogControllerTest.kt
@@ -32,7 +32,7 @@ import java.util.UUID
 class AddPhoneNumberDialogControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val uiEvents = PublishSubject.create<UiEvent>()
   private val dialog = mock<AddPhoneNumberDialog>()

--- a/app/src/test/java/org/simple/clinic/summary/linkId/LinkIdWithPatientViewControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/linkId/LinkIdWithPatientViewControllerTest.kt
@@ -23,7 +23,7 @@ import java.util.UUID
 class LinkIdWithPatientViewControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val patientRepository = mock<PatientRepository>()
 

--- a/app/src/test/java/org/simple/clinic/summary/updatephone/UpdatePhoneNumberDialogControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/updatephone/UpdatePhoneNumberDialogControllerTest.kt
@@ -35,7 +35,7 @@ import java.util.UUID
 class UpdatePhoneNumberDialogControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val uiEvents = PublishSubject.create<UiEvent>()
   private val dialog = mock<UpdatePhoneNumberDialog>()

--- a/app/src/test/java/org/simple/clinic/sync/ModelSyncTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/ModelSyncTest.kt
@@ -30,7 +30,7 @@ import org.simple.clinic.util.RxErrorsRule
 class ModelSyncTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   val syncConfigProvider = Single.fromCallable {
     SyncConfig(

--- a/app/src/test/java/org/simple/clinic/sync/SyncCoordinatorTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/SyncCoordinatorTest.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 class SyncCoordinatorTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private lateinit var syncCoordinator: SyncCoordinator
   private lateinit var repository: SynceableRepository<Any, Any>

--- a/app/src/test/java/org/simple/clinic/sync/indicator/SyncIndicatorStatusCalculatorTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/indicator/SyncIndicatorStatusCalculatorTest.kt
@@ -31,7 +31,7 @@ import org.threeten.bp.Instant
 class SyncIndicatorStatusCalculatorTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val dataSync = mock<DataSync>()
   private val syncResultPreference = mock<Preference<LastSyncedState>>()

--- a/app/src/test/java/org/simple/clinic/sync/indicator/SyncIndicatorViewControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/indicator/SyncIndicatorViewControllerTest.kt
@@ -45,7 +45,7 @@ import java.net.UnknownHostException
 class SyncIndicatorViewControllerTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val lastSyncStatePreference = mock<Preference<LastSyncedState>>()
   private val indicator = mock<SyncIndicatorView>()

--- a/app/src/test/java/org/simple/clinic/user/NewlyVerifiedUserTest.kt
+++ b/app/src/test/java/org/simple/clinic/user/NewlyVerifiedUserTest.kt
@@ -17,7 +17,7 @@ import org.simple.clinic.util.RxErrorsRule
 class NewlyVerifiedUserTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private lateinit var newlyVerifiedUser: NewlyVerifiedUser
   private lateinit var receivedUsers: MutableList<User>

--- a/app/src/test/java/org/simple/clinic/user/UserSessionTest.kt
+++ b/app/src/test/java/org/simple/clinic/user/UserSessionTest.kt
@@ -52,7 +52,7 @@ import java.util.UUID
 class UserSessionTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val accessTokenPref = mock<Preference<Optional<String>>>()
   private val facilityRepository = mock<FacilityRepository>()

--- a/app/src/test/java/org/simple/clinic/user/finduser/UserLookupTest.kt
+++ b/app/src/test/java/org/simple/clinic/user/finduser/UserLookupTest.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 class UserLookupTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val phoneNumber = "1234567890"
 

--- a/app/src/test/java/org/simple/clinic/user/refreshuser/RefreshCurrentUserTest.kt
+++ b/app/src/test/java/org/simple/clinic/user/refreshuser/RefreshCurrentUserTest.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 class RefreshCurrentUserTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   private val userUuid = UUID.fromString("2a90955a-d21b-4fa9-918f-d1c4c44b7aae")
   private val phone = "1234567890"

--- a/app/src/test/java/org/simple/clinic/widgets/RecyclerViewUserScrollDetectorTest.kt
+++ b/app/src/test/java/org/simple/clinic/widgets/RecyclerViewUserScrollDetectorTest.kt
@@ -18,7 +18,7 @@ import org.simple.clinic.util.RxErrorsRule
 class RecyclerViewUserScrollDetectorTest {
 
   @get:Rule
-  val rxErrorsRule = RxErrorsRule()
+  val rules: org.junit.rules.RuleChain = org.simple.clinic.util.Rules.global()
 
   @Test
   @Parameters(value = [

--- a/app/src/test/resources/quarantine.properties
+++ b/app/src/test/resources/quarantine.properties
@@ -1,0 +1,3 @@
+enabled=false
+serviceEndpoint=https://flakiness.dx.obvious.in/
+slug=simple-android-unit-tests

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ buildscript {
       truth               : '1.0',
       junit               : '4.12',
       mockitoKotlin       : '1.6.0',
-      junitParams         : '1.1.1',
+      junitParams         : '1.1.2',
       sqliteAndroid       : '3.24.0',
       playServicesAuth    : '16.0.1',
       playServicesVision  : '16.2.0',
@@ -95,6 +95,7 @@ allprojects {
   repositories {
     google()
     mavenCentral()
+    maven { url 'https://jitpack.io' }
     jcenter()
   }
 }

--- a/router/build.gradle
+++ b/router/build.gradle
@@ -30,9 +30,6 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlin"
   implementation "io.reactivex.rxjava2:rxjava:$versions.rxJava"
   implementation "com.jakewharton.timber:timber:$versions.timber"
-  testImplementation "pl.pragmatists:JUnitParams:$versions.junitParams"
+  testImplementation "com.github.vinaysshenoy:JUnitParams:$versions.junitParams"
   testImplementation "com.google.truth:truth:$versions.truth"
-}
-repositories {
-  mavenCentral()
 }


### PR DESCRIPTION
We currently use `io.reactivex.Completable` instances in a lot of places to perform side-effects. While this works well with our use-case, a common problem is that we sometimes do not subscribe to the instantiated `Completable`.

```kotlin
Observable.just(1)
  .doOnNext { repository.saveToDatabase(it) }

interface Repository {
  fun saveToDatabase(value: Int): Completable
}
```

A test to verify this might be:
```kotlin
verify(repository).saveToDatabase(value)
```

Here, the `doOnNext` should actually have been a `flatMapCompletable` because the created `Completable` from `saveToDatabase(Int)` never gets subscribed to. However, the test never fails because we only verify that `saveToDatabase` gets called, but not that the returned `Completable` gets subscribed to.

This PR attemps to add a check for this. To do this, we

- Hook into the `Completable` assembly to verify that every `Completable` that is instantiated also gets subscribed to.
- Use a jUnit rule (currently piggybacks on `RxErrorsRule`, which is already present in all our test classes) to set up and tear this down in tests.

The end result is that we get an error message like this in tests:
```shell
Found unsubscribed Completables!
--------------------------------
Assembled: 3
Subscribed: 0
Expected to be not subscribed to: 0
--------------------------------
#00 - org.simple.clinic.user.UserSessionTest.setUp(UserSessionTest.kt:89)
#01 - org.simple.clinic.user.UserSessionTest.setUp(UserSessionTest.kt:91)
#02 - org.simple.clinic.user.UserSessionTest.setUp(UserSessionTest.kt:93)
--------------------------------
```

This PR also includes a meta-annotation, `ExpectUnsubscribed`, that we can annotate test methods with to handle cases where the correct behaviour is never to subscribe to a created `Completable`.