### PR TITLE
Checkout using `GITHUB_ACCESS_TOKEN`

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -167,6 +167,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_ACCESS_TOKEN }}
 
       - name: Fix ellipsise in strings
         run: .github/scripts/strings_reader.py


### PR DESCRIPTION
When running checkout in `fix_strings_ellipsise` use `GITHUB_ACCESS_TOKEN` to be able to push back as a user to the repo.

https://www.pivotaltracker.com/story/show/172579029