### PR TITLE
Return `MedicalHistory` or default value for patient immediately

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/medicalhistory/MedicalHistoryRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/medicalhistory/MedicalHistoryRepositoryAndroidTest.kt
@@ -154,14 +154,14 @@ class MedicalHistoryRepositoryAndroidTest {
 
     dao.save(listOf(olderHistory, newerHistory))
 
-    val foundHistory = repository.historyForPatient(patientUuid)
+    val foundHistory = repository.historyForPatientOrDefaultImmediate(patientUuid)
     assertThat(foundHistory).isEqualTo(newerHistory)
   }
 
   @Test
   fun when_no_medical_history_is_present_for_a_patient_then_return_detail_medical_history() {
     val patientUuid = UUID.fromString("694d1c32-048f-4d43-93d4-0cd51be686b0")
-    val emptyHistory = repository.historyForPatient(patientUuid)
+    val emptyHistory = repository.historyForPatientOrDefaultImmediate(patientUuid)
 
     assertThat(emptyHistory.hasHadHeartAttack).isEqualTo(Unanswered)
     assertThat(emptyHistory.hasHadStroke).isEqualTo(Unanswered)

--- a/app/src/androidTest/java/org/simple/clinic/medicalhistory/MedicalHistoryRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/medicalhistory/MedicalHistoryRepositoryAndroidTest.kt
@@ -12,7 +12,6 @@ import org.simple.clinic.medicalhistory.Answer.No
 import org.simple.clinic.medicalhistory.Answer.Unanswered
 import org.simple.clinic.medicalhistory.Answer.Yes
 import org.simple.clinic.patient.SyncStatus
-import org.simple.clinic.util.Just
 import org.simple.clinic.rules.LocalAuthenticationRule
 import org.simple.clinic.util.Rules
 import org.simple.clinic.util.UtcClock
@@ -155,7 +154,20 @@ class MedicalHistoryRepositoryAndroidTest {
 
     dao.save(listOf(olderHistory, newerHistory))
 
-    val foundHistory = (repository.historyForPatient(patientUuid) as Just<MedicalHistory>).value
+    val foundHistory = repository.historyForPatient(patientUuid)
     assertThat(foundHistory).isEqualTo(newerHistory)
+  }
+
+  @Test
+  fun when_no_medical_history_is_present_for_a_patient_then_return_detail_medical_history() {
+    val patientUuid = UUID.fromString("694d1c32-048f-4d43-93d4-0cd51be686b0")
+    val emptyHistory = repository.historyForPatient(patientUuid)
+
+    assertThat(emptyHistory.hasHadHeartAttack).isEqualTo(Unanswered)
+    assertThat(emptyHistory.hasHadStroke).isEqualTo(Unanswered)
+    assertThat(emptyHistory.hasHadKidneyDisease).isEqualTo(Unanswered)
+    assertThat(emptyHistory.diagnosedWithHypertension).isEqualTo(Unanswered)
+    assertThat(emptyHistory.diagnosedWithDiabetes).isEqualTo(Unanswered)
+    assertThat(emptyHistory.syncStatus).isEqualTo(SyncStatus.DONE)
   }
 }

--- a/app/src/main/java/org/simple/clinic/medicalhistory/MedicalHistoryRepository.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/MedicalHistoryRepository.kt
@@ -51,7 +51,7 @@ class MedicalHistoryRepository @Inject constructor(
         }
   }
 
