### PR TITLE
Fix fetching teleconsultation info on patient summary screen restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 - Fix camera crash when QR scanner view is paused/closed
+- Fix fetching teleconsultation error when `PatientSummaryScreen` is restored
 
 ## On Demo
 ### Feature

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryInit.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryInit.kt
@@ -15,15 +15,8 @@ class PatientSummaryInit : Init<PatientSummaryModel, PatientSummaryEffect> {
       effects.add(LoadCurrentUserAndFacility)
     }
 
-    if (model.hasLoadedCurrentFacility) {
-      when (model.teleconsultInfo) {
-        null, is TeleconsultInfo.Fetching -> {
-          effects.add(FetchTeleconsultationInfo(model.currentFacility!!.uuid))
-        }
-        is TeleconsultInfo.NetworkError -> {
-          effects.add(ShowTeleconsultInfoError)
-        }
-      }
+    if (model.canCheckTeleconsultationInfo) {
+      effectForTeleconsultInfoState(model, effects)
     }
 
     if (!model.hasCheckedForInvalidPhone) {
@@ -35,5 +28,19 @@ class PatientSummaryInit : Init<PatientSummaryModel, PatientSummaryEffect> {
     }
 
     return first(model, effects)
+  }
+
+  private fun effectForTeleconsultInfoState(
+      model: PatientSummaryModel,
+      effects: MutableSet<PatientSummaryEffect>
+  ) {
+    when (model.teleconsultInfo) {
+      null, is TeleconsultInfo.Fetching -> {
+        effects.add(FetchTeleconsultationInfo(model.currentFacility!!.uuid))
+      }
+      is TeleconsultInfo.NetworkError -> {
+        effects.add(ShowTeleconsultInfoError)
+      }
+    }
   }
 }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryModel.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryModel.kt
@@ -52,6 +52,9 @@ data class PatientSummaryModel(
   val hasUserLoggedInStatus: Boolean
     get() = userLoggedInStatus != null
 
+  val canCheckTeleconsultationInfo: Boolean
+    get() = hasLoadedCurrentFacility && isTeleconsultationEnabled && isUserLoggedIn
+
   fun patientSummaryProfileLoaded(patientSummaryProfile: PatientSummaryProfile): PatientSummaryModel {
     return copy(patientSummaryProfile = patientSummaryProfile)
   }


### PR DESCRIPTION
We are now checking if teleconsultation is enabled for the facility and user is logged in before making this call.

https://www.pivotaltracker.com/story/show/172935677