### PR TITLE
Fix occasional crash when starting a teleconsultation session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 ### Changes
 - Updated translations: `bn_IN`, `am_ET`, `te_IN`, `pa_IN`, `hi_IN`, `bn_BD`
 
+### Fixes
+- Fixed occasional crash when starting a teleconsultation session ([LINK](https://app.clubhouse.io/simpledotorg/story/414/starting-a-teleconsultation-session-crashes-in-some-scenarios))
+
 ## On Demo
 ### Internal
 - Migrated `RegistrationPinScreen` to Mobius

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffect.kt
@@ -68,4 +68,7 @@ data class FetchTeleconsultationInfo(val facilityUuid: UUID) : PatientSummaryEff
 
 object ShowTeleconsultInfoError : PatientSummaryEffect()
 
-data class OpenSelectDoctorSheet(val phoneNumbers: List<TeleconsultPhoneNumber>) : PatientSummaryEffect()
+data class OpenSelectDoctorSheet(
+    val facility: Facility,
+    val phoneNumbers: List<TeleconsultPhoneNumber>
+) : PatientSummaryEffect()

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
@@ -84,7 +84,7 @@ class PatientSummaryEffectHandler @AssistedInject constructor(
         .addConsumer(ContactDoctor::class.java, { uiActions.contactDoctor(it.patientTeleconsultationInfo, it.teleconsultationPhoneNumber) }, schedulersProvider.ui())
         .addTransformer(FetchTeleconsultationInfo::class.java, fetchFacilityTeleconsultationInfo())
         .addAction(ShowTeleconsultInfoError::class.java, { uiActions.showTeleconsultInfoError() }, schedulersProvider.ui())
-        .addConsumer(OpenSelectDoctorSheet::class.java, { uiActions.openContactDoctorSheet(currentFacility.get(), it.phoneNumbers) }, schedulersProvider.ui())
+        .addConsumer(OpenSelectDoctorSheet::class.java, { uiActions.openContactDoctorSheet(it.facility, it.phoneNumbers) }, schedulersProvider.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
@@ -113,7 +113,7 @@ class PatientSummaryUpdate : Update<PatientSummaryModel, PatientSummaryEvent, Pa
       model: PatientSummaryModel
   ): PatientSummaryEffect {
     return if (teleconsultInfo.areMultipleDoctorsAvailable) {
-      OpenSelectDoctorSheet(teleconsultInfo.doctorsPhoneNumbers)
+      OpenSelectDoctorSheet(model.currentFacility!!, teleconsultInfo.doctorsPhoneNumbers)
     } else {
       LoadPatientTeleconsultationInfo(
           model.patientUuid,

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
@@ -35,9 +35,9 @@ import org.simple.clinic.util.Just
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.scheduler.TrampolineSchedulersProvider
 import org.simple.clinic.uuid.FakeUuidGenerator
+import java.net.UnknownHostException
 import java.time.Duration
 import java.time.Instant
-import java.net.UnknownHostException
 import java.util.UUID
 
 class PatientSummaryEffectHandlerTest {
@@ -490,7 +490,7 @@ class PatientSummaryEffectHandlerTest {
     )
 
     // when
-    testCase.dispatch(OpenSelectDoctorSheet(phoneNumbers))
+    testCase.dispatch(OpenSelectDoctorSheet(facility, phoneNumbers))
 
     // then
     verify(uiActions).openContactDoctorSheet(facility, phoneNumbers)

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
@@ -671,7 +671,7 @@ class PatientSummaryUpdateTest {
         .then(
             assertThatNext(
                 hasNoModel(),
-                hasEffects(OpenSelectDoctorSheet(phoneNumbers) as PatientSummaryEffect)
+                hasEffects(OpenSelectDoctorSheet(facilityWithDiabetesManagementEnabled, phoneNumbers) as PatientSummaryEffect)
             )
         )
   }


### PR DESCRIPTION
Ticket: https://app.clubhouse.io/simpledotorg/story/414/starting-a-teleconsultation-session-crashes-in-some-scenarios

The current facility was being lazily queried and stored in the `PatientSummaryEffectHandler`
via a `dagger.Lazy` class. When the screen is created, we query this as
part of the screen setup which runs on a background thread. However, on
screen restoration we do not query it if it was already fetched.

This means that a database query would be made the next time the lazy
property is invoked, which would happen when there are multiple doctors
available for teleconsultation and we show the picker sheet. This runs
on the UI thread and caused a crash.

This commit fixes the issue by passing in the facility via the effect
since the model already has it.