### PR TITLE
Retrying on a failed teleconsultation fetch only works once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Internal
 - Migrated `RecentPatientItemType` to use `ItemAdapter`
 
+### Fixes
+- Fixed retrying on a failed teleconsultation fetch when in airplane mode
+
 ## On Demo
 ### Feature
 - User can soft delete patient

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -134,7 +134,9 @@ class PatientSummaryScreen(
   private val teleconsultationErrorSnackbar by unsafeLazy {
     Snackbar.make(rootLayout, R.string.patientsummary_teleconsult_network_error, Snackbar.LENGTH_INDEFINITE)
         .setAction(R.string.patientsummary_teleconsult_network_error_retry) {
-          snackbarActionClicks.onNext(RetryFetchTeleconsultInfo)
+          postDelayed({
+            snackbarActionClicks.onNext(RetryFetchTeleconsultInfo)
+          }, 100)
         }
         .setActionTextColor(ContextCompat.getColor(context, R.color.green2))
         .setAnchorView(R.id.doneButtonFrame)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172910991

This was happening because of a race condition of dismissing and showing snackbar again when in airplane mode.