### PR TITLE
Change `PinEntryCardView` to be able to do both local and remote PIN verifications

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/rules/ServerAuthenticationRule.kt
+++ b/app/src/androidTest/java/org/simple/clinic/rules/ServerAuthenticationRule.kt
@@ -6,7 +6,6 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonClass
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Moshi
-import io.bloco.faker.Faker
 import io.bloco.faker.components.PhoneNumber
 import org.junit.rules.TestRule
 import org.junit.runner.Description
@@ -183,7 +182,7 @@ class ServerAuthenticationRule : TestRule {
   private fun registerUserAtFacility(facility: Facility): RegistrationResult {
     val user = testData.loggedInUser(
         phone = fakePhoneNumber.phoneNumber(),
-        pinDigest = passwordHasher.hash(userPin).blockingGet()
+        pinDigest = passwordHasher.hash(userPin)
     )
 
     return registerUser.registerUserAtFacility(user, facility).blockingGet()

--- a/app/src/androidTest/java/org/simple/clinic/user/RegisterUserServerIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/user/RegisterUserServerIntegrationTest.kt
@@ -77,7 +77,7 @@ class RegisterUserServerIntegrationTest {
     val registerUserWithId = UUID.randomUUID()
     val user = testData.loggedInUser(
         uuid = registerUserWithId,
-        pinDigest = passwordHasher.hash(userPin).blockingGet()
+        pinDigest = passwordHasher.hash(userPin)
     )
 
     val registrationResult = registerUser.registerUserAtFacility(user, facilityDao.getOne(registerFacility.uuid)!!)

--- a/app/src/main/java/org/simple/clinic/di/AppModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/AppModule.kt
@@ -26,6 +26,7 @@ import org.simple.clinic.patient.shortcode.UuidShortCodeCreatorModule
 import org.simple.clinic.registration.RegistrationModule
 import org.simple.clinic.remoteconfig.RemoteConfigModule
 import org.simple.clinic.remoteconfig.firebase.FirebaseRemoteConfigModule
+import org.simple.clinic.security.di.PinVerificationModule
 import org.simple.clinic.security.pin.BruteForceProtectionModule
 import org.simple.clinic.settings.SettingsModule
 import org.simple.clinic.storage.StorageModule
@@ -77,7 +78,8 @@ import javax.inject.Named
   RetrofitModule::class,
   ClearPatientDataModule::class,
   PatientEntryModule::class,
-  FlipperModule::class
+  FlipperModule::class,
+  PinVerificationModule::class
 ])
 class AppModule(private val appContext: Application) {
 

--- a/app/src/main/java/org/simple/clinic/login/applock/AppLockScreen.kt
+++ b/app/src/main/java/org/simple/clinic/login/applock/AppLockScreen.kt
@@ -13,8 +13,8 @@ import io.reactivex.rxkotlin.ofType
 import kotlinx.android.synthetic.main.pin_entry_card.view.*
 import kotterknife.bindView
 import org.simple.clinic.R
-import org.simple.clinic.main.TheActivity
 import org.simple.clinic.bindUiToController
+import org.simple.clinic.main.TheActivity
 import org.simple.clinic.router.screen.BackPressInterceptCallback
 import org.simple.clinic.router.screen.BackPressInterceptor
 import org.simple.clinic.router.screen.ScreenRouter
@@ -112,9 +112,5 @@ class AppLockScreen(context: Context, attrs: AttributeSet) : RelativeLayout(cont
 
   fun showConfirmResetPinDialog() {
     ConfirmResetPinDialog.show(activity.supportFragmentManager)
-  }
-
-  fun unlockWithPinDigest(pinDigest: String) {
-    // TODO: Delete this method
   }
 }

--- a/app/src/main/java/org/simple/clinic/login/applock/AppLockScreen.kt
+++ b/app/src/main/java/org/simple/clinic/login/applock/AppLockScreen.kt
@@ -19,7 +19,6 @@ import org.simple.clinic.router.screen.BackPressInterceptCallback
 import org.simple.clinic.router.screen.BackPressInterceptor
 import org.simple.clinic.router.screen.ScreenRouter
 import org.simple.clinic.security.pin.PinAuthenticated
-import org.simple.clinic.security.pin.PinDigestToVerify
 import org.simple.clinic.security.pin.PinEntryCardView
 import org.simple.clinic.widgets.ScreenDestroyed
 import org.simple.clinic.widgets.showKeyboard
@@ -116,6 +115,6 @@ class AppLockScreen(context: Context, attrs: AttributeSet) : RelativeLayout(cont
   }
 
   fun unlockWithPinDigest(pinDigest: String) {
-    pinEntryCardView.upstreamUiEvents.onNext(PinDigestToVerify(pinDigest))
+    // TODO: Delete this method
   }
 }

--- a/app/src/main/java/org/simple/clinic/login/applock/AppLockScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/login/applock/AppLockScreenController.kt
@@ -33,8 +33,7 @@ class AppLockScreenController @Inject constructor(
         populateFacilityName(replayedEvents),
         unlockOnAuthentication(replayedEvents),
         exitOnBackClick(replayedEvents),
-        showConfirmResetPinDialog(replayedEvents),
-        readPinDigestToVerify(replayedEvents)
+        showConfirmResetPinDialog(replayedEvents)
     )
   }
 
@@ -79,14 +78,5 @@ class AppLockScreenController @Inject constructor(
     return events
         .ofType<AppLockForgotPinClicked>()
         .map { { ui: Ui -> ui.showConfirmResetPinDialog() } }
-  }
-
-  private fun readPinDigestToVerify(events: Observable<UiEvent>): Observable<UiChange> {
-    return events
-        .ofType<AppLockScreenCreated>()
-        .flatMap { userSession.requireLoggedInUser() }
-        .take(1)
-        .map { loggedInUser -> loggedInUser.pinDigest }
-        .map { unlockWithPinDigest -> { ui: Ui -> ui.unlockWithPinDigest(unlockWithPinDigest) } }
   }
 }

--- a/app/src/main/java/org/simple/clinic/login/pin/LoginPinScreen.kt
+++ b/app/src/main/java/org/simple/clinic/login/pin/LoginPinScreen.kt
@@ -19,7 +19,6 @@ import org.simple.clinic.router.screen.BackPressInterceptor
 import org.simple.clinic.router.screen.RouterDirection
 import org.simple.clinic.router.screen.ScreenRouter
 import org.simple.clinic.security.pin.PinAuthenticated
-import org.simple.clinic.security.pin.PinDigestToVerify
 import org.simple.clinic.security.pin.PinEntryCardView
 import org.simple.clinic.security.pin.PinEntryUi.Mode
 import org.simple.clinic.widgets.ScreenDestroyed
@@ -120,6 +119,6 @@ class LoginPinScreen(context: Context, attrs: AttributeSet) : RelativeLayout(con
   }
 
   fun submitWithPinDigest(pinDigest: String) {
-    pinEntryCardView.upstreamUiEvents.onNext(PinDigestToVerify(pinDigest))
+    // TODO: Delete this method
   }
 }

