### PR TITLE
Cancel patient link ID on back press

### DIFF
--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -45,6 +45,7 @@ import org.simple.clinic.util.identifierdisplay.IdentifierDisplayAdapter
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.hideKeyboard
+import org.simple.clinic.widgets.isVisible
 import org.simple.clinic.widgets.scrollToChild
 import org.simple.clinic.widgets.visibleOrGone
 import java.util.UUID
@@ -161,7 +162,13 @@ class PatientSummaryScreen(
 
     return backButton.clicks()
         .mergeWith(hardwareBackKeyClicks)
-        .map { PatientSummaryBackClicked(screenKey.patientUuid, screenKey.screenCreatedTimestamp) }
+        .map {
+          if (linkIdWithPatientView.isVisible) {
+            PatientSummaryLinkIdCancelled
+          } else {
+            PatientSummaryBackClicked(screenKey.patientUuid, screenKey.screenCreatedTimestamp)
+          }
+        }
   }
 
   private fun bloodPressureSaves(): Observable<PatientSummaryBloodPressureSaved> {

--- a/app/src/main/java/org/simple/clinic/summary/linkId/LinkIdWithPatientView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/linkId/LinkIdWithPatientView.kt
@@ -14,8 +14,8 @@ import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 import kotterknife.bindView
 import org.simple.clinic.R
-import org.simple.clinic.main.TheActivity
 import org.simple.clinic.bindUiToController
+import org.simple.clinic.main.TheActivity
 import org.simple.clinic.patient.businessid.Identifier
 import org.simple.clinic.text.style.TextAppearanceWithLetterSpacingSpan
 import org.simple.clinic.util.Truss

--- a/app/src/main/java/org/simple/clinic/widgets/Views.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/Views.kt
@@ -279,3 +279,6 @@ fun ViewPropertyAnimator.setDuration(duration: Duration): ViewPropertyAnimator {
 
 val Int.dp: Int
   get() = (Resources.getSystem().displayMetrics.density * this).toInt()
+
+inline val View.isVisible: Boolean
+  get() = visibility == View.VISIBLE


### PR DESCRIPTION
Back press when showing `linkIdWithPatientView` should cancel the link id with the patient, this will take back the user to search results instead of the home screen.

https://www.pivotaltracker.com/story/show/171308016

Since `LinkIdWithPatientView` is a subview of `PatientSummaryScreen` I am not sure if we can handle the back clicks separately for that view, so instead I just went this approach. But maybe once we move towards the navigation component we can migrate `LinkIdWithPatientView` to a proper bottom sheet?