### PR TITLE
Exclude appcompat 1.1.0 from the dependency tree

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -339,6 +339,8 @@ dependencies {
   }
   runtimeOnly "com.fasterxml.jackson.core:jackson-core:$versions.jackson"
   runtimeOnly "ch.qos.logback:logback-classic:$versions.logback"
+
+  implementation "androidx.appcompat:appcompat:$versions.appcompat"
 }
 
 // This must always be present at the bottom of this file, as per:

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ buildscript {
       cameraLifecycle     : '1.0.0-alpha09',
       zxing               : '3.3.3',
       paging              : '2.1.2',
+      appcompat           : '1.2.0-beta01'
   ]
 
   repositories {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/170332759

I had to bump the appcompat version to `1.2.0-beta01` to get it to work. Since beta releases are more or less stable, and what is expected to change would only be API contracts, I think this is a safe tradeoff.