### PR TITLE
Fix PR description CI when using markdown syntax

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -131,7 +131,8 @@ jobs:
     steps:
       - name: Verify PR description
         run: |
-          PR_DESCRIPTION='${{github.event.pull_request.body}}'
+          QUOTED_PR_DESCRIPTION="$(printf "%q" "${{github.event.pull_request.body}}")"
+          PR_DESCRIPTION="$QUOTED_PR_DESCRIPTION"
           PIVOTAL_STORY_REGEX='https:\/\/www.pivotaltracker.com\/story\/show\/[0-9]{9}'
 
           if [[ $PR_DESCRIPTION =~ $PIVOTAL_STORY_REGEX ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Internal
 - Lazy inject `facility` and `user` in all `EffectHandler` classes
 - [In Progress: 18th May 2020] Migrate `ScheduleAppointmentSheet` to Mobius
+- Fix PR description CI when using markdown syntax
 
 ### Fixes
 - Fix the [click issue](https://www.pivotaltracker.com/story/show/172784091) in custom prescription on Medicines screen
@@ -231,7 +232,7 @@
 
 ### Internal
 - Add Mixpanel analytics
-- Add device locale, timezone, and timezone offset headers to all requests 
+- Add device locale, timezone, and timezone offset headers to all requests
 
 ## 2019-08-26-5229
 ### Feature
@@ -310,23 +311,23 @@
 - Hide the sync indicator if nurse hasn’t been approved
 
 ## 3269-18Mar
-- While creating a new account, facilities located nearby are automatically suggested 
-- Scheduling an appointment shows new date options 
+- While creating a new account, facilities located nearby are automatically suggested
+- Scheduling an appointment shows new date options
 
 ## 2856-25Feb
-- Updated illustration on the patients tab 
-- Improved app performance during first sync of patient data 
-- Improve design of medical history screen 
+- Updated illustration on the patients tab
+- Improved app performance during first sync of patient data
+- Improve design of medical history screen
 
 ## 2605-04Feb
-- Blood pressures can be entered for dates in the past 
-- New prescription drugs screen design 
-- New medicine dosage picker design 
+- Blood pressures can be entered for dates in the past
+- New prescription drugs screen design
+- New medicine dosage picker design
 
 ## 2301-04Jan
-- Age and date of birth fields removed from patient search screen 
+- Age and date of birth fields removed from patient search screen
 - Improved patient search algorithm
-- Added new cancellation reasons for appointments 
+- Added new cancellation reasons for appointments
 - Updated the rules for identifying high-risk patients
 
 ## 2204-26Dec
@@ -334,22 +335,22 @@
 
 ## 2116-17Dec
 - Automatically submit PIN when 4 digits have been entered
-- Show Yes/No/Unanswered buttons on medical history questions 
-- Show option to change clinics from the home screen 
+- Show Yes/No/Unanswered buttons on medical history questions
+- Show option to change clinics from the home screen
 - Ask for confirmation when exiting Edit Patient screen without saving the edited information
 
 ## 2052-10Dec
-- Dismiss keyboard while scrolling list of clinics 
-- Highlight search query term when filtering clinics 
+- Dismiss keyboard while scrolling list of clinics
+- Highlight search query term when filtering clinics
 
 ## 1991-03Dec
-- Added ability to request a new OTP via SMS, while logging in 
+- Added ability to request a new OTP via SMS, while logging in
 - Blood pressure values are now editable for 24 hours
 - Demographic data of patients is now editable
-- "Very High" and "Extremely High" BPs are now shows as "High" 
+- "Very High" and "Extremely High" BPs are now shows as "High"
 - PIN entry is now protected against brute force attacks
 - High risk patients are labelled in the overdue list
-- Fix: crash when app was closed before entering OTP, while logging in 
+- Fix: crash when app was closed before entering OTP, while logging in
 
 ## 1705-10Nov
 - Patient searches with more than 100 results caused a crash
@@ -366,7 +367,7 @@
 
 ## 1462-16Oct
 - Add a helpful message to the home screen
-- Fix: calling a patient from the overdue list sometimes used an incorrect phone number 
+- Fix: calling a patient from the overdue list sometimes used an incorrect phone number
 
 ## 1420-11Oct
 - Order facilities alphabetically in lists
@@ -375,5 +376,5 @@
 - Fix: crash on opening patient summary if there was a BP recorded more than 6 months ago
 
 ## 1356-07Oct
-- Fix: crash if multiple histories are present for the same patient 
+- Fix: crash if multiple histories are present for the same patient
 - Fix: crash if empty systolic or diastolic blood pressure value is submitted


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172909087

Because we were using a single quote when converting the PR body to a string, it started considering the URL markdown syntax `()` as "commands". In order to fix that, I have changed to to convert the received PR description to a proper double-quoted string so that it will ignore the "command" blocks inside the string.