### PR TITLE
Define a build matrix to verify all release builds on CI

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -90,6 +90,9 @@ jobs:
 
   verify_release_build:
     runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        buildType: ['Sandbox', 'Staging', 'Security', 'Production']
     steps:
       - uses: actions/checkout@v2
 
@@ -98,12 +101,12 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: SBX Release build with Proguard
+      - name: ${{ matrix.buildType }} Release build with Proguard
         run: |
           ./gradlew \
           -PrunProguard=true \
           -PdefaultProguardFile=proguard-android.txt \
-          assembleSandboxRelease
+          assemble${{ matrix.buildType }}Release
 
   verify_room_schemas:
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
Currently, we only verify that the **SANDBOX** environment builds on CI checks. The problems with this are:

- The only thing this verifies is the R8 configuration files.
- Things like build specific Dagger setup, etc are not verified.

This PR changes the CI checks to run verifications on ALL our release variants. It does this using a [build matrix](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#configuring-a-build-matrix), which allows all the different builds to happen in parallel.