-  fun historyForPatient(patientUuid: PatientUuid): MedicalHistory {
+  fun historyForPatientOrDefaultImmediate(patientUuid: PatientUuid): MedicalHistory {
     val defaultValue = MedicalHistory(
         uuid = UUID.randomUUID(),
         patientUuid = patientUuid,

--- a/app/src/main/java/org/simple/clinic/medicalhistory/MedicalHistoryRepository.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/MedicalHistoryRepository.kt
@@ -9,9 +9,7 @@ import org.simple.clinic.patient.PatientUuid
 import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.patient.canBeOverriddenByServerCopy
 import org.simple.clinic.sync.SynceableRepository
-import org.simple.clinic.util.Optional
 import org.simple.clinic.util.UtcClock
-import org.simple.clinic.util.toOptional
 import org.threeten.bp.Instant
 import java.util.UUID
 import javax.inject.Inject
@@ -53,8 +51,21 @@ class MedicalHistoryRepository @Inject constructor(
         }
   }
 
-  fun historyForPatient(patientUuid: PatientUuid): Optional<MedicalHistory> {
-    return dao.historyForPatientImmediate(patientUuid).toOptional()
+  fun historyForPatient(patientUuid: PatientUuid): MedicalHistory {
+    val defaultValue = MedicalHistory(
+        uuid = UUID.randomUUID(),
+        patientUuid = patientUuid,
+        diagnosedWithHypertension = Unanswered,
+        hasHadHeartAttack = Unanswered,
+        hasHadStroke = Unanswered,
+        hasHadKidneyDisease = Unanswered,
+        diagnosedWithDiabetes = Unanswered,
+        syncStatus = SyncStatus.DONE,
+        createdAt = Instant.now(utcClock),
+        updatedAt = Instant.now(utcClock),
+        deletedAt = null)
+
+    return dao.historyForPatientImmediate(patientUuid) ?: defaultValue
   }
 
   fun save(patientUuid: UUID, historyEntry: OngoingMedicalHistoryEntry): Completable {

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
@@ -11,8 +11,6 @@ import org.simple.clinic.analytics.Analytics
 import org.simple.clinic.bloodsugar.BloodSugarRepository
 import org.simple.clinic.bp.BloodPressureRepository
 import org.simple.clinic.facility.FacilityRepository
-import org.simple.clinic.medicalhistory.Answer.Unanswered
-import org.simple.clinic.medicalhistory.MedicalHistory
 import org.simple.clinic.medicalhistory.MedicalHistoryRepository
 import org.simple.clinic.overdue.AppointmentRepository
 import org.simple.clinic.patient.PatientProfile
@@ -156,7 +154,7 @@ class PatientSummaryEffectHandler @AssistedInject constructor(
           .map { loadDataForBackClick ->
             val patientUuid = loadDataForBackClick.patientUuid
             val timestamp = loadDataForBackClick.screenCreatedTimestamp
-            val medicalHistory = medicalHistoryRepository.historyForPatient(patientUuid)
+            val medicalHistory = medicalHistoryRepository.historyForPatientOrDefaultImmediate(patientUuid)
 
             DataForBackClickLoaded(
                 hasPatientDataChangedSinceScreenCreated = patientRepository.hasPatientDataChangedSince(patientUuid, timestamp),
@@ -175,7 +173,7 @@ class PatientSummaryEffectHandler @AssistedInject constructor(
           .observeOn(scheduler)
           .map { loadDataForBackClick ->
             val patientUuid = loadDataForBackClick.patientUuid
-            val medicalHistory = medicalHistoryRepository.historyForPatient(patientUuid)
+            val medicalHistory = medicalHistoryRepository.historyForPatientOrDefaultImmediate(patientUuid)
 
             DataForDoneClickLoaded(countOfRecordedMeasurements = countOfRecordedMeasurements(patientUuid), diagnosisRecorded = medicalHistory.diagnosisRecorded)
           }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
@@ -156,7 +156,7 @@ class PatientSummaryEffectHandler @AssistedInject constructor(
           .map { loadDataForBackClick ->
             val patientUuid = loadDataForBackClick.patientUuid
             val timestamp = loadDataForBackClick.screenCreatedTimestamp
-            val medicalHistory = (medicalHistoryRepository.historyForPatient(patientUuid) as Just<MedicalHistory>).value
+            val medicalHistory = medicalHistoryRepository.historyForPatient(patientUuid)
 
             DataForBackClickLoaded(
                 hasPatientDataChangedSinceScreenCreated = patientRepository.hasPatientDataChangedSince(patientUuid, timestamp),
@@ -175,7 +175,7 @@ class PatientSummaryEffectHandler @AssistedInject constructor(
           .observeOn(scheduler)
           .map { loadDataForBackClick ->
             val patientUuid = loadDataForBackClick.patientUuid
-            val medicalHistory = (medicalHistoryRepository.historyForPatient(patientUuid) as Just<MedicalHistory>).value
+            val medicalHistory = medicalHistoryRepository.historyForPatient(patientUuid)
 
             DataForDoneClickLoaded(countOfRecordedMeasurements = countOfRecordedMeasurements(patientUuid), diagnosisRecorded = medicalHistory.diagnosisRecorded)
           }

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
@@ -13,7 +13,6 @@ import org.simple.clinic.TestData
 import org.simple.clinic.bloodsugar.BloodSugarRepository
 import org.simple.clinic.bp.BloodPressureRepository
 import org.simple.clinic.facility.FacilityRepository
-import org.simple.clinic.medicalhistory.Answer.Unanswered
 import org.simple.clinic.medicalhistory.MedicalHistoryRepository
 import org.simple.clinic.mobius.EffectHandlerTestCase
 import org.simple.clinic.patient.PatientProfile
@@ -144,7 +143,7 @@ class PatientSummaryEffectHandlerTest {
     whenever(patientRepository.hasPatientDataChangedSince(patientUuid, screenCreatedTimestamp)) doReturn true
     whenever(bloodPressureRepository.bloodPressureCountImmediate(patientUuid)) doReturn 3
     whenever(bloodSugarRepository.bloodSugarCountImmediate(patientUuid)) doReturn 2
-    whenever(medicalHistoryRepository.historyForPatient(patientUuid)) doReturn medicalHistory
+    whenever(medicalHistoryRepository.historyForPatientOrDefaultImmediate(patientUuid)) doReturn medicalHistory
 
     // when
     testCase.dispatch(LoadDataForBackClick(patientUuid, screenCreatedTimestamp))
@@ -169,7 +168,7 @@ class PatientSummaryEffectHandlerTest {
 
     whenever(bloodPressureRepository.bloodPressureCountImmediate(patientUuid)) doReturn 2
     whenever(bloodSugarRepository.bloodSugarCountImmediate(patientUuid)) doReturn 3
-    whenever(medicalHistoryRepository.historyForPatient(patientUuid)) doReturn medicalHistory
+    whenever(medicalHistoryRepository.historyForPatientOrDefaultImmediate(patientUuid)) doReturn medicalHistory
 
     // when
     testCase.dispatch(LoadDataForDoneClick(patientUuid))

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
@@ -144,7 +144,7 @@ class PatientSummaryEffectHandlerTest {
     whenever(patientRepository.hasPatientDataChangedSince(patientUuid, screenCreatedTimestamp)) doReturn true
     whenever(bloodPressureRepository.bloodPressureCountImmediate(patientUuid)) doReturn 3
     whenever(bloodSugarRepository.bloodSugarCountImmediate(patientUuid)) doReturn 2
-    whenever(medicalHistoryRepository.historyForPatient(patientUuid)) doReturn Just(medicalHistory)
+    whenever(medicalHistoryRepository.historyForPatient(patientUuid)) doReturn medicalHistory
 
     // when
     testCase.dispatch(LoadDataForBackClick(patientUuid, screenCreatedTimestamp))
@@ -169,7 +169,7 @@ class PatientSummaryEffectHandlerTest {
 
     whenever(bloodPressureRepository.bloodPressureCountImmediate(patientUuid)) doReturn 2
     whenever(bloodSugarRepository.bloodSugarCountImmediate(patientUuid)) doReturn 3
-    whenever(medicalHistoryRepository.historyForPatient(patientUuid)) doReturn Just(medicalHistory)
+    whenever(medicalHistoryRepository.historyForPatient(patientUuid)) doReturn medicalHistory
 
     // when
     testCase.dispatch(LoadDataForDoneClick(patientUuid))


### PR DESCRIPTION
This is mainly to avoid cases where medical history may not be synced which may cause app to crash when user back clicks or clicks on the done button.