### PR TITLE
Fix keyboard not opening in app lock screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixes
 - Fixed retrying on a failed teleconsultation fetch when in airplane mode
 - Fixed showing diagnosis text in teleconsult message when diagnosis are unanswered
+- Fixed keyboard not opening in app lock screen
 
 ## 2020-06-22-7314
 ### Feature

--- a/app/src/main/java/org/simple/clinic/widgets/Views.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/Views.kt
@@ -31,11 +31,11 @@ import org.threeten.bp.Duration
 import timber.log.Timber
 
 fun EditText.showKeyboard() {
-  post {
+  postDelayed({
     this.requestFocus()
     val inputMethodManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
     inputMethodManager.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT)
-  }
+  }, 100)
 }
 
 fun ViewGroup.hideKeyboard() {


### PR DESCRIPTION
This might be occurring because some other view might be requesting focus when laying down the layout. So adding a slight delay when posting should resolve this issue. I have done this for the extension itself to avoid any issues related to this in other screens.