### PR TITLE
Fix appointment facility selection change does not work anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fixed showing diagnosis text in teleconsult message when diagnosis are unanswered
 - Fixed keyboard not opening in app lock screen
 - Fixed prescription created from a protocol drug not-showing in `EditMedicinesScreen`
+- Fix changing of appointment facility does not update the facility
 
 ## 2020-06-22-7314
 ### Feature

--- a/mobius-base/src/main/java/org/simple/clinic/mobius/DeferredEventSource.kt
+++ b/mobius-base/src/main/java/org/simple/clinic/mobius/DeferredEventSource.kt
@@ -1,0 +1,47 @@
+package org.simple.clinic.mobius
+
+import com.spotify.mobius.EventSource
+import com.spotify.mobius.disposables.Disposable
+import com.spotify.mobius.functions.Consumer
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * This class was repurposed from https://github.com/spotify/mobius-android-sample/blob/5778c008a8b7acb88adf5c2c652bed53de66fd80/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/view/DeferredEventSource.java
+ **/
+class DeferredEventSource<E> : EventSource<E> {
+
+  private val events: BlockingQueue<E> = LinkedBlockingQueue()
+
+  override fun subscribe(eventConsumer: Consumer<E>): Disposable {
+    val run = AtomicBoolean(true)
+
+    val thread = Thread {
+      while (run.get()) {
+        try {
+          val event = events.take()
+
+          if (run.get()) {
+            eventConsumer.accept(event)
+          }
+
+        } catch (e: InterruptedException) {
+          // Nothing to do here
+        }
+      }
+    }
+
+    thread.start()
+
+    return Disposable {
+      run.set(false)
+      thread.interrupt()
+    }
+  }
+
+  @Synchronized
+  fun notify(event: E) {
+    events.offer(event)
+  }
+}

--- a/mobius-base/src/main/java/org/simple/clinic/mobius/MobiusDelegate.kt
+++ b/mobius-base/src/main/java/org/simple/clinic/mobius/MobiusDelegate.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.mobius
 import android.os.Parcelable
 import com.spotify.mobius.Connectable
 import com.spotify.mobius.Connection
+import com.spotify.mobius.EventSource
 import com.spotify.mobius.First.first
 import com.spotify.mobius.Init
 import com.spotify.mobius.MobiusLoop
