### PR TITLE
Add separate `ParcelableOptional` to use in Parcelable classes

### DIFF
--- a/app/src/main/java/org/simple/clinic/util/ParcelableOptional.kt
+++ b/app/src/main/java/org/simple/clinic/util/ParcelableOptional.kt
@@ -1,0 +1,57 @@
+package org.simple.clinic.util
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+/**
+ * We already have an [Optional] class that we use for representing
+ * optional values. However, that has a major drawback on Android:
+ *
+ * - We cannot use it in any class that implements the [Parcelable]
+ * interface since it itself is not [Parcelable].
+ *
+ * In addition, we cannot make the class [Parcelable] because that would
+ * force every user of the class to also implement the interface.
+ *
+ * This class is based on the Java [Optional](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html)
+ * class, but which forces the [Parcelable] interface on its types.
+ **/
+@Parcelize
+data class ParcelableOptional<T : Parcelable>(
+    private val value: T?
+) : Parcelable {
+
+  companion object {
+    fun <T : Parcelable> of(value: T?) = ParcelableOptional(value)
+  }
+
+  fun get(): T {
+    if (value == null) throw NoSuchElementException("value is not present!")
+
+    return value
+  }
+
+  fun isPresent(): Boolean = value != null
+
+  fun isEmpty(): Boolean = value == null
+
+  fun ifPresent(consumer: (T) -> Unit) {
+    if (value != null) {
+      consumer.invoke(value)
+    }
+  }
+
+  fun orElse(other: T): T {
+    return value ?: other
+  }
+
+  fun orElse(failureSupplier: () -> Throwable): T {
+    if (value == null) throw failureSupplier()
+
+    return value
+  }
+}
+
+fun <T : Parcelable> Optional<T>.parcelable(): ParcelableOptional<T> {
+  return ParcelableOptional(this.toNullable())
+}


### PR DESCRIPTION
This is required for https://www.pivotaltracker.com/story/show/172194270.

The reason this class has been added is because the model *requires* the notion of an `Optional`, but it also has to be `Parcelable`, which our current `Optional` class cannot be.

