### PR TITLE
Migrate to MaterialComponents bridge theme

### DIFF
--- a/app/src/main/res/values/colors_v2.xml
+++ b/app/src/main/res/values/colors_v2.xml
@@ -36,4 +36,6 @@
   <color name="facility_search_query_highlight">@color/blue2</color>
   <color name="status_bar">#0a2e52</color>
   <color name="settings_divider_background">@color/grey3</color>
+
+  <color name="scrim_color">#52000000</color>
 </resources>

--- a/app/src/main/res/values/styles_v2.xml
+++ b/app/src/main/res/values/styles_v2.xml
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
-  <style name="Clinic.V2" />
-
-  <style name="Clinic.V2.Theme" parent="Theme.Design.Light.NoActionBar">
-    <item name="colorPrimary">@color/color_primary</item>
-    <item name="colorPrimaryDark">@color/color_primary_dark</item>
-    <item name="colorAccent">@color/color_accent</item>
-    <item name="colorError">@color/color_error</item>
-    <item name="toolbarStyle">@style/Clinic.V2.ToolbarStyle</item>
-    <item name="alertDialogTheme">@style/Clinic.V2.DialogStyle</item>
-    <item name="android:windowBackground">@color/window_background</item>
-  </style>
-
   <style name="Clinic.V2.DialogStyle" parent="Theme.AppCompat.Light.Dialog.Alert">
     <item name="buttonBarNeutralButtonStyle">@style/Clinic.V2.DialogNeutralButton</item>
     <item name="buttonBarNegativeButtonStyle">@style/Clinic.V2.DialogNegativeButton</item>
@@ -228,7 +216,6 @@
   <style name="Clinic.V2.TextAppearance.Subtitle1Left.Blue1">
     <item name="android:textColor">@color/blue1</item>
   </style>
-
 
   <style name="Clinic.V2.TextAppearance.Subtitle1Left.Grey1">
     <item name="android:textColor">@color/grey1</item>

--- a/app/src/main/res/values/theme_material.xml
+++ b/app/src/main/res/values/theme_material.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <style name="Clinic.V2" />
+
+  <style name="Clinic.V2.Theme" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
+    <item name="colorPrimary">@color/color_primary</item>
+    <item name="colorPrimaryDark">@color/color_primary_dark</item>
+    <item name="colorAccent">@color/color_accent</item>
+    <item name="colorError">@color/color_error</item>
+    <item name="toolbarStyle">@style/Clinic.V2.ToolbarStyle</item>
+    <item name="alertDialogTheme">@style/Clinic.V2.DialogStyle</item>
+    <item name="android:windowBackground">@color/window_background</item>
+
+    <!-- New MaterialComponents Attributes -->
+    <item name="colorPrimaryVariant">@color/color_primary_dark</item>
+    <item name="scrimBackground">@color/scrim_color</item>
+    <item name="textAppearanceHeadline1">@style/TextAppearance.MaterialComponents.Headline1</item>
+    <item name="textAppearanceHeadline2">@style/TextAppearance.MaterialComponents.Headline2</item>
+    <item name="textAppearanceHeadline3">@style/TextAppearance.MaterialComponents.Headline3</item>
+    <item name="textAppearanceHeadline4">@style/TextAppearance.MaterialComponents.Headline4</item>
+    <item name="textAppearanceHeadline5">@style/TextAppearance.MaterialComponents.Headline5</item>
+    <item name="textAppearanceHeadline6">@style/TextAppearance.MaterialComponents.Headline6</item>
+    <item name="textAppearanceSubtitle1">@style/TextAppearance.MaterialComponents.Subtitle1</item>
+    <item name="textAppearanceSubtitle2">@style/TextAppearance.MaterialComponents.Subtitle2</item>
+    <item name="textAppearanceBody1">@style/TextAppearance.MaterialComponents.Body1</item>
+    <item name="textAppearanceBody2">@style/TextAppearance.MaterialComponents.Body2</item>
+    <item name="textAppearanceCaption">@style/TextAppearance.MaterialComponents.Caption</item>
+    <item name="textAppearanceButton">@style/TextAppearance.MaterialComponents.Button</item>
+    <item name="textAppearanceOverline">@style/TextAppearance.MaterialComponents.Overline</item>
+  </style>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
       kotlin              : '1.3.71',
       supportLib          : '1.0.0',
       recyclerView        : '1.0.0',
-      material            : '1.0.0',
+      material            : '1.1.0',
       cardview            : '1.0.0',
       room                : '2.2.5',
       androidXTestExt     : '1.1.1',


### PR DESCRIPTION
We are migrating to bridge theme first so that the existing widget themes don't break. In future, we will remove the bridge theme and use full material components theme and fix broken widget themes.

We can now start using Material components in our app, you can find the necessary style attrs and components [here](https://material.io/components/).