### PR TITLE
Fix PR description CI check when using markdown syntax

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -131,7 +131,8 @@ jobs:
     steps:
       - name: Verify PR description
         run: |
-          PR_DESCRIPTION='${{github.event.pull_request.body}}'
+          QUOTED_PR_DESCRIPTION="$(printf "%q" "${{github.event.pull_request.body}}")"
+          PR_DESCRIPTION="$QUOTED_PR_DESCRIPTION"
           PIVOTAL_STORY_REGEX='https:\/\/www.pivotaltracker.com\/story\/show\/[0-9]{9}'
 
           if [[ $PR_DESCRIPTION =~ $PIVOTAL_STORY_REGEX ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Internal
 - [In Progress: 18th May 2020] Migrate `ScheduleAppointmentSheet` to Mobius
+- Fix PR description CI when using markdown syntax
 
 ## On Demo
 ### Feature


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172909087

Because we were using a single quote when converting the PR body to a string, it started considering the markdown syntax as "commands". In order to fix that, I have changed it to convert the received PR description to a proper double-quoted string so that it will ignore the "command" blocks inside the string.

A sample **markdown** [link](https://github.com/simpledotorg/simple-android) to test it.