--- a/app/src/main/java/org/simple/clinic/login/pin/LoginPinScreen.kt
+++ b/app/src/main/java/org/simple/clinic/login/pin/LoginPinScreen.kt
@@ -11,9 +11,9 @@ import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
 import kotterknife.bindView
 import org.simple.clinic.R
-import org.simple.clinic.main.TheActivity
 import org.simple.clinic.bindUiToController
 import org.simple.clinic.home.HomeScreenKey
+import org.simple.clinic.main.TheActivity
 import org.simple.clinic.router.screen.BackPressInterceptCallback
 import org.simple.clinic.router.screen.BackPressInterceptor
 import org.simple.clinic.router.screen.RouterDirection
@@ -116,9 +116,5 @@ class LoginPinScreen(context: Context, attrs: AttributeSet) : RelativeLayout(con
 
   fun goBackToRegistrationScreen() {
     screenRouter.pop()
-  }
-
-  fun submitWithPinDigest(pinDigest: String) {
-    // TODO: Delete this method
   }
 }

--- a/app/src/main/java/org/simple/clinic/login/pin/LoginPinScreenController.kt
+++ b/app/src/main/java/org/simple/clinic/login/pin/LoginPinScreenController.kt
@@ -40,7 +40,6 @@ class LoginPinScreenController @Inject constructor(
     return Observable.mergeArray(
         screenSetups(replayedEvents),
         backClicks(replayedEvents),
-        readPinDigestToVerify(replayedEvents),
         syncFacilitiesAndLoginUser(replayedEvents)
     )
   }
