### PR TITLE
Show phone number empty error in `EditPatientScreen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Updated translations: `bn_IN`, `am_ET`, `te_IN`, `pa_IN`, `hi_IN`, `bn_BD`
 - Added Registration Facility name and date in `PatientSummaryScreen`
 
+### Fixes
+- Fix crash when removing phone number for a patient that already has one ([LINK](https://app.clubhouse.io/simpledotorg/story/366/app-crashing-when-phone-number-is-empty-while-editing-patient))
+
 ## On Demo
 ### Internal
 - Migrated `RegistrationPinScreen` to Mobius

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
@@ -375,6 +375,7 @@ class EditPatientScreen(context: Context, attributeSet: AttributeSet) : Relative
     errors.forEach {
       when (it) {
         FullNameEmpty -> showEmptyFullNameError(true)
+        PhoneNumberEmpty -> showPhoneNumberEmptyError()
         is PhoneNumberLengthTooShort -> showLengthTooShortPhoneNumberError(it.minimumAllowedNumberLength)
         is PhoneNumberLengthTooLong -> showLengthTooLongPhoneNumberError(it.maximumAllowedNumberLength)
         ColonyOrVillageEmpty -> showEmptyColonyOrVillageError(true)
@@ -387,9 +388,6 @@ class EditPatientScreen(context: Context, attributeSet: AttributeSet) : Relative
         DateOfBirthExceedsMaxLimit -> showDateOfBirthExceedsMaxLimitError()
         AgeExceedsMinLimit -> showAgeExceedsMinLimitError()
         DateOfBirthExceedsMinLimit -> showDateOfBirthExceedsMinLimitError()
-        PhoneNumberEmpty -> {
-          throw AssertionError("Should  never receive this error: $it")
-        }
       }.exhaustive()
     }
   }
@@ -468,6 +466,10 @@ class EditPatientScreen(context: Context, attributeSet: AttributeSet) : Relative
       show -> resources.getString(R.string.patientedit_error_both_dateofbirth_and_age_empty)
       else -> null
     }
+  }
+
+  private fun showPhoneNumberEmptyError() {
+    phoneNumberInputLayout.error = context.getString(R.string.patientedit_error_phonenumber_blank)
   }
 
   private fun showLengthTooShortPhoneNumberError(requiredNumberLength: Int) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
   <string name="patientedit_error_empty_colony_or_village" translatable="false">@string/patiententry_error_empty_colony_or_village</string>
   <string name="patientedit_error_empty_district" translatable="false">@string/patiententry_error_empty_district</string>
   <string name="patientedit_error_state_empty" translatable="false">@string/patiententry_error_state_empty</string>
+  <string name="patientedit_error_phonenumber_blank" translatable="false">@string/patiententry_error_phonenumber_blank</string>
   <string name="patientedit_error_phonenumber_length_less" translatable="false">@string/patiententry_error_phonenumber_length_less</string>
   <string name="patientedit_error_phonenumber_length_more" translatable="false">@string/patiententry_error_phonenumber_length_more</string>
   <string name="patientedit_date_of_birth_unfocused" translatable="false">@string/patiententry_date_of_birth_unfocused</string>


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/366/app-crashing-when-phone-number-is-empty-while-editing-patient