@@ -24,7 +25,8 @@ class MobiusDelegate<M : Parcelable, E, F> private constructor(
     private val update: Update<M, E, F>,
     private val effectHandler: ObservableTransformer<F, E>,
     private val modelUpdateListener: (M) -> Unit,
-    private val savedStateHandle: SavedStateHandle<M>
+    private val savedStateHandle: SavedStateHandle<M>,
+    private val additionalEventSources: List<EventSource<E>>
 ) : Connectable<M, E> {
 
   companion object {
@@ -34,7 +36,8 @@ class MobiusDelegate<M : Parcelable, E, F> private constructor(
         update: Update<M, E, F>,
         effectHandler: ObservableTransformer<F, E>,
         init: Init<M, F> = Init { first(defaultModel) },
-        modelUpdateListener: (M) -> Unit = {}
+        modelUpdateListener: (M) -> Unit = {},
+        additionalEventSources: List<EventSource<E>> = emptyList()
     ): MobiusDelegate<M, E, F> {
       return MobiusDelegate(
           events = events,
@@ -43,7 +46,8 @@ class MobiusDelegate<M : Parcelable, E, F> private constructor(
           update = update,
           effectHandler = effectHandler,
           modelUpdateListener = modelUpdateListener,
-          savedStateHandle = ViewSavedStateHandle(defaultModel::class.java.name)
+          savedStateHandle = ViewSavedStateHandle(defaultModel::class.java.name),
+          additionalEventSources = additionalEventSources
       )
     }
 
@@ -53,7 +57,8 @@ class MobiusDelegate<M : Parcelable, E, F> private constructor(
         update: Update<M, E, F>,
         effectHandler: ObservableTransformer<F, E>,
         init: Init<M, F> = Init { first(defaultModel) },
-        modelUpdateListener: (M) -> Unit = {}
+        modelUpdateListener: (M) -> Unit = {},
+        additionalEventSources: List<EventSource<E>> = emptyList()
     ): MobiusDelegate<M, E, F> {
       return MobiusDelegate(
           events = events,
@@ -62,7 +67,8 @@ class MobiusDelegate<M : Parcelable, E, F> private constructor(
           update = update,
           effectHandler = effectHandler,
           modelUpdateListener = modelUpdateListener,
-          savedStateHandle = ActivitySavedStateHandle(defaultModel::class.java.name)
+          savedStateHandle = ActivitySavedStateHandle(defaultModel::class.java.name),
+          additionalEventSources = additionalEventSources
       )
     }
   }
@@ -86,7 +92,8 @@ class MobiusDelegate<M : Parcelable, E, F> private constructor(
       update = update,
       effectHandler = effectHandler,
       modelUpdateListener = modelUpdateListener,
-      savedStateHandle = ViewSavedStateHandle(defaultModel::class.java.name)
+      savedStateHandle = ViewSavedStateHandle(defaultModel::class.java.name),
+      additionalEventSources = emptyList()
   )
 
   private val controller: MobiusLoop.Controller<M, E> by lazy(NONE) {
@@ -102,6 +109,7 @@ class MobiusDelegate<M : Parcelable, E, F> private constructor(
             { effects -> effects.compose(effectHandler) }
         )
         .init(init)
+        .eventSources(additionalEventSources)
   }
 
   @Deprecated(message = "Added to aid refactoring to Mobius. Do not use anywhere else.")

--- a/mobius-base/src/main/java/org/simple/clinic/mobius/MobiusFoo.kt
+++ b/mobius-base/src/main/java/org/simple/clinic/mobius/MobiusFoo.kt
@@ -1,6 +1,8 @@
 package org.simple.clinic.mobius
 
+import com.spotify.mobius.EventSource
 import com.spotify.mobius.First
+import com.spotify.mobius.MobiusLoop
 import com.spotify.mobius.Next
 
 fun <M, F> next(model: M, vararg effects: F): Next<M, F> = if (effects.isEmpty()) {
@@ -16,4 +18,12 @@ fun <M, F> first(model: M, vararg effects: F): First<M, F> = if (effects.isEmpty
   First.first(model)
 } else {
   First.first(model, setOf(*effects))
+}
+
+fun <M, E, F> MobiusLoop.Builder<M, E, F>.eventSources(eventsSources: List<EventSource<E>>): MobiusLoop.Builder<M, E, F> {
+  return when {
+    eventsSources.isEmpty() -> this
+    eventsSources.size == 1 -> eventSource(eventsSources.first())
+    else -> eventSources(eventsSources.first(), *eventsSources.subList(1, eventsSources.size).toTypedArray())
+  }
 }

--- a/mobius-migration/src/test/java/org/simple/mobius/migration/MobiusTestFixtureTest.kt
+++ b/mobius-migration/src/test/java/org/simple/mobius/migration/MobiusTestFixtureTest.kt
@@ -19,13 +19,17 @@ class MobiusTestFixtureTest {
   private val view = VerifiableCounterView()
   private val modelUpdateListener = { model: CounterModel -> view.render(model) }
   private val effectHandler = createEffectHandler(view)
+  private val firstAdditionalEventSource = ImmediateEventSource<CounterEvent>()
+  private val secondAdditionalEventSource = ImmediateEventSource<CounterEvent>()
+
   private val fixture = MobiusTestFixture(
-      events,
-      defaultModel,
-      null,
-      CounterUpdate(),
-      effectHandler,
-      modelUpdateListener
+      events = events,
+      defaultModel = defaultModel,
+      init = null,
+      update = CounterUpdate(),
+      effectHandler = effectHandler,
+      modelUpdateListener = modelUpdateListener,
+      additionalEventSources = listOf(firstAdditionalEventSource, secondAdditionalEventSource)
   )
 
   @Before
@@ -85,5 +89,20 @@ class MobiusTestFixtureTest {
     // then
     assertThat(view.model)
         .isEqualTo(defaultModel)
+  }
+
+  @Test
+  fun `it can dispatch events via the additional event sources to update the model`() {
+    // when
+    with(events) {
+      onNext(Increment)
+      firstAdditionalEventSource.notifyEvent(Increment)
+      onNext(Increment)
+      secondAdditionalEventSource.notifyEvent(Increment)
+    }
+
+    // then
+    assertThat(fixture.model)
+        .isEqualTo(4)
   }
 }


### PR DESCRIPTION
This PR fixes https://www.pivotaltracker.com/story/show/173509335.

The reason this was happening is because of the following reasons:

- Mobius subscribes to the events in `onStart()` since `ScheduleAppointmentSheet` is an activity.
- The event that forwards the facility change to the loop is emitted in `onActivityResult()`.
- `onActivityResult` gets invoked *before* `onStart()` and the event is lost because the loop has not yet been setup at this point.

According to an issue ([LINK](https://github.com/spotify/mobius/issues/42)) on the Mobius repository, they solve this case using an alternate event source that caches these events until the source gets subscribed to. This PR implements the fix by adding support for these sources.