### PR TITLE
Update NDK version

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -67,7 +67,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
-          script: ./gradlew -PandroidNdkVersion=18.1.5063045 connectedQaDebugAndroidTest
+          script: ./gradlew connectedQaDebugAndroidTest
 
   qa_build_apk:
     runs-on: [ubuntu-latest]

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,4 +60,4 @@ securityFallbackApiEndpoint=do_not_change_here
 #
 # Currently, this is only used for assembling the APK where the build process
 # strips debug symbols from the APK.
-androidNdkVersion=21.0.6113669
+androidNdkVersion=21.1.6352462


### PR DESCRIPTION
# Changes

- Pin the current NDK version to the latest available.
- Remove the switching of NDK version for the android tests since the version of the NDK installed on the macOS runner is [updated](https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md#android-utils).

