### PR TITLE
Fix failing test that verifies login to the server

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/login/LoginUserWithOtpServerIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/login/LoginUserWithOtpServerIntegrationTest.kt
@@ -28,6 +28,9 @@ class LoginUserWithOtpServerIntegrationTest {
   @Inject
   lateinit var loginUserWithOtp: LoginUserWithOtp
 
+  @Inject
+  lateinit var loginApi: LoginApi
+
   @field:[Inject Named("user_pin")]
   lateinit var userPin: String
 
@@ -42,6 +45,8 @@ class LoginUserWithOtpServerIntegrationTest {
   @Test
   fun when_correct_login_params_are_given_then_login_should_happen_and_session_data_should_be_persisted() {
     val user = userSession.loggedInUserImmediate()!!
+
+    loginApi.requestLoginOtp(user.uuid).blockingAwait()
 
     val loginResult = loginUserWithOtp.loginWithOtp(user.phoneNumber, userPin, userOtp)
         .blockingGet()


### PR DESCRIPTION
Previously, the server would accept a login call for an OTP any number
of times. Now, that has changed to only allow verifying an OTP once.

This caused a test to fail because the test was not generating a new
OTP before verifying the login call. This commit fixes the issue by
generating an OTP.