### PR TITLE
Fix `DosagePickerSheet` crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -102,6 +102,11 @@
       android:windowSoftInputMode="adjustResize" />
 
     <activity
+      android:name=".drugs.selection.dosage.DosagePickerSheet"
+      android:theme="@style/Clinic.V2.Theme.BottomSheetActivity"
+      android:windowSoftInputMode="adjustResize" />
+
+    <activity
       android:name=".deeplink.DeepLinkActivity"
       android:screenOrientation="portrait"
       android:windowSoftInputMode="adjustResize">


### PR DESCRIPTION
I have accidentally removed the `DosagePickerSheet` activity entry from the `AndroidManifest`, that caused the app to crash when we are starting the `DosagePickerSheet`