@@ -72,13 +71,6 @@ class LoginPinScreenController @Inject constructor(
     return events.ofType<PinBackClicked>()
         .doOnNext { userSession.clearOngoingLoginEntry() }
         .flatMap { Observable.just(Ui::goBackToRegistrationScreen) }
-  }
-
-  private fun readPinDigestToVerify(events: Observable<UiEvent>): Observable<UiChange> {
-    return events.ofType<PinScreenCreated>()
-        .flatMapSingle { userSession.ongoingLoginEntry() }
-        .map { it.pinDigest }
-        .map { pinDigestToVerify -> { ui: Ui -> ui.submitWithPinDigest(pinDigestToVerify) } }
   }
 
   private fun syncFacilitiesAndLoginUser(events: Observable<UiEvent>): Observable<UiChange> {

--- a/app/src/main/java/org/simple/clinic/security/BCryptPasswordHasher.kt
+++ b/app/src/main/java/org/simple/clinic/security/BCryptPasswordHasher.kt
@@ -1,6 +1,5 @@
 package org.simple.clinic.security
 
-import io.reactivex.Single
 import org.mindrot.jbcrypt.BCrypt
 import org.simple.clinic.security.ComparisonResult.DIFFERENT
 import org.simple.clinic.security.ComparisonResult.SAME
@@ -8,19 +7,11 @@ import javax.inject.Inject
 
 class BCryptPasswordHasher @Inject constructor() : PasswordHasher {
 
-  override fun compare(hashed: String, password: String): Single<ComparisonResult> {
-    return Single.fromCallable {
-      val checkpw = BCrypt.checkpw(password, hashed)
-      when (checkpw) {
-        true -> SAME
-        false -> DIFFERENT
-      }
-    }
+  override fun compare(hashed: String, password: String): ComparisonResult {
+    return if (BCrypt.checkpw(password, hashed)) SAME else DIFFERENT
   }
 
-  override fun hash(password: String): Single<String> {
-    return Single.fromCallable {
-      BCrypt.hashpw(password, BCrypt.gensalt())
-    }
+  override fun hash(password: String): String {
+    return BCrypt.hashpw(password, BCrypt.gensalt())
   }
 }

--- a/app/src/main/java/org/simple/clinic/security/PasswordHasher.kt
+++ b/app/src/main/java/org/simple/clinic/security/PasswordHasher.kt
@@ -1,10 +1,8 @@
 package org.simple.clinic.security
 
-import io.reactivex.Single
-
 interface PasswordHasher {
 
-  fun hash(password: String): Single<String>
+  fun hash(password: String): String
 
-  fun compare(hashed: String, password: String): Single<ComparisonResult>
+  fun compare(hashed: String, password: String): ComparisonResult
 }

--- a/app/src/main/java/org/simple/clinic/security/di/PinVerificationModule.kt
+++ b/app/src/main/java/org/simple/clinic/security/di/PinVerificationModule.kt
@@ -1,0 +1,26 @@
+package org.simple.clinic.security.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.multibindings.IntoMap
+import org.simple.clinic.security.pin.verification.LocalUserPinVerificationMethod
+import org.simple.clinic.security.pin.verification.OngoingLoginEntryPinVerificationMethod
+import org.simple.clinic.security.pin.verification.PinVerificationMethod
+
+@Module
+abstract class PinVerificationModule {
+
+  @Binds
+  @IntoMap
+  @VerificationMethodKey(Method.Local)
+  abstract fun bindsLocalPinVerificationMethod(
+      pinVerificationMethod: LocalUserPinVerificationMethod
+  ): PinVerificationMethod
+
+  @Binds
+  @IntoMap
+  @VerificationMethodKey(Method.OngoingEntry)
+  abstract fun bindsOngoingEntryPinVerificationMethod(
+      pinVerificationMethod: OngoingLoginEntryPinVerificationMethod
+  ): PinVerificationMethod
+}

--- a/app/src/main/java/org/simple/clinic/security/di/VerificationMethodKey.kt
+++ b/app/src/main/java/org/simple/clinic/security/di/VerificationMethodKey.kt
@@ -1,0 +1,11 @@
+package org.simple.clinic.security.di
+
+import dagger.MapKey
+
+@MapKey
+annotation class VerificationMethodKey(val value: Method)
+
+enum class Method {
+  Local,
+  OngoingEntry
+}

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryCardView.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryCardView.kt
@@ -229,10 +229,6 @@ class PinEntryCardView(context: Context, attrs: AttributeSet) : CardView(context
     pinEditText.text = null
   }
 
-  override fun dispatchAuthenticatedCallback(enteredPin: String) {
-    downstreamUiEvents.onNext(PinAuthenticated(enteredPin))
-  }
-
   override fun pinVerified(data: Any?) {
     // TODO: Change the type to an `Any?`
     downstreamUiEvents.onNext(PinAuthenticated(data as String))

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryCardView.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryCardView.kt
@@ -233,6 +233,11 @@ class PinEntryCardView(context: Context, attrs: AttributeSet) : CardView(context
     downstreamUiEvents.onNext(PinAuthenticated(enteredPin))
   }
 
+  override fun pinVerified(data: Any?) {
+    // TODO: Change the type to an `Any?`
+    downstreamUiEvents.onNext(PinAuthenticated(data as String))
+  }
+
   /** Defaults to visible. */
   fun setForgotButtonVisible(visible: Boolean) {
     if (visible) {

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryCardView.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryCardView.kt
@@ -50,7 +50,6 @@ class PinEntryCardView(context: Context, attrs: AttributeSet) : CardView(context
   @Inject
   lateinit var verificationMethods: Map<Method, @JvmSuppressWildcards PinVerificationMethod>
 
-  val upstreamUiEvents: PublishSubject<UiEvent> = PublishSubject.create<UiEvent>()
   val downstreamUiEvents: PublishSubject<UiEvent> = PublishSubject.create<UiEvent>()
 
   private val method: Method
@@ -73,11 +72,7 @@ class PinEntryCardView(context: Context, attrs: AttributeSet) : CardView(context
   }
 
   private val events by unsafeLazy {
-    Observable
-        .merge(
-            pinTextChanges(),
-            upstreamUiEvents
-        )
+    pinTextChanges()
         .compose(ReportAnalyticsEvents())
   }
 

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffect.kt
@@ -4,8 +4,6 @@ import org.threeten.bp.Instant
 
 sealed class PinEntryEffect
 
-data class ValidateEnteredPin(val enteredPin: String, val pinDigest: String): PinEntryEffect()
-
 object LoadPinEntryProtectedStates: PinEntryEffect()
 
 object HideError: PinEntryEffect()
@@ -25,8 +23,6 @@ object RecordFailedAttempt: PinEntryEffect()
 object ShowProgress: PinEntryEffect()
 
 object ClearPin: PinEntryEffect()
-
-data class DispatchPinVerified(val pin: String): PinEntryEffect()
 
 data class VerifyPin(val pin: String): PinEntryEffect()
 

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffect.kt
@@ -29,3 +29,5 @@ object ClearPin: PinEntryEffect()
 data class DispatchPinVerified(val pin: String): PinEntryEffect()
 
 data class VerifyPin(val pin: String): PinEntryEffect()
+
+data class DispatchCorrectPinEntered(val pinVerifiedData: Any?): PinEntryEffect()

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffect.kt
@@ -27,3 +27,5 @@ object ShowProgress: PinEntryEffect()
 object ClearPin: PinEntryEffect()
 
 data class DispatchPinVerified(val pin: String): PinEntryEffect()
+
+data class VerifyPin(val pin: String): PinEntryEffect()

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffect.kt
@@ -26,4 +26,4 @@ object ClearPin: PinEntryEffect()
 
 data class VerifyPin(val pin: String): PinEntryEffect()
 
-data class DispatchCorrectPinEntered(val pinVerifiedData: Any?): PinEntryEffect()
+data class CorrectPinEntered(val pinVerifiedData: Any?): PinEntryEffect()

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffect.kt
@@ -26,4 +26,4 @@ object ShowProgress: PinEntryEffect()
 
 object ClearPin: PinEntryEffect()
 
-data class PinVerified(val pin: String): PinEntryEffect()
+data class DispatchPinVerified(val pin: String): PinEntryEffect()

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffectHandler.kt
@@ -12,18 +12,23 @@ import org.simple.clinic.security.PasswordHasher
 import org.simple.clinic.security.pin.PinEntryUi.Mode.BruteForceLocked
 import org.simple.clinic.security.pin.PinEntryUi.Mode.PinEntry
 import org.simple.clinic.security.pin.PinEntryUi.Mode.Progress
+import org.simple.clinic.security.pin.verification.PinVerificationMethod
 import org.simple.clinic.util.scheduler.SchedulersProvider
 
 class PinEntryEffectHandler @AssistedInject constructor(
     private val passwordHasher: PasswordHasher,
     private val bruteForceProtection: BruteForceProtection,
     private val schedulersProvider: SchedulersProvider,
-    @Assisted private val uiActions: UiActions
+    @Assisted private val uiActions: UiActions,
+    @Assisted private val pinVerificationMethod: PinVerificationMethod
 ) {
 
   @AssistedInject.Factory
   interface Factory {
-    fun create(uiActions: UiActions): PinEntryEffectHandler
+    fun create(
+        uiActions: UiActions,
+        pinVerificationMethod: PinVerificationMethod
+    ): PinEntryEffectHandler
   }
 
   fun build(): ObservableTransformer<PinEntryEffect, PinEntryEvent> {

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffectHandler.kt
@@ -47,6 +47,7 @@ class PinEntryEffectHandler @AssistedInject constructor(
         .addAction(ClearPin::class.java, { uiActions.clearPin() }, schedulersProvider.ui())
         .addConsumer(DispatchPinVerified::class.java, { uiActions.dispatchAuthenticatedCallback(it.pin) }, schedulersProvider.ui())
         .addTransformer(VerifyPin::class.java, verifyPin(schedulersProvider.io()))
+        .addConsumer(DispatchCorrectPinEntered::class.java, { uiActions.pinVerified(it.pinVerifiedData) }, schedulersProvider.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffectHandler.kt
@@ -40,7 +40,7 @@ class PinEntryEffectHandler @AssistedInject constructor(
         .addTransformer(RecordFailedAttempt::class.java, incrementIncorrectPinEntryCount(schedulersProvider.io()))
         .addAction(ShowProgress::class.java, { uiActions.setPinEntryMode(Progress) }, schedulersProvider.ui())
         .addAction(ClearPin::class.java, { uiActions.clearPin() }, schedulersProvider.ui())
-        .addConsumer(PinVerified::class.java, { uiActions.dispatchAuthenticatedCallback(it.pin)}, schedulersProvider.ui())
+        .addConsumer(PinVerified::class.java, { uiActions.dispatchAuthenticatedCallback(it.pin) }, schedulersProvider.ui())
         .build()
   }
 
@@ -49,11 +49,8 @@ class PinEntryEffectHandler @AssistedInject constructor(
   ): ObservableTransformer<ValidateEnteredPin, PinEntryEvent> {
     return ObservableTransformer { effects ->
       effects
-          .flatMapSingle {
-            passwordHasher
-                .compare(hashed = it.pinDigest, password = it.enteredPin)
-                .subscribeOn(scheduler)
-          }
+          .observeOn(scheduler)
+          .map { passwordHasher.compare(hashed = it.pinDigest, password = it.enteredPin) }
           .map { result ->
             when (result) {
               SAME -> CorrectPinEntered

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffectHandler.kt
@@ -45,7 +45,7 @@ class PinEntryEffectHandler @AssistedInject constructor(
         .addTransformer(RecordFailedAttempt::class.java, incrementIncorrectPinEntryCount(schedulersProvider.io()))
         .addAction(ShowProgress::class.java, { uiActions.setPinEntryMode(Progress) }, schedulersProvider.ui())
         .addAction(ClearPin::class.java, { uiActions.clearPin() }, schedulersProvider.ui())
-        .addConsumer(PinVerified::class.java, { uiActions.dispatchAuthenticatedCallback(it.pin) }, schedulersProvider.ui())
+        .addConsumer(DispatchPinVerified::class.java, { uiActions.dispatchAuthenticatedCallback(it.pin) }, schedulersProvider.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryEffectHandler.kt
@@ -41,7 +41,7 @@ class PinEntryEffectHandler @AssistedInject constructor(
         .addAction(ShowProgress::class.java, { uiActions.setPinEntryMode(Progress) }, schedulersProvider.ui())
         .addAction(ClearPin::class.java, { uiActions.clearPin() }, schedulersProvider.ui())
         .addTransformer(VerifyPin::class.java, verifyPin(schedulersProvider.io()))
-        .addConsumer(DispatchCorrectPinEntered::class.java, { uiActions.pinVerified(it.pinVerifiedData) }, schedulersProvider.ui())
+        .addConsumer(CorrectPinEntered::class.java, { uiActions.pinVerified(it.pinVerifiedData) }, schedulersProvider.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryEvent.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryEvent.kt
@@ -1,6 +1,7 @@
 package org.simple.clinic.security.pin
 
 import org.simple.clinic.security.pin.BruteForceProtection.ProtectedState
+import org.simple.clinic.security.pin.verification.PinVerificationMethod
 import org.simple.clinic.widgets.UiEvent
 
 sealed class PinEntryEvent : UiEvent
@@ -15,8 +16,10 @@ object CorrectPinEntered : PinEntryEvent()
 
 object WrongPinEntered : PinEntryEvent()
 
-data class PinEntryStateChanged(val state: ProtectedState): PinEntryEvent()
+data class PinEntryStateChanged(val state: ProtectedState) : PinEntryEvent()
 
 data class PinAuthenticated(val pin: String) : PinEntryEvent() {
   override val analyticsName = "PIN authenticated"
 }
+
+data class PinVerified(val result: PinVerificationMethod.VerificationResult) : PinEntryEvent()

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryEvent.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryEvent.kt
@@ -10,12 +10,6 @@ data class PinTextChanged(val pin: String) : PinEntryEvent() {
   override val analyticsName = "PIN text changed"
 }
 
-data class PinDigestToVerify(val pinDigest: String) : PinEntryEvent()
-
-object CorrectPinEntered : PinEntryEvent()
-
-object WrongPinEntered : PinEntryEvent()
-
 data class PinEntryStateChanged(val state: ProtectedState) : PinEntryEvent()
 
 data class PinAuthenticated(val pin: String) : PinEntryEvent() {

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryModel.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryModel.kt
@@ -5,24 +5,16 @@ import kotlinx.android.parcel.Parcelize
 
 @Parcelize
 data class PinEntryModel(
-    val enteredPin: String,
-    val pinDigestToVerify: String?
+    val enteredPin: String
 ): Parcelable {
-
-  val hasPinDigestBeenLoaded: Boolean
-    get() = pinDigestToVerify != null
 
   companion object {
     fun default(): PinEntryModel {
-      return PinEntryModel(enteredPin = "", pinDigestToVerify = null)
+      return PinEntryModel(enteredPin = "")
     }
   }
 
   fun enteredPinChanged(pin: String): PinEntryModel {
     return copy(enteredPin = pin)
-  }
-
-  fun updatePinDigest(pinDigest: String): PinEntryModel {
-    return copy(pinDigestToVerify = pinDigest)
   }
 }

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryUpdate.kt
@@ -25,7 +25,7 @@ class PinEntryUpdate(
       is PinEntryStateChanged -> Next.dispatch(effectsForStateChange(event.state))
       is PinVerified -> {
         when (event.result) {
-          is Correct -> dispatch(RecordSuccessfulAttempt, DispatchCorrectPinEntered(event.result.data))
+          is Correct -> dispatch(RecordSuccessfulAttempt, CorrectPinEntered(event.result.data))
           is Incorrect -> dispatch(AllowPinEntry, RecordFailedAttempt, ClearPin)
           // Will be filled in later when we implement PIN verification
           // via the server API call.

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryUpdate.kt
@@ -7,7 +7,6 @@ import com.spotify.mobius.Update
 import org.simple.clinic.mobius.dispatch
 import org.simple.clinic.security.pin.BruteForceProtection.ProtectedState.Allowed
 import org.simple.clinic.security.pin.BruteForceProtection.ProtectedState.Blocked
-import org.simple.clinic.security.pin.verification.PinVerificationMethod
 import org.simple.clinic.security.pin.verification.PinVerificationMethod.VerificationResult.Correct
 import org.simple.clinic.security.pin.verification.PinVerificationMethod.VerificationResult.Failure
 import org.simple.clinic.security.pin.verification.PinVerificationMethod.VerificationResult.Incorrect
@@ -23,16 +22,9 @@ class PinEntryUpdate(
 
         next(updatedModel, generateEffectsForPinSubmission(updatedModel))
       }
-      is PinDigestToVerify -> {
-        val updatedModel = model.updatePinDigest(event.pinDigest)
-
-        next(updatedModel)
-      }
       is PinEntryStateChanged -> Next.dispatch(effectsForStateChange(event.state))
-      is CorrectPinEntered -> dispatch(RecordSuccessfulAttempt, DispatchPinVerified(model.enteredPin))
-      is WrongPinEntered -> dispatch(AllowPinEntry, RecordFailedAttempt, ClearPin)
       is PinVerified -> {
-        when(event.result) {
+        when (event.result) {
           is Correct -> dispatch(RecordSuccessfulAttempt, DispatchCorrectPinEntered(event.result.data))
           is Incorrect -> dispatch(AllowPinEntry, RecordFailedAttempt, ClearPin)
           // Will be filled in later when we implement PIN verification

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryUpdate.kt
@@ -26,7 +26,7 @@ class PinEntryUpdate(
       is PinDigestToVerify -> {
         val updatedModel = model.updatePinDigest(event.pinDigest)
 
-        next(updatedModel, generateEffectsForPinSubmission(updatedModel))
+        next(updatedModel)
       }
       is PinEntryStateChanged -> Next.dispatch(effectsForStateChange(event.state))
       is CorrectPinEntered -> dispatch(RecordSuccessfulAttempt, DispatchPinVerified(model.enteredPin))
@@ -60,7 +60,7 @@ class PinEntryUpdate(
   }
 
   private fun isReadyToSubmitPin(model: PinEntryModel): Boolean {
-    return model.hasPinDigestBeenLoaded && model.enteredPin.length == submitPinAtLength
+    return model.enteredPin.length == submitPinAtLength
   }
 
   private fun generateEffectsForPinSubmission(model: PinEntryModel): Set<PinEntryEffect> {
@@ -68,7 +68,7 @@ class PinEntryUpdate(
 
     if (isReadyToSubmitPin(model)) {
       effects.apply {
-        add(ValidateEnteredPin(model.enteredPin, model.pinDigestToVerify!!))
+        add(VerifyPin(model.enteredPin))
         add(HideError)
         add(ShowProgress)
       }

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryUpdate.kt
@@ -25,7 +25,7 @@ class PinEntryUpdate(
         next(updatedModel, generateEffectsForPinSubmission(updatedModel))
       }
       is PinEntryStateChanged -> Next.dispatch(effectsForStateChange(event.state))
-      is CorrectPinEntered -> dispatch(RecordSuccessfulAttempt, PinVerified(model.enteredPin))
+      is CorrectPinEntered -> dispatch(RecordSuccessfulAttempt, DispatchPinVerified(model.enteredPin))
       is WrongPinEntered -> dispatch(AllowPinEntry, RecordFailedAttempt, ClearPin)
       is PinAuthenticated -> noChange()
     }

--- a/app/src/main/java/org/simple/clinic/security/pin/UiActions.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/UiActions.kt
@@ -10,6 +10,5 @@ interface UiActions {
   fun showIncorrectAttemptsLimitReachedError(attemptsMade: Int)
   fun setPinEntryMode(mode: Mode)
   fun clearPin()
-  fun dispatchAuthenticatedCallback(enteredPin: String)
   fun pinVerified(data: Any?)
 }

--- a/app/src/main/java/org/simple/clinic/security/pin/UiActions.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/UiActions.kt
@@ -11,4 +11,5 @@ interface UiActions {
   fun setPinEntryMode(mode: Mode)
   fun clearPin()
   fun dispatchAuthenticatedCallback(enteredPin: String)
+  fun pinVerified(data: Any?)
 }

--- a/app/src/main/java/org/simple/clinic/security/pin/verification/LocalUserPinVerificationMethod.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/verification/LocalUserPinVerificationMethod.kt
@@ -1,0 +1,26 @@
+package org.simple.clinic.security.pin.verification
+
+import org.simple.clinic.security.ComparisonResult.DIFFERENT
+import org.simple.clinic.security.ComparisonResult.SAME
+import org.simple.clinic.security.PasswordHasher
+import org.simple.clinic.security.pin.verification.PinVerificationMethod.VerificationResult
+import org.simple.clinic.security.pin.verification.PinVerificationMethod.VerificationResult.Correct
+import org.simple.clinic.security.pin.verification.PinVerificationMethod.VerificationResult.Incorrect
+import org.simple.clinic.user.UserSession
+import javax.inject.Inject
+
+class LocalUserPinVerificationMethod @Inject constructor(
+    private val userSession: UserSession,
+    private val passwordHasher: PasswordHasher
+) : PinVerificationMethod {
+
+  override fun verify(pin: String): VerificationResult {
+    val user = userSession.loggedInUserImmediate()
+    requireNotNull(user)
+
+    return when (passwordHasher.compare(user.pinDigest, pin)) {
+      SAME -> Correct(pin)
+      DIFFERENT -> Incorrect(pin)
+    }
+  }
+}

--- a/app/src/main/java/org/simple/clinic/security/pin/verification/OngoingLoginEntryPinVerificationMethod.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/verification/OngoingLoginEntryPinVerificationMethod.kt
@@ -1,0 +1,25 @@
+package org.simple.clinic.security.pin.verification
+
+import org.simple.clinic.security.ComparisonResult.DIFFERENT
+import org.simple.clinic.security.ComparisonResult.SAME
+import org.simple.clinic.security.PasswordHasher
+import org.simple.clinic.security.pin.verification.PinVerificationMethod.VerificationResult
+import org.simple.clinic.security.pin.verification.PinVerificationMethod.VerificationResult.Correct
+import org.simple.clinic.security.pin.verification.PinVerificationMethod.VerificationResult.Incorrect
+import org.simple.clinic.user.OngoingLoginEntryRepository
+import javax.inject.Inject
+
+class OngoingLoginEntryPinVerificationMethod @Inject constructor(
+    private val ongoingLoginEntryRepository: OngoingLoginEntryRepository,
+    private val passwordHasher: PasswordHasher
+) : PinVerificationMethod {
+
+  override fun verify(pin: String): VerificationResult {
+    val entry = ongoingLoginEntryRepository.entryImmediate()
+
+    return when (passwordHasher.compare(entry.pinDigest!!, pin)) {
+      SAME -> Correct(pin)
+      DIFFERENT -> Incorrect(pin)
+    }
+  }
+}

--- a/app/src/main/java/org/simple/clinic/security/pin/verification/PinVerificationMethod.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/verification/PinVerificationMethod.kt
@@ -1,0 +1,15 @@
+package org.simple.clinic.security.pin.verification
+
+interface PinVerificationMethod {
+
+  fun verify(pin: String): VerificationResult
+
+  sealed class VerificationResult {
+
+    data class Correct(val data: Any? = null) : VerificationResult()
+
+    data class Incorrect(val data: Any? = null) : VerificationResult()
+
+    data class Failure(val error: Throwable) : VerificationResult()
+  }
+}

--- a/app/src/main/java/org/simple/clinic/user/OngoingLoginEntry.kt
+++ b/app/src/main/java/org/simple/clinic/user/OngoingLoginEntry.kt
@@ -40,6 +40,9 @@ data class OngoingLoginEntry(
     @Query("SELECT * FROM OngoingLoginEntry")
     fun getEntry(): Flowable<List<OngoingLoginEntry>>
 
+    @Query("SELECT * FROM OngoingLoginEntry")
+    fun getEntryImmediate(): OngoingLoginEntry?
+
     @Query("DELETE FROM OngoingLoginEntry")
     fun delete()
   }

--- a/app/src/main/java/org/simple/clinic/user/OngoingLoginEntryRepository.kt
+++ b/app/src/main/java/org/simple/clinic/user/OngoingLoginEntryRepository.kt
@@ -23,6 +23,10 @@ class OngoingLoginEntryRepository @Inject constructor(
 
   }
 
+  fun entryImmediate(): OngoingLoginEntry {
+    return dao.getEntryImmediate()!!
+  }
+
   fun clearLoginEntry() {
     dao.delete()
   }

--- a/app/src/main/java/org/simple/clinic/user/UserSession.kt
+++ b/app/src/main/java/org/simple/clinic/user/UserSession.kt
@@ -5,7 +5,6 @@ import com.f2prateek.rx.preferences2.Preference
 import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.Single
-import io.reactivex.rxkotlin.zipWith
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.analytics.Analytics
 import org.simple.clinic.appconfig.Country
@@ -57,11 +56,9 @@ class UserSession @Inject constructor(
   }
 
   fun saveOngoingRegistrationEntryAsUser(): Completable {
-    val ongoingEntry = ongoingRegistrationEntry().cache()
-
-    return ongoingEntry
+    return ongoingRegistrationEntry()
         .doOnSubscribe { Timber.i("Logging in from ongoing registration entry") }
-        .zipWith(ongoingEntry.flatMap { entry -> passwordHasher.hash(entry.pin!!) })
+        .map { entry -> entry to passwordHasher.hash(entry.pin!!) }
         .flatMapCompletable { (entry, passwordDigest) ->
           val user = User(
               uuid = entry.uuid!!,

--- a/app/src/main/java/org/simple/clinic/user/resetpin/ResetUserPin.kt
+++ b/app/src/main/java/org/simple/clinic/user/resetpin/ResetUserPin.kt
@@ -34,7 +34,7 @@ class ResetUserPin @Inject constructor(
 ) {
 
   fun resetPin(pin: String): Single<ResetPinResult> {
-    return passwordHasher.hash(pin)
+    return Single.fromCallable { passwordHasher.hash(pin) }
         .doOnSubscribe { Timber.i("Resetting PIN") }
         .map(::ResetPinRequest)
         .flatMap(loginApi::resetPin)

--- a/app/src/main/res/layout/screen_app_lock.xml
+++ b/app/src/main/res/layout/screen_app_lock.xml
@@ -2,6 +2,7 @@
 <org.simple.clinic.login.applock.AppLockScreen android:id="@+id/applock_root"
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:background="@color/window_background_auth"
@@ -71,5 +72,7 @@
   <org.simple.clinic.security.pin.PinEntryCardView
     android:id="@+id/applock_pin_entry_card"
     style="@style/Clinic.LoginCard"
-    android:layout_below="@+id/applock_logo_container" />
+    android:layout_below="@+id/applock_logo_container"
+    app:verificationMethod="local"
+    />
 </org.simple.clinic.login.applock.AppLockScreen>

--- a/app/src/main/res/layout/screen_login_pin.xml
+++ b/app/src/main/res/layout/screen_login_pin.xml
@@ -2,6 +2,7 @@
 <org.simple.clinic.login.pin.LoginPinScreen android:id="@+id/loginpin_root"
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:background="@color/window_background_auth">
@@ -33,5 +34,6 @@
   <org.simple.clinic.security.pin.PinEntryCardView
     android:id="@+id/loginpin_pin_entry_card"
     style="@style/Clinic.LoginCard"
-    android:layout_below="@+id/loginpin_logo_container" />
+    android:layout_below="@+id/loginpin_logo_container"
+    app:verificationMethod="ongoingEntry"/>
 </org.simple.clinic.login.pin.LoginPinScreen>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -23,4 +23,11 @@
     <attr name="contentPaddingStart" format="dimension" />
     <attr name="contentPaddingEnd" format="dimension" />
   </declare-styleable>
+
+  <declare-styleable name="PinEntryCardView">
+    <attr name="verificationMethod" format="enum">
+      <enum name="local" value="0"/>
+      <enum name="ongoingEntry" value="1" />
+    </attr>
+  </declare-styleable>
 </resources>

--- a/app/src/sharedTest/java/org/simple/clinic/TestData.kt
+++ b/app/src/sharedTest/java/org/simple/clinic/TestData.kt
@@ -51,6 +51,7 @@ import org.simple.clinic.protocol.sync.ProtocolDrugPayload
 import org.simple.clinic.protocol.sync.ProtocolPayload
 import org.simple.clinic.storage.Timestamps
 import org.simple.clinic.user.LoggedInUserPayload
+import org.simple.clinic.user.OngoingLoginEntry
 import org.simple.clinic.user.OngoingRegistrationEntry
 import org.simple.clinic.user.User
 import org.simple.clinic.user.UserStatus
@@ -957,6 +958,28 @@ object TestData {
       gender = gender,
       dateOfBirth = dateOfBirth,
       age = age,
+      updatedAt = updatedAt
+  )
+
+  fun ongoingLoginEntry(
+      uuid: UUID = UUID.fromString("e4d91a34-c475-4038-a066-a866f9ecafec"),
+      phoneNumber: String? = "1111111111",
+      pin: String? = "1234",
+      fullName: String? = "Anish Acharya",
+      pinDigest: String? = "digest",
+      registrationFacilityUuid: UUID? = UUID.fromString("d91fb2ba-9c87-4de0-b425-eea44457c746"),
+      status: UserStatus? = UserStatus.ApprovedForSyncing,
+      createdAt: Instant? = Instant.parse("2018-01-01T00:00:00Z"),
+      updatedAt: Instant? = Instant.parse("2018-01-01T00:00:00Z")
+  ) = OngoingLoginEntry(
+      uuid = uuid,
+      phoneNumber = phoneNumber,
+      pin = pin,
+      fullName = fullName,
+      pinDigest = pinDigest,
+      registrationFacilityUuid = registrationFacilityUuid,
+      status = status,
+      createdAt = createdAt,
       updatedAt = updatedAt
   )
 }

--- a/app/src/test/java/org/simple/clinic/login/applock/AppLockScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/login/applock/AppLockScreenControllerTest.kt
@@ -10,10 +10,9 @@ import io.reactivex.subjects.PublishSubject
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.TestData
+import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.user.UserSession
-import org.simple.clinic.util.Just
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.widgets.UiEvent
 import org.threeten.bp.Instant
@@ -75,13 +74,5 @@ class AppLockScreenControllerTest {
   fun `when forgot pin is clicked then the confirm forgot pin alert must be shown`() {
     uiEvents.onNext(AppLockForgotPinClicked())
     verify(screen).showConfirmResetPinDialog()
-  }
-
-  @Test
-  fun `when the screen is created the pin digest to verify must be forwarded to the screen`() {
-    whenever(facilityRepository.currentFacility(loggedInUser)).thenReturn(Observable.never())
-    uiEvents.onNext(AppLockScreenCreated())
-
-    verify(screen).unlockWithPinDigest(loggedInUser.pinDigest)
   }
 }

--- a/app/src/test/java/org/simple/clinic/login/pin/LoginPinScreenControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/login/pin/LoginPinScreenControllerTest.kt
@@ -114,17 +114,6 @@ class LoginPinScreenControllerTest {
   }
 
   @Test
-  fun `when the screen is created, the pin digest to verify must be forwarded to the screen`() {
-    val pinDigest = "digest"
-    whenever(userSession.ongoingLoginEntry())
-        .thenReturn(Single.just(ongoingLoginEntry.copy(pinDigest = pinDigest)))
-
-    uiEvents.onNext(PinScreenCreated())
-
-    verify(screen).submitWithPinDigest(pinDigest)
-  }
-
-  @Test
   fun `when PIN is submitted, update the saved login entry with the new PIN`() {
     // given
     val newPin = "new-pin"

--- a/app/src/test/java/org/simple/clinic/security/BCryptPasswordHasherTest.kt
+++ b/app/src/test/java/org/simple/clinic/security/BCryptPasswordHasherTest.kt
@@ -1,7 +1,10 @@
 package org.simple.clinic.security
 
+import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
+import org.simple.clinic.security.ComparisonResult.DIFFERENT
+import org.simple.clinic.security.ComparisonResult.SAME
 import org.simple.clinic.util.RxErrorsRule
 
 class BCryptPasswordHasherTest {
@@ -9,15 +12,25 @@ class BCryptPasswordHasherTest {
   @get:Rule
   val rxErrorsRule = RxErrorsRule()
 
-  @Test
-  fun `comparison test`() {
-    val bcryptHasher = BCryptPasswordHasher()
+  private val passwordHasher = BCryptPasswordHasher()
 
+  @Test
+  fun `it should return SAME if compare a hash from the same password`() {
     val password = "12341234"
 
-    bcryptHasher.hash(password)
-        .flatMap { bcryptHasher.compare(it, password) }
-        .test()
-        .assertValue { it == ComparisonResult.SAME }
+    val hashed = passwordHasher.hash(password)
+    val result = passwordHasher.compare(hashed, password)
+
+    assertThat(result).isEqualTo(SAME)
+  }
+
+  @Test
+  fun `it should return DIFFERENT if compare a hash from a different password`() {
+    val password = "12341234"
+
+    val hashed = passwordHasher.hash(password)
+    val result = passwordHasher.compare(hashed, "hacker")
+
+    assertThat(result).isEqualTo(DIFFERENT)
   }
 }

--- a/app/src/test/java/org/simple/clinic/security/pin/JavaHashPasswordHasher.kt
+++ b/app/src/test/java/org/simple/clinic/security/pin/JavaHashPasswordHasher.kt
@@ -1,6 +1,5 @@
 package org.simple.clinic.security.pin
 
-import io.reactivex.Single
 import org.simple.clinic.security.ComparisonResult
 import org.simple.clinic.security.ComparisonResult.DIFFERENT
 import org.simple.clinic.security.ComparisonResult.SAME
@@ -8,16 +7,13 @@ import org.simple.clinic.security.PasswordHasher
 
 class JavaHashPasswordHasher : PasswordHasher {
 
-  override fun hash(password: String): Single<String> {
-    return Single.just(genHash(password))
+  override fun hash(password: String): String {
+    return password.hashCode().toString()
   }
 
-  override fun compare(hashed: String, password: String): Single<ComparisonResult> {
-    val hashedPassword = genHash(password)
+  override fun compare(hashed: String, password: String): ComparisonResult {
+    val hashedPassword = hash(password)
 
-    val result = if (hashed == hashedPassword) SAME else DIFFERENT
-    return Single.just(result)
+    return if (hashed == hashedPassword) SAME else DIFFERENT
   }
-
-  private fun genHash(string: String): String = string.hashCode().toString()
 }

--- a/app/src/test/java/org/simple/clinic/security/pin/PinEntryCardControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/security/pin/PinEntryCardControllerTest.kt
@@ -45,7 +45,8 @@ class PinEntryCardControllerTest {
       passwordHasher = passwordHasher,
       bruteForceProtection = bruteForceProtection,
       schedulersProvider = TrampolineSchedulersProvider(),
-      uiActions = uiActions
+      uiActions = uiActions,
+      pinVerificationMethod = mock()
   )
 
   private lateinit var testFixture: MobiusTestFixture<PinEntryModel, PinEntryEvent, PinEntryEffect>

--- a/app/src/test/java/org/simple/clinic/security/pin/PinEntryCardControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/security/pin/PinEntryCardControllerTest.kt
@@ -34,7 +34,7 @@ class PinEntryCardControllerTest {
 
   private val correctPin = "1234"
   private val incorrectPin = "1233"
-  private val pinDigest = passwordHasher.hash(correctPin).blockingGet()
+  private val pinDigest = passwordHasher.hash(correctPin)
 
   private val uiEvents = PublishSubject.create<UiEvent>()
   private val clock = TestUtcClock()

--- a/app/src/test/java/org/simple/clinic/security/pin/PinEntryLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/security/pin/PinEntryLogicTest.kt
@@ -22,7 +22,7 @@ import org.simple.mobius.migration.MobiusTestFixture
 import org.threeten.bp.Duration
 import org.threeten.bp.Instant
 
-class PinEntryCardControllerTest {
+class PinEntryLogicTest {
 
   @get:Rule
   val rxErrorsRule = RxErrorsRule()

--- a/app/src/test/java/org/simple/clinic/security/pin/PinEntryLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/security/pin/PinEntryLogicTest.kt
@@ -33,21 +33,18 @@ class PinEntryLogicTest {
 
   private val ui = mock<PinEntryUi>()
   private val uiActions = mock<UiActions>()
-  private val passwordHasher = JavaHashPasswordHasher()
   private val bruteForceProtection = mock<BruteForceProtection>()
+  private val pinVerificationMethod = mock<PinVerificationMethod>()
 
   private val correctPin = "1234"
   private val incorrectPin = "1233"
-  private val pinDigest = passwordHasher.hash(correctPin)
 
   private val uiEvents = PublishSubject.create<UiEvent>()
   private val clock = TestUtcClock()
 
   private val uiRenderer = PinEntryUiRenderer(ui)
-  private val pinVerificationMethod = mock<PinVerificationMethod>()
 
   private val pinEntryEffectHandler = PinEntryEffectHandler(
-      passwordHasher = passwordHasher,
       bruteForceProtection = bruteForceProtection,
       schedulersProvider = TrampolineSchedulersProvider(),
       uiActions = uiActions,
@@ -86,7 +83,6 @@ class PinEntryLogicTest {
     uiEvents.onNext(PinTextChanged("12"))
     uiEvents.onNext(PinTextChanged("123"))
     uiEvents.onNext(PinTextChanged("1234"))
-    uiEvents.onNext(PinDigestToVerify(pinDigest))
 
     verify(uiActions).hideError()
     verify(uiActions).setPinEntryMode(Mode.Progress)
@@ -99,7 +95,6 @@ class PinEntryLogicTest {
     whenever(pinVerificationMethod.verify(incorrectPin)) doReturn Incorrect()
     startMobiusLoop()
 
-    uiEvents.onNext(PinDigestToVerify(pinDigest))
     uiEvents.onNext(PinTextChanged(incorrectPin))
 
     verify(uiActions).setPinEntryMode(Mode.PinEntry)
@@ -111,7 +106,6 @@ class PinEntryLogicTest {
     startMobiusLoop()
 
     uiEvents.onNext(PinTextChanged(incorrectPin))
-    uiEvents.onNext(PinDigestToVerify(pinDigest))
 
     verify(uiActions).clearPin()
   }
@@ -121,7 +115,6 @@ class PinEntryLogicTest {
     whenever(pinVerificationMethod.verify(correctPin)) doReturn Correct(correctPin)
     startMobiusLoop()
 
-    uiEvents.onNext(PinDigestToVerify(pinDigest))
     uiEvents.onNext(PinTextChanged(correctPin))
 
     verify(uiActions).pinVerified(correctPin)
@@ -133,7 +126,6 @@ class PinEntryLogicTest {
 
     startMobiusLoop()
 
-    uiEvents.onNext(PinDigestToVerify(pinDigest))
     uiEvents.onNext(PinTextChanged(incorrectPin))
 
     verify(bruteForceProtection).incrementFailedAttempt()
@@ -144,7 +136,6 @@ class PinEntryLogicTest {
     whenever(pinVerificationMethod.verify(correctPin)) doReturn Correct(correctPin)
     startMobiusLoop()
 
-    uiEvents.onNext(PinDigestToVerify(pinDigest))
     uiEvents.onNext(PinTextChanged(correctPin))
 
     verify(bruteForceProtection).recordSuccessfulAuthentication()
@@ -203,7 +194,6 @@ class PinEntryLogicTest {
 
     startMobiusLoop()
 
-    uiEvents.onNext(PinDigestToVerify(pinDigest))
     uiEvents.onNext(PinTextChanged(correctPin))
 
     verify(uiActions).hideError()

--- a/app/src/test/java/org/simple/clinic/security/pin/verification/LocalUserPinVerificationMethodTest.kt
+++ b/app/src/test/java/org/simple/clinic/security/pin/verification/LocalUserPinVerificationMethodTest.kt
@@ -1,0 +1,55 @@
+package org.simple.clinic.security.pin.verification
+
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.Test
+import org.simple.clinic.TestData
+import org.simple.clinic.security.pin.JavaHashPasswordHasher
+import org.simple.clinic.user.UserSession
+import java.util.UUID
+
+class LocalUserPinVerificationMethodTest {
+
+  private val passwordHasher = JavaHashPasswordHasher()
+
+  private val userSession = mock<UserSession>()
+
+  private val pinVerificationMethod = LocalUserPinVerificationMethod(userSession, passwordHasher)
+
+  @Test
+  fun `when the entered password matches the saved digest of the user, it should mark the password as correct`() {
+    // given
+    val correctPassword = "1234"
+    val user = TestData.loggedInUser(
+        uuid = UUID.fromString("3be29dea-b1ca-4113-94c6-db51d4a86f9b"),
+        pinDigest = passwordHasher.hash(correctPassword)
+    )
+    whenever(userSession.loggedInUserImmediate()) doReturn user
+
+    // when
+    val result = pinVerificationMethod.verify(correctPassword)
+
+    // then
+    assertThat(result).isEqualTo(PinVerificationMethod.VerificationResult.Correct(correctPassword))
+  }
+
+  @Test
+  fun `when the entered password does not match the saved digest of the user, it should mark the password as incorrect`() {
+    // given
+    val correctPassword = "1234"
+    val user = TestData.loggedInUser(
+        uuid = UUID.fromString("3be29dea-b1ca-4113-94c6-db51d4a86f9b"),
+        pinDigest = passwordHasher.hash(correctPassword)
+    )
+    whenever(userSession.loggedInUserImmediate()) doReturn user
+
+    // when
+    val enteredPassword = "1111"
+    val result = pinVerificationMethod.verify(enteredPassword)
+
+    // then
+    assertThat(result).isEqualTo(PinVerificationMethod.VerificationResult.Incorrect(enteredPassword))
+  }
+}

--- a/app/src/test/java/org/simple/clinic/security/pin/verification/OngoingLoginEntryPinVerificationMethodTest.kt
+++ b/app/src/test/java/org/simple/clinic/security/pin/verification/OngoingLoginEntryPinVerificationMethodTest.kt
@@ -1,0 +1,53 @@
+package org.simple.clinic.security.pin.verification
+
+import com.google.common.truth.Truth
+import com.google.common.truth.Truth.*
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.Test
+import org.simple.clinic.TestData
+import org.simple.clinic.security.pin.JavaHashPasswordHasher
+import org.simple.clinic.user.OngoingLoginEntryRepository
+
+class OngoingLoginEntryPinVerificationMethodTest {
+
+  private val passwordHasher = JavaHashPasswordHasher()
+
+  private val repository = mock<OngoingLoginEntryRepository>()
+
+  private val pinVerificationMethod = OngoingLoginEntryPinVerificationMethod(repository, passwordHasher)
+
+  @Test
+  fun `when the entered password matches the saved digest of the entry, it should mark the password as correct`() {
+    // given
+    val correctPassword = "1234"
+    val entry = TestData.ongoingLoginEntry(
+        pinDigest = passwordHasher.hash(correctPassword)
+    )
+    whenever(repository.entryImmediate()) doReturn entry
+
+    // when
+    val result = pinVerificationMethod.verify(correctPassword)
+
+    // then
+    assertThat(result).isEqualTo(PinVerificationMethod.VerificationResult.Correct(correctPassword))
+  }
+
+  @Test
+  fun `when the entered password does not match the saved digest of the entry, it should mark the password as incorrect`() {
+    // given
+    val correctPassword = "1234"
+    val entry = TestData.ongoingLoginEntry(
+        pinDigest = passwordHasher.hash(correctPassword)
+    )
+    whenever(repository.entryImmediate()) doReturn entry
+
+    // when
+    val enteredPassword = "1111"
+    val result = pinVerificationMethod.verify(enteredPassword)
+
+    // then
+    assertThat(result).isEqualTo(PinVerificationMethod.VerificationResult.Incorrect(enteredPassword))
+  }
+}

--- a/app/src/test/java/org/simple/clinic/user/resetpin/ResetUserPinTest.kt
+++ b/app/src/test/java/org/simple/clinic/user/resetpin/ResetUserPinTest.kt
@@ -12,11 +12,11 @@ import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Single
 import org.junit.Test
+import org.simple.clinic.TestData
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.forgotpin.ForgotPinResponse
 import org.simple.clinic.forgotpin.ResetPinRequest
 import org.simple.clinic.login.LoginApi
-import org.simple.clinic.TestData
 import org.simple.clinic.security.pin.JavaHashPasswordHasher
 import org.simple.clinic.user.User
 import org.simple.clinic.user.User.LoggedInStatus.RESETTING_PIN
@@ -211,7 +211,7 @@ class ResetUserPinTest {
     assertThat(result).isEqualTo(UnexpectedError(exception))
   }
 
-  private fun hash(pin: String): String = passwordHasher.hash(pin).blockingGet()
+  private fun hash(pin: String): String = passwordHasher.hash(pin)
 
   private fun User.afterPinResetRequested(updatedPinDigest: String): User {
     return copy(pinDigest = updatedPinDigest, status = WaitingForApproval, loggedInStatus = RESET_PIN_REQUESTED)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171923997

# Changes
- Add a `PinVerificationMethod` and interfaces that implement the current behaviour
  - For verifying during login by reading the PIN digest from `OngoingLoginEntry`
  - For verifying during app unlock by reading the PIN digest from `User`
- Change `PinEntryEffectHandler` to dynamically select which method to use via an XML attribute which can be set by the screen it is embedded in.