### PR TITLE
Use unicode characters for percent symbol in string resources

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -523,9 +523,9 @@
   <string name="bloodsugarentry_month">Month</string>
   <string name="bloodsugarentry_year">Year</string>
   <string name="bloodsugarentry_error_lower_limit">Value cannot be less than 30 mg/dL</string>
-  <string name="bloodsugarentry_error_lower_limit_hba1c">Value cannot be less than 3%</string>
+  <string name="bloodsugarentry_error_lower_limit_hba1c">Value cannot be less than 3\u0025</string>
   <string name="bloodsugarentry_error_higher_limit">Value cannot be more than 1000 mg/dL</string>
-  <string name="bloodsugarentry_error_higher_limit_hba1c">Value cannot be more than 25%</string>
+  <string name="bloodsugarentry_error_higher_limit_hba1c">Value cannot be more than 25\u0025</string>
   <string name="bloodsugarentry_error_empty">Value cannot be empty</string>
   <string name="bloodsugarentry_error_date_invalid_pattern">Enter a valid date in DD/MM/YYYY</string>
   <string name="bloodsugarentry_error_date_is_in_future">Date cannot be in the future</string>


### PR DESCRIPTION
We need to escape percent symbols in string resources by using the double percent sequence (`%%`). However, it seems like the Android toolchain only throws an error if the percent symbol is present in the middle of the string and not at the end.

So we can have situations where a source string in English ("Value cannot be less than 3%") works fine, but when it gets translated to another language, the "3%" part moves to a different location and starts throwing errors.

In order to fix this, we will use the unicode symbol for the percent character whenever it is meant to be displayed on screen and translated.