### PR TITLE
Add zxing core dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -257,7 +257,7 @@ dependencies {
   implementation "androidx.camera:camera-view:$versions.cameraView"
   implementation "androidx.camera:camera-lifecycle:$versions.cameraxLifecycle"
 
-  implementation "com.google.zxing:android-core:$versions.zxingAndroid"
+  implementation "com.google.zxing:core:$versions.zxing"
 
   implementation "com.google.dagger:dagger:$versions.dagger"
   kapt "com.google.dagger:dagger-compiler:$versions.dagger"

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ buildscript {
       camerax             : '1.0.0-beta02',
       cameraView          : '1.0.0-alpha09',
       cameraLifecycle     : '1.0.0-alpha09',
-      zxingAndroid        : '3.3.0',
+      zxing               : '3.3.3',
   ]
 
   repositories {


### PR DESCRIPTION
We were using a transitive zxing dependency from the QR scanner library. Once we remove the old QR scanner the new one will be broken, adding the zxing dependency to the app gradle.

The zxing android-core dependency we added didn't internally contain the zxing core dependency.