### PR TITLE
Fix flaky test in `BloodPressureRepositoryAndroidTest`

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/bp/BloodPressureHistoryListItemDataSourceTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/bp/BloodPressureHistoryListItemDataSourceTest.kt
@@ -5,14 +5,18 @@ import androidx.paging.PositionalDataSource.LoadInitialCallback
 import androidx.paging.PositionalDataSource.LoadInitialParams
 import androidx.paging.PositionalDataSource.LoadRangeParams
 import com.google.common.truth.Truth.assertThat
+import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.TestClinicApp
 import org.simple.clinic.TestData
 import org.simple.clinic.bp.history.adapter.BloodPressureHistoryListItem
 import org.simple.clinic.bp.history.adapter.BloodPressureHistoryListItem.BloodPressureHistoryItem
 import org.simple.clinic.bp.history.adapter.BloodPressureHistoryListItem.NewBpButton
+import org.simple.clinic.util.Rules
 import org.simple.clinic.util.TestUserClock
 import org.simple.clinic.util.TestUtcClock
 import org.threeten.bp.Duration
@@ -41,12 +45,20 @@ class BloodPressureHistoryListItemDataSourceTest {
   @field:[Inject Named("time_for_measurement_history")]
   lateinit var timeFormatter: DateTimeFormatter
 
+  @get:Rule
+  val ruleChain: RuleChain = Rules.global()
+
   private val canEditBpFor = Duration.ofMinutes(10)
 
   @Before
   fun setup() {
     TestClinicApp.appComponent().inject(this)
     utcClock.setDate(LocalDate.parse("2020-01-01"))
+  }
+
+  @After
+  fun tearDown() {
+    appDatabase.bloodPressureDao().clearData()
   }
 
   @Test


### PR DESCRIPTION
`BloodPressureRepositoryAndroidTest#getting_the_blood_pressure_count_immediate_for_a_patient_should_work_correctly`
was detected as 10% flaky over the last few days. I investigated this
and found out the cause:

- `BloodPressureHistoryListItemDataSourceTest` was added which creates
some data in the `BloodPressureMeasurement` table, but does not clean
up after itself.
- The flaky test in question asserts the total count of BPs present
in the database before running its assertions.
- When the test was run by itself, it would work fine.
- When the test was run *after* `BloodPressureHistoryListItemDataSourceTest`,
it would first fail because the BP count was not what it expected, then
the test rule would clear the databases, then the flaky test rule would
execute it again and it would pass.

This commit fixes the issue by changing `BloodPressureHistoryListItemDataSourceTest`
to clean up after itself.