### PR TITLE
Bump Kotlin version to `1.3.70`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   ext.versions = [
       minSdk              : 21,
       compileSdk          : 29,
-      kotlin              : '1.3.61',
+      kotlin              : '1.3.70',
       supportLib          : '1.0.0',
       recyclerView        : '1.0.0',
       material            : '1.0.0',


### PR DESCRIPTION
https://blog.jetbrains.com/kotlin/2020/03/kotlin-1-3-70-released/