### PR TITLE
Add support for Android App Bundles

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -69,25 +69,6 @@ jobs:
           api-level: 29
           script: ./gradlew connectedQaDebugAndroidTest
 
-  qa_build_apk:
-    runs-on: [ubuntu-latest]
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-
-      - name: QA Debug Build
-        run: ./gradlew assembleQaDebug
-
-      - name: Upload APK
-        uses: actions/upload-artifact@v1
-        with:
-          name: app_qa_debug
-          path: app/build/outputs/apk/qa/debug/app-qa-debug.apk
-
   verify_release_bundles:
     runs-on: [ubuntu-latest]
     strategy:
@@ -182,7 +163,7 @@ jobs:
 
   qa_purge_env:
     runs-on: [ubuntu-latest]
-    needs: [qa_lint, qa_unit_tests, mobius_migration_tests, qa_android_tests, qa_build_apk]
+    needs: [qa_lint, qa_unit_tests, mobius_migration_tests, qa_android_tests]
     steps:
       - name: Purge QA server
         run: |

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -88,7 +88,7 @@ jobs:
           name: app_qa_debug
           path: app/build/outputs/apk/qa/debug/app-qa-debug.apk
 
-  verify_release_build:
+  verify_release_bundles:
     runs-on: [ubuntu-latest]
     strategy:
       matrix:
@@ -101,12 +101,12 @@ jobs:
         with:
           java-version: 1.8
 
-      - name: ${{ matrix.buildType }} Release build with Proguard
+      - name: Build ${{ matrix.buildType }} Release bundle
         run: |
           ./gradlew \
           -PrunProguard=true \
           -PdefaultProguardFile=proguard-android.txt \
-          assemble${{ matrix.buildType }}Release
+          bundle${{ matrix.buildType }}Release
 
   verify_room_schemas:
     runs-on: [ubuntu-latest]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 - Improved analytics around sync events
 - Updated translations: `bn_BD`
 - Tighten Code Climate checks
-- Bump AGP to 4.0.0
+- Add support for Android Studio 4.0
+- Add support for building Android App Bundles (AABs)
 
 ### Fixes
 - Fix camera crash when QR scanner view is paused/closed

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -194,6 +194,16 @@ android {
     exclude 'lib/armeabi/libsqlite3x.so'
   }
 
+  bundle {
+    language {
+      // Specifies that the app bundle should not support configuration APKs for language resources.
+      // These resources are instead packaged with each base and dynamic feature APK.
+      // We are doing this since we support switching the language within the app and we want all
+      // translations to be delivered to all devices.
+      enableSplit = false
+    }
+  }
+
   // We don't obfuscate (only minify) using proguard. Gradle plugin 3.2.0 (and greater?) generates
   // an empty mappings.txt file. This caused an issue where the CI deploy to play store task tries
   // to upload the empty mapping file, which causes the Play Store api to complain.


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/164202222

This was blocked on Heap Analytics earlier since their plugin was not supporting Android App Bundles. But we no longer use Heap, so we should be able to switch.