### PR TITLE
Fix `BloodSugarSyncAndroidTest`

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/bloodsugar/sync/BloodSugarSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/bloodsugar/sync/BloodSugarSyncAndroidTest.kt
@@ -11,6 +11,7 @@ import org.simple.clinic.TestClinicApp
 import org.simple.clinic.TestData
 import org.simple.clinic.bloodsugar.BloodSugarMeasurement
 import org.simple.clinic.bloodsugar.BloodSugarRepository
+import org.simple.clinic.bloodsugar.Random
 import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.rules.ServerAuthenticationRule
 import org.simple.clinic.sync.BaseSyncCoordinatorAndroidTest
@@ -69,7 +70,8 @@ class BloodSugarSyncAndroidTest : BaseSyncCoordinatorAndroidTest<BloodSugarMeasu
 
   override fun generateRecord(syncStatus: SyncStatus) = testData.bloodSugarMeasurement(syncStatus = syncStatus)
 
-  override fun generatePayload() = testData.bloodSugarPayload()
+  // TODO (SM): Remove blood sugar type once HbA1c sync is enabled
+  override fun generatePayload() = testData.bloodSugarPayload(bloodSugarType = Random)
 
   override fun lastPullToken(): Preference<Optional<String>> = lastPullToken
 


### PR DESCRIPTION
Since `HbA1c` support is not added on the server side yet, the sync test will fail if we use `HbA1c`. To avoid that, for now, we are setting the blood sugar type to `RBS`