### PR TITLE
Stop tracking ongoing registration entry in `UserSession`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Change selection of facility throughout the codebase to use `ItemAdapter`
 - Bump patient resync token
 - Migrated `RecentPatientsScreen` to Mobius
+- Remove tracking of ongoing registration entry from `UserSession`
 - [In Progress: 16th Jul 2020] Migrate `LoginPinScreen` to Mobius
 
 ### Changes

--- a/app/src/androidTest/java/org/simple/clinic/user/UserSessionAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/user/UserSessionAndroidTest.kt
@@ -63,8 +63,7 @@ class UserSessionAndroidTest {
         uuid = user.uuid,
         registrationFacility = facility
     )
-    userSession.saveOngoingRegistrationEntry(ongoingRegistrationEntry)
-    userSession.saveOngoingRegistrationEntryAsUser(Instant.parse("2018-01-01T00:00:00Z")).blockingAwait()
+    userSession.saveOngoingRegistrationEntryAsUser(ongoingRegistrationEntry, Instant.parse("2018-01-01T00:00:00Z")).blockingAwait()
 
     assertThat(userSession.isUserLoggedIn()).isTrue()
     val loggedInUser = userSession.loggedInUser().blockingFirst().get()
@@ -74,8 +73,6 @@ class UserSessionAndroidTest {
         .currentFacility(user)
         .blockingFirst()
     assertThat(currentFacility.uuid).isEqualTo(facility.uuid)
-
-    assertThat(userSession.ongoingRegistrationEntry()).isEqualTo(Optional.of(ongoingRegistrationEntry))
   }
 
   @Test

--- a/app/src/main/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinEffect.kt
+++ b/app/src/main/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinEffect.kt
@@ -11,8 +11,6 @@ data class ValidatePinConfirmation(
 
 object ClearPin: RegistrationConfirmPinEffect()
 
-data class SaveCurrentRegistrationEntry(val entry: OngoingRegistrationEntry): RegistrationConfirmPinEffect()
-
 data class OpenFacilitySelectionScreen(val entry: OngoingRegistrationEntry): RegistrationConfirmPinEffect()
 
 data class GoBackToPinEntry(val entry: OngoingRegistrationEntry): RegistrationConfirmPinEffect()

--- a/app/src/main/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinEffectHandler.kt
@@ -7,12 +7,10 @@ import io.reactivex.ObservableTransformer
 import org.simple.clinic.registration.confirmpin.RegistrationConfirmPinValidationResult.DoesNotMatchEnteredPin
 import org.simple.clinic.registration.confirmpin.RegistrationConfirmPinValidationResult.Valid
 import org.simple.clinic.user.OngoingRegistrationEntry
-import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.scheduler.SchedulersProvider
 
 class RegistrationConfirmPinEffectHandler @AssistedInject constructor(
     private val schedulers: SchedulersProvider,
-    private val userSession: UserSession,
     @Assisted private val uiActions: RegistrationConfirmPinUiActions
 ) {
 
@@ -26,7 +24,6 @@ class RegistrationConfirmPinEffectHandler @AssistedInject constructor(
         .subtypeEffectHandler<RegistrationConfirmPinEffect, RegistrationConfirmPinEvent>()
         .addTransformer(ValidatePinConfirmation::class.java, validatePinConfirmation())
         .addAction(ClearPin::class.java, uiActions::clearPin, schedulers.ui())
-        .addTransformer(SaveCurrentRegistrationEntry::class.java, saveCurrentRegistrationEntry())
         .addConsumer(OpenFacilitySelectionScreen::class.java, { uiActions.openFacilitySelectionScreen(it.entry) }, schedulers.ui())
         .addConsumer(GoBackToPinEntry::class.java, { uiActions.goBackToPinScreen(it.entry) }, schedulers.ui())
         .build()
@@ -50,13 +47,5 @@ class RegistrationConfirmPinEffectHandler @AssistedInject constructor(
       Valid
     else
       DoesNotMatchEnteredPin
-  }
-
-  private fun saveCurrentRegistrationEntry(): ObservableTransformer<SaveCurrentRegistrationEntry, RegistrationConfirmPinEvent> {
-    return ObservableTransformer { effects ->
-      effects
-          .doOnNext { userSession.saveOngoingRegistrationEntry(it.entry) }
-          .map { RegistrationEntrySaved }
-    }
   }
 }

--- a/app/src/main/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinEvent.kt
+++ b/app/src/main/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinEvent.kt
@@ -14,8 +14,6 @@ class RegistrationConfirmPinDoneClicked : RegistrationConfirmPinEvent() {
   override val analyticsName = "Registration:Confirm Pin:Done Clicked"
 }
 
-object RegistrationEntrySaved: RegistrationConfirmPinEvent()
-
 class RegistrationResetPinClicked : RegistrationConfirmPinEvent() {
   override val analyticsName = "Registration:Confirm PIN:Reset Clicked"
 }

--- a/app/src/main/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinUpdate.kt
@@ -15,7 +15,6 @@ class RegistrationConfirmPinUpdate : Update<RegistrationConfirmPinModel, Registr
       is RegistrationConfirmPinTextChanged -> next(model.withEnteredPinConfirmation(event.confirmPin))
       is RegistrationConfirmPinDoneClicked -> dispatch(ValidatePinConfirmation(model.enteredPinConfirmation, model.ongoingRegistrationEntry))
       is PinConfirmationValidated -> validateEnteredPin(model, event)
-      is RegistrationEntrySaved -> dispatch(OpenFacilitySelectionScreen(model.ongoingRegistrationEntry))
       is RegistrationResetPinClicked -> dispatch(GoBackToPinEntry(model.ongoingRegistrationEntry.resetPin()))
     }
   }
@@ -27,7 +26,7 @@ class RegistrationConfirmPinUpdate : Update<RegistrationConfirmPinModel, Registr
     val updatedModel = model.validatedPinConfirmation(event.result)
 
     return if (updatedModel.pinConfirmationMatchesEnteredPin) {
-      next(updatedModel, SaveCurrentRegistrationEntry(updatedModel.ongoingRegistrationEntry))
+      next(updatedModel, OpenFacilitySelectionScreen(model.ongoingRegistrationEntry))
     } else {
       next(updatedModel, ClearPin)
     }

--- a/app/src/main/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionEffectHandler.kt
@@ -82,7 +82,6 @@ class RegistrationFacilitySelectionEffectHandler @AssistedInject constructor(
   private fun saveCurrentRegistrationEntry(): ObservableTransformer<SaveRegistrationEntryAsUser, RegistrationFacilitySelectionEvent> {
     return ObservableTransformer { effects ->
       effects
-          .doOnNext { userSession.saveOngoingRegistrationEntry(it.entry) }
           .switchMap {
             userSession
                 .saveOngoingRegistrationEntryAsUser(it.entry, Instant.now(utcClock))

--- a/app/src/main/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionEffectHandler.kt
@@ -85,7 +85,7 @@ class RegistrationFacilitySelectionEffectHandler @AssistedInject constructor(
           .doOnNext { userSession.saveOngoingRegistrationEntry(it.entry) }
           .switchMap {
             userSession
-                .saveOngoingRegistrationEntryAsUser(Instant.now(utcClock))
+                .saveOngoingRegistrationEntryAsUser(it.entry, Instant.now(utcClock))
                 .andThen(Observable.just(CurrentRegistrationEntrySaved))
           }
     }

--- a/app/src/main/java/org/simple/clinic/registration/name/RegistrationNameEffect.kt
+++ b/app/src/main/java/org/simple/clinic/registration/name/RegistrationNameEffect.kt
@@ -8,6 +8,4 @@ data class PrefillFields(val entry: OngoingRegistrationEntry) : RegistrationName
 
 data class ValidateEnteredName(val name: String) : RegistrationNameEffect()
 
-data class SaveCurrentRegistrationEntry(val entry: OngoingRegistrationEntry) : RegistrationNameEffect()
-
 data class ProceedToPinEntry(val entry: OngoingRegistrationEntry) : RegistrationNameEffect()

--- a/app/src/main/java/org/simple/clinic/registration/name/RegistrationNameEvent.kt
+++ b/app/src/main/java/org/simple/clinic/registration/name/RegistrationNameEvent.kt
@@ -13,5 +13,3 @@ data class NameValidated(val result: RegistrationNameValidationResult) : Registr
 class RegistrationFullNameDoneClicked : RegistrationNameEvent() {
   override val analyticsName = "Registration:Name Entry:Done Clicked"
 }
-
-object CurrentRegistrationEntrySaved : RegistrationNameEvent()

--- a/app/src/main/java/org/simple/clinic/registration/name/RegistrationNameUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/registration/name/RegistrationNameUpdate.kt
@@ -12,7 +12,6 @@ class RegistrationNameUpdate : Update<RegistrationNameModel, RegistrationNameEve
       is RegistrationFullNameTextChanged -> next(model.nameChanged(event.fullName))
       is NameValidated -> nameValidated(model, event)
       is RegistrationFullNameDoneClicked -> dispatch(ValidateEnteredName(model.ongoingRegistrationEntry.fullName!!) as RegistrationNameEffect)
-      is CurrentRegistrationEntrySaved -> dispatch(ProceedToPinEntry(model.ongoingRegistrationEntry))
     }
   }
 
@@ -23,7 +22,7 @@ class RegistrationNameUpdate : Update<RegistrationNameModel, RegistrationNameEve
     val updatedModel = model.nameValidated(event.result)
 
     return if (updatedModel.isEnteredNameValid)
-      next(updatedModel, SaveCurrentRegistrationEntry(updatedModel.ongoingRegistrationEntry) as RegistrationNameEffect)
+      next(updatedModel, ProceedToPinEntry(model.ongoingRegistrationEntry) as RegistrationNameEffect)
     else
       next(updatedModel)
   }

--- a/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneEffect.kt
+++ b/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneEffect.kt
@@ -18,8 +18,6 @@ data class ShowAccessDeniedScreen(val number: String): RegistrationPhoneEffect()
 
 data class CreateUserLocally(val userUuid: UUID, val number: String, val status: UserStatus): RegistrationPhoneEffect()
 
-object ClearCurrentRegistrationEntry: RegistrationPhoneEffect()
-
 object ProceedToLogin: RegistrationPhoneEffect()
 
 object LoadCurrentUserUnauthorizedStatus: RegistrationPhoneEffect()

--- a/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneEffect.kt
+++ b/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneEffect.kt
@@ -24,6 +24,4 @@ object LoadCurrentUserUnauthorizedStatus: RegistrationPhoneEffect()
 
 object ShowUserLoggedOutAlert: RegistrationPhoneEffect()
 
-data class SaveCurrentRegistrationEntry(val entry: OngoingRegistrationEntry): RegistrationPhoneEffect()
-
 data class ContinueRegistration(val entry: OngoingRegistrationEntry): RegistrationPhoneEffect()

--- a/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneEffectHandler.kt
@@ -39,7 +39,6 @@ class RegistrationPhoneEffectHandler @AssistedInject constructor(
         .addAction(ProceedToLogin::class.java, uiActions::openLoginPinEntryScreen, schedulers.ui())
         .addTransformer(LoadCurrentUserUnauthorizedStatus::class.java, loadCurrentUserUnauthorizedStatus())
         .addAction(ShowUserLoggedOutAlert::class.java, uiActions::showLoggedOutOfDeviceDialog, schedulers.ui())
-        .addTransformer(SaveCurrentRegistrationEntry::class.java, saveCurrentRegistrationEntry())
         .addConsumer(ContinueRegistration::class.java, { uiActions.openRegistrationNameEntryScreen(it.entry) }, schedulers.ui())
         .build()
   }
@@ -97,14 +96,6 @@ class RegistrationPhoneEffectHandler @AssistedInject constructor(
                 .firstOrError()
           }
           .map(::CurrentUserUnauthorizedStatusLoaded)
-    }
-  }
-
-  private fun saveCurrentRegistrationEntry(): ObservableTransformer<SaveCurrentRegistrationEntry, RegistrationPhoneEvent> {
-    return ObservableTransformer { effects ->
-      effects
-          .doOnNext { userSession.saveOngoingRegistrationEntry(it.entry) }
-          .map { CurrentRegistrationEntrySaved }
     }
   }
 }

--- a/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneEffectHandler.kt
@@ -36,7 +36,6 @@ class RegistrationPhoneEffectHandler @AssistedInject constructor(
         .addTransformer(SearchForExistingUser::class.java, findUserByPhoneNumber())
         .addConsumer(ShowAccessDeniedScreen::class.java, { uiActions.showAccessDeniedScreen(it.number) }, schedulers.ui())
         .addTransformer(CreateUserLocally::class.java, createUserLocally())
-        .addTransformer(ClearCurrentRegistrationEntry::class.java, clearCurrentRegistrationEntry())
         .addAction(ProceedToLogin::class.java, uiActions::openLoginPinEntryScreen, schedulers.ui())
         .addTransformer(LoadCurrentUserUnauthorizedStatus::class.java, loadCurrentUserUnauthorizedStatus())
         .addAction(ShowUserLoggedOutAlert::class.java, uiActions::showLoggedOutOfDeviceDialog, schedulers.ui())
@@ -85,14 +84,6 @@ class RegistrationPhoneEffectHandler @AssistedInject constructor(
                 .saveOngoingLoginEntry(it)
                 .andThen(Single.just(UserCreatedLocally as RegistrationPhoneEvent))
           }
-    }
-  }
-
-  private fun clearCurrentRegistrationEntry(): ObservableTransformer<ClearCurrentRegistrationEntry, RegistrationPhoneEvent> {
-    return ObservableTransformer { effects ->
-      effects
-          .doOnNext { userSession.clearOngoingRegistrationEntry() }
-          .map { CurrentRegistrationEntryCleared }
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneEvent.kt
+++ b/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneEvent.kt
@@ -89,5 +89,3 @@ class RegistrationPhoneDoneClicked : RegistrationPhoneEvent() {
 object UserCreatedLocally : RegistrationPhoneEvent()
 
 data class CurrentUserUnauthorizedStatusLoaded(val isUserUnauthorized: Boolean): RegistrationPhoneEvent()
-
-object CurrentRegistrationEntrySaved: RegistrationPhoneEvent()

--- a/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneEvent.kt
+++ b/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneEvent.kt
@@ -88,8 +88,6 @@ class RegistrationPhoneDoneClicked : RegistrationPhoneEvent() {
 
 object UserCreatedLocally : RegistrationPhoneEvent()
 
-object CurrentRegistrationEntryCleared: RegistrationPhoneEvent()
-
 data class CurrentUserUnauthorizedStatusLoaded(val isUserUnauthorized: Boolean): RegistrationPhoneEvent()
 
 object CurrentRegistrationEntrySaved: RegistrationPhoneEvent()

--- a/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneUpdate.kt
@@ -24,10 +24,6 @@ class RegistrationPhoneUpdate : Update<RegistrationPhoneModel, RegistrationPhone
       is SearchForExistingUserCompleted -> registerOrLoginUser(model, event.result)
       is UserCreatedLocally -> next(model.switchToPhoneEntryMode(), ProceedToLogin)
       is CurrentUserUnauthorizedStatusLoaded -> showUserLoggedOut(event)
-      is CurrentRegistrationEntrySaved -> {
-        val updatedModel = model.switchToPhoneEntryMode()
-        next(updatedModel, ContinueRegistration(model.ongoingRegistrationEntry))
-      }
     }
   }
 
@@ -68,7 +64,7 @@ class RegistrationPhoneUpdate : Update<RegistrationPhoneModel, RegistrationPhone
   ): Next<RegistrationPhoneModel, RegistrationPhoneEffect> {
     return when (result) {
       is SearchUserResult.Found -> saveFoundUserLocally(model, result.uuid, result.status)
-      SearchUserResult.NotFound -> dispatch(SaveCurrentRegistrationEntry(model.ongoingRegistrationEntry!!) as RegistrationPhoneEffect)
+      SearchUserResult.NotFound -> next(model.switchToPhoneEntryMode(), ContinueRegistration(model.ongoingRegistrationEntry))
       SearchUserResult.NetworkError -> next(model.switchToPhoneEntryMode().withRegistrationResult(RegistrationResult.NetworkError))
       SearchUserResult.OtherError -> next(model.switchToPhoneEntryMode().withRegistrationResult(RegistrationResult.OtherError))
     }

--- a/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneUpdate.kt
@@ -22,8 +22,7 @@ class RegistrationPhoneUpdate : Update<RegistrationPhoneModel, RegistrationPhone
       is EnteredNumberValidated -> syncFacilitiesOnValidNumber(model, event)
       is FacilitiesSynced -> lookupUserByNumber(event, model)
       is SearchForExistingUserCompleted -> registerOrLoginUser(model, event.result)
-      is UserCreatedLocally -> dispatch(ClearCurrentRegistrationEntry)
-      is CurrentRegistrationEntryCleared -> next(model.switchToPhoneEntryMode(), ProceedToLogin)
+      is UserCreatedLocally -> next(model.switchToPhoneEntryMode(), ProceedToLogin)
       is CurrentUserUnauthorizedStatusLoaded -> showUserLoggedOut(event)
       is CurrentRegistrationEntrySaved -> {
         val updatedModel = model.switchToPhoneEntryMode()

--- a/app/src/main/java/org/simple/clinic/registration/pin/RegistrationPinEffect.kt
+++ b/app/src/main/java/org/simple/clinic/registration/pin/RegistrationPinEffect.kt
@@ -4,6 +4,4 @@ import org.simple.clinic.user.OngoingRegistrationEntry
 
 sealed class RegistrationPinEffect
 
-data class SaveCurrentOngoingEntry(val entry: OngoingRegistrationEntry): RegistrationPinEffect()
-
 data class ProceedToConfirmPin(val entry: OngoingRegistrationEntry): RegistrationPinEffect()

--- a/app/src/main/java/org/simple/clinic/registration/pin/RegistrationPinEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/registration/pin/RegistrationPinEffectHandler.kt
@@ -4,11 +4,9 @@ import com.spotify.mobius.rx2.RxMobius
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import io.reactivex.ObservableTransformer
-import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.scheduler.SchedulersProvider
 
 class RegistrationPinEffectHandler @AssistedInject constructor(
-    private val userSession: UserSession,
     private val schedulers: SchedulersProvider,
     @Assisted private val uiActions: RegistrationPinUiActions
 ) {
@@ -20,16 +18,7 @@ class RegistrationPinEffectHandler @AssistedInject constructor(
 
   fun build(): ObservableTransformer<RegistrationPinEffect, RegistrationPinEvent> {
     return RxMobius.subtypeEffectHandler<RegistrationPinEffect, RegistrationPinEvent>()
-        .addTransformer(SaveCurrentOngoingEntry::class.java, saveCurrentOngoingEntry())
         .addConsumer(ProceedToConfirmPin::class.java, { uiActions.openRegistrationConfirmPinScreen(it.entry) }, schedulers.ui())
         .build()
-  }
-
-  private fun saveCurrentOngoingEntry(): ObservableTransformer<SaveCurrentOngoingEntry, RegistrationPinEvent> {
-    return ObservableTransformer { effects ->
-      effects
-          .doOnNext { userSession.saveOngoingRegistrationEntry(it.entry) }
-          .map { CurrentOngoingEntrySaved }
-    }
   }
 }

--- a/app/src/main/java/org/simple/clinic/registration/pin/RegistrationPinEvent.kt
+++ b/app/src/main/java/org/simple/clinic/registration/pin/RegistrationPinEvent.kt
@@ -4,8 +4,6 @@ import org.simple.clinic.widgets.UiEvent
 
 sealed class RegistrationPinEvent: UiEvent
 
-object CurrentOngoingEntrySaved: RegistrationPinEvent()
-
 data class RegistrationPinTextChanged(val pin: String) : RegistrationPinEvent() {
   override val analyticsName = "Registration:Pin Entry:Pin Text Changed"
 }

--- a/app/src/main/java/org/simple/clinic/registration/pin/RegistrationPinUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/registration/pin/RegistrationPinUpdate.kt
@@ -2,7 +2,6 @@ package org.simple.clinic.registration.pin
 
 import com.spotify.mobius.Next
 import com.spotify.mobius.Update
-import org.simple.clinic.mobius.dispatch
 import org.simple.clinic.mobius.next
 
 class RegistrationPinUpdate(
@@ -11,7 +10,6 @@ class RegistrationPinUpdate(
 
   override fun update(model: RegistrationPinModel, event: RegistrationPinEvent): Next<RegistrationPinModel, RegistrationPinEffect> {
     return when (event) {
-      is CurrentOngoingEntrySaved -> dispatch(ProceedToConfirmPin(model.ongoingRegistrationEntry))
       is RegistrationPinTextChanged -> next(model.pinChanged(event.pin))
       is RegistrationPinDoneClicked -> doneClicked(model)
     }
@@ -21,7 +19,7 @@ class RegistrationPinUpdate(
     val updatedModel = validateModel(model)
 
     return if (updatedModel.isEnteredPinValid)
-      next(updatedModel, SaveCurrentOngoingEntry(updatedModel.ongoingRegistrationEntry))
+      next(updatedModel, ProceedToConfirmPin(model.ongoingRegistrationEntry))
     else
       next(updatedModel)
   }

--- a/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingEffect.kt
+++ b/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingEffect.kt
@@ -9,6 +9,4 @@ object LoadRegistrationDetails: RegistrationLoadingEffect()
 
 data class RegisterUserAtFacility(val user: User, val facility: Facility): RegistrationLoadingEffect()
 
-object ClearCurrentRegistrationEntry: RegistrationLoadingEffect()
-
 object GoToHomeScreen: RegistrationLoadingEffect()

--- a/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingEffectHandler.kt
@@ -8,13 +8,11 @@ import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.user.User
-import org.simple.clinic.user.UserSession
 import org.simple.clinic.user.registeruser.RegisterUser
 import org.simple.clinic.util.scheduler.SchedulersProvider
 
 class RegistrationLoadingEffectHandler @AssistedInject constructor(
     private val schedulers: SchedulersProvider,
-    private val userSession: UserSession,
     private val registerUser: RegisterUser,
     private val currentUser: Lazy<User>,
     private val currentFacility: Lazy<Facility>,
@@ -31,7 +29,6 @@ class RegistrationLoadingEffectHandler @AssistedInject constructor(
         .subtypeEffectHandler<RegistrationLoadingEffect, RegistrationLoadingEvent>()
         .addTransformer(LoadRegistrationDetails::class.java, loadRegistrationDetails())
         .addTransformer(RegisterUserAtFacility::class.java, registerUserAtFacility())
-        .addTransformer(ClearCurrentRegistrationEntry::class.java, clearCurrentRegistrationEntry())
         .addAction(GoToHomeScreen::class.java, uiActions::openHomeScreen, schedulers.ui())
         .build()
   }
@@ -60,14 +57,6 @@ class RegistrationLoadingEffectHandler @AssistedInject constructor(
                 .subscribeOn(schedulers.io())
                 .map { UserRegistrationCompleted(RegisterUserResult.from(it)) }
           }
-    }
-  }
-
-  private fun clearCurrentRegistrationEntry(): ObservableTransformer<ClearCurrentRegistrationEntry, RegistrationLoadingEvent> {
-    return ObservableTransformer { effects ->
-      effects
-          .doOnNext { userSession.clearOngoingRegistrationEntry() }
-          .map { CurrentRegistrationEntryCleared }
     }
   }
 }

--- a/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingEvent.kt
+++ b/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingEvent.kt
@@ -10,8 +10,6 @@ data class RegistrationDetailsLoaded(val user: User, val facility: Facility) : R
 
 data class UserRegistrationCompleted(val result: RegisterUserResult) : RegistrationLoadingEvent()
 
-object CurrentRegistrationEntryCleared: RegistrationLoadingEvent()
-
 object RegisterErrorRetryClicked : RegistrationLoadingEvent() {
   override val analyticsName: String = "Registration:Loading:Retry Clicked"
 }

--- a/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingUpdate.kt
@@ -11,7 +11,6 @@ class RegistrationLoadingUpdate : Update<RegistrationLoadingModel, RegistrationL
     return when (event) {
       is RegistrationDetailsLoaded -> dispatch(RegisterUserAtFacility(event.user, event.facility))
       is UserRegistrationCompleted -> userRegistrationCompleted(event, model)
-      is CurrentRegistrationEntryCleared -> dispatch(GoToHomeScreen)
       is RegisterErrorRetryClicked -> next(model.clearRegistrationResult(), LoadRegistrationDetails)
     }
   }
@@ -23,7 +22,7 @@ class RegistrationLoadingUpdate : Update<RegistrationLoadingModel, RegistrationL
     val result = event.result
 
     return if (result == RegisterUserResult.Success) {
-      dispatch(ClearCurrentRegistrationEntry as RegistrationLoadingEffect)
+      dispatch(GoToHomeScreen as RegistrationLoadingEffect)
     } else {
       next(model.withRegistrationResult(result))
     }

--- a/app/src/main/java/org/simple/clinic/user/UserSession.kt
+++ b/app/src/main/java/org/simple/clinic/user/UserSession.kt
@@ -99,10 +99,6 @@ class UserSession @Inject constructor(
     this.ongoingRegistrationEntry = entry
   }
 
-  fun clearOngoingRegistrationEntry() {
-    ongoingRegistrationEntry = null
-  }
-
   fun storeUserAndAccessToken(userPayload: LoggedInUserPayload, accessToken: String): Completable {
     accessTokenPreference.set(Just(accessToken))
     return storeUser(

--- a/app/src/main/java/org/simple/clinic/user/UserSession.kt
+++ b/app/src/main/java/org/simple/clinic/user/UserSession.kt
@@ -38,8 +38,6 @@ class UserSession @Inject constructor(
     @Named("onboarding_complete") private val onboardingComplete: Preference<Boolean>
 ) {
 
-  private var ongoingRegistrationEntry: OngoingRegistrationEntry? = null
-
   @Deprecated(message = "Use OngoingLoginEntryRepository directly.")
   fun saveOngoingLoginEntry(entry: OngoingLoginEntry): Completable {
     return ongoingLoginEntryRepository.saveLoginEntry(entry)
@@ -93,10 +91,6 @@ class UserSession @Inject constructor(
           currentFacilityUuid = payload.registrationFacilityId
       )
     }
-  }
-
-  fun saveOngoingRegistrationEntry(entry: OngoingRegistrationEntry) {
-    this.ongoingRegistrationEntry = entry
   }
 
   fun storeUserAndAccessToken(userPayload: LoggedInUserPayload, accessToken: String): Completable {

--- a/app/src/main/java/org/simple/clinic/user/UserSession.kt
+++ b/app/src/main/java/org/simple/clinic/user/UserSession.kt
@@ -56,8 +56,11 @@ class UserSession @Inject constructor(
     ongoingLoginEntryRepository.clearLoginEntry()
   }
 
-  fun saveOngoingRegistrationEntryAsUser(timestamp: Instant): Completable {
-    val user = ongoingRegistrationEntry!!.let { entry ->
+  fun saveOngoingRegistrationEntryAsUser(
+      ongoingRegistrationEntry: OngoingRegistrationEntry,
+      timestamp: Instant
+  ): Completable {
+    val user = ongoingRegistrationEntry.let { entry ->
       User(
           uuid = entry.uuid!!,
           fullName = entry.fullName!!,
@@ -72,7 +75,7 @@ class UserSession @Inject constructor(
       )
     }
 
-    return storeUser(user, ongoingRegistrationEntry!!.facilityId!!)
+    return storeUser(user, ongoingRegistrationEntry.facilityId!!)
         .doOnSubscribe { Timber.i("Logging in from ongoing registration entry") }
   }
 

--- a/app/src/main/java/org/simple/clinic/user/UserSession.kt
+++ b/app/src/main/java/org/simple/clinic/user/UserSession.kt
@@ -19,9 +19,8 @@ import org.simple.clinic.util.Just
 import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.filterAndUnwrapJust
-import org.simple.clinic.util.toOptional
-import java.time.Instant
 import timber.log.Timber
+import java.time.Instant
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Named
@@ -98,10 +97,6 @@ class UserSession @Inject constructor(
 
   fun saveOngoingRegistrationEntry(entry: OngoingRegistrationEntry) {
     this.ongoingRegistrationEntry = entry
-  }
-
-  fun ongoingRegistrationEntry(): Optional<OngoingRegistrationEntry> {
-    return ongoingRegistrationEntry.toOptional()
   }
 
   fun clearOngoingRegistrationEntry() {

--- a/app/src/test/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinLogicTest.kt
@@ -1,6 +1,5 @@
 package org.simple.clinic.registration.confirmpin
 
-import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.clearInvocations
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
@@ -12,7 +11,6 @@ import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.user.OngoingRegistrationEntry
-import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.scheduler.TestSchedulersProvider
 import org.simple.clinic.widgets.UiEvent
@@ -27,7 +25,6 @@ class RegistrationConfirmPinLogicTest {
   private val uiEvents = PublishSubject.create<UiEvent>()
   private val ui = mock<RegistrationConfirmPinUi>()
   private val uiActions = mock<RegistrationConfirmPinUiActions>()
-  private val userSession = mock<UserSession>()
 
   private val originalPin = "1234"
   private val ongoingEntry = OngoingRegistrationEntry(
@@ -106,7 +103,6 @@ class RegistrationConfirmPinLogicTest {
     uiEvents.onNext(RegistrationConfirmPinDoneClicked())
 
     // then
-    verify(userSession, never()).saveOngoingRegistrationEntry(any())
     verify(ui).showPinMismatchError()
     verify(uiActions).clearPin()
     verify(uiActions, never()).openFacilitySelectionScreen(ongoingEntry)
@@ -138,7 +134,6 @@ class RegistrationConfirmPinLogicTest {
     uiEvents.onNext(RegistrationConfirmPinDoneClicked())
 
     // then
-    verify(userSession, never()).saveOngoingRegistrationEntry(any())
     verify(ui).showPinMismatchError()
     verify(uiActions).clearPin()
     verifyNoMoreInteractions(ui, uiActions)
@@ -149,7 +144,6 @@ class RegistrationConfirmPinLogicTest {
   ) {
     val effectHandler = RegistrationConfirmPinEffectHandler(
         schedulers = TestSchedulersProvider.trampoline(),
-        userSession = userSession,
         uiActions = uiActions
     )
     val uiRenderer = RegistrationConfirmPinUiRenderer(ui)

--- a/app/src/test/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinLogicTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
-import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
 import org.junit.After
@@ -16,7 +15,6 @@ import org.simple.clinic.user.OngoingRegistrationEntry
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.scheduler.TestSchedulersProvider
-import org.simple.clinic.util.toOptional
 import org.simple.clinic.widgets.UiEvent
 import org.simple.mobius.migration.MobiusTestFixture
 import java.util.UUID
@@ -149,8 +147,6 @@ class RegistrationConfirmPinLogicTest {
   private fun setupController(
       ongoingRegistrationEntry: OngoingRegistrationEntry = ongoingEntry
   ) {
-    whenever(userSession.ongoingRegistrationEntry()).thenReturn(ongoingRegistrationEntry.toOptional())
-
     val effectHandler = RegistrationConfirmPinEffectHandler(
         schedulers = TestSchedulersProvider.trampoline(),
         userSession = userSession,

--- a/app/src/test/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionLogicTest.kt
@@ -222,7 +222,7 @@ class RegistrationFacilitySelectionLogicTest {
     val facility1 = TestData.facility(name = "Hoshiarpur", uuid = UUID.fromString("5cf9d744-7f34-4633-aa46-a6c7e7542060"))
 
     whenever(userSession.ongoingRegistrationEntry()).thenReturn(ongoingEntry.toOptional())
-    whenever(userSession.saveOngoingRegistrationEntryAsUser(currentTime)).thenReturn(Completable.complete())
+    whenever(userSession.saveOngoingRegistrationEntryAsUser(ongoingEntry, currentTime)).thenReturn(Completable.complete())
     whenever(facilityRepository.facilities("")).thenReturn(Observable.just(listOf(facility1)))
     whenever(facilityRepository.recordCount()).thenReturn(Observable.just(1))
 
@@ -243,9 +243,10 @@ class RegistrationFacilitySelectionLogicTest {
   fun `when a facility is confirmed then the ongoing entry should be updated with selected facility and the user should be logged in`() {
     // given
     val facility1 = TestData.facility(name = "Hoshiarpur", uuid = UUID.fromString("bc761c6c-032f-4f1d-a66a-3ec81e9e8aa3"))
+    val entryWithFacility = ongoingEntry.copy(facilityId = facility1.uuid)
 
     whenever(userSession.ongoingRegistrationEntry()).thenReturn(ongoingEntry.toOptional())
-    whenever(userSession.saveOngoingRegistrationEntryAsUser(currentTime)).thenReturn(Completable.complete())
+    whenever(userSession.saveOngoingRegistrationEntryAsUser(entryWithFacility, currentTime)).thenReturn(Completable.complete())
     whenever(facilityRepository.facilities("")).thenReturn(Observable.just(listOf(facility1)))
     whenever(facilityRepository.recordCount()).thenReturn(Observable.just(1))
 
@@ -260,8 +261,8 @@ class RegistrationFacilitySelectionLogicTest {
     verify(ui).updateFacilities(listItemBuilder.build(listOf(facility1), "", null, registrationConfig.proximityThresholdForNearbyFacilities))
     verify(uiActions).openIntroVideoScreen()
     verifyNoMoreInteractions(uiActions)
-    verify(userSession).saveOngoingRegistrationEntry(ongoingEntry.copy(facilityId = facility1.uuid))
-    verify(userSession).saveOngoingRegistrationEntryAsUser(currentTime)
+    verify(userSession).saveOngoingRegistrationEntry(entryWithFacility)
+    verify(userSession).saveOngoingRegistrationEntryAsUser(entryWithFacility, currentTime)
   }
 
   @Test

--- a/app/src/test/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionLogicTest.kt
@@ -258,7 +258,6 @@ class RegistrationFacilitySelectionLogicTest {
     verify(ui).updateFacilities(listItemBuilder.build(listOf(facility1), "", null, registrationConfig.proximityThresholdForNearbyFacilities))
     verify(uiActions).openIntroVideoScreen()
     verifyNoMoreInteractions(uiActions)
-    verify(userSession).saveOngoingRegistrationEntry(entryWithFacility)
     verify(userSession).saveOngoingRegistrationEntryAsUser(entryWithFacility, currentTime)
   }
 

--- a/app/src/test/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionLogicTest.kt
@@ -30,7 +30,6 @@ import org.simple.clinic.util.Distance
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.TestUtcClock
 import org.simple.clinic.util.scheduler.TestSchedulersProvider
-import org.simple.clinic.util.toOptional
 import org.simple.clinic.widgets.UiEvent
 import java.time.Duration
 import java.time.Instant
@@ -221,7 +220,6 @@ class RegistrationFacilitySelectionLogicTest {
         pin = "1234")
     val facility1 = TestData.facility(name = "Hoshiarpur", uuid = UUID.fromString("5cf9d744-7f34-4633-aa46-a6c7e7542060"))
 
-    whenever(userSession.ongoingRegistrationEntry()).thenReturn(ongoingEntry.toOptional())
     whenever(userSession.saveOngoingRegistrationEntryAsUser(ongoingEntry, currentTime)).thenReturn(Completable.complete())
     whenever(facilityRepository.facilities("")).thenReturn(Observable.just(listOf(facility1)))
     whenever(facilityRepository.recordCount()).thenReturn(Observable.just(1))
@@ -245,7 +243,6 @@ class RegistrationFacilitySelectionLogicTest {
     val facility1 = TestData.facility(name = "Hoshiarpur", uuid = UUID.fromString("bc761c6c-032f-4f1d-a66a-3ec81e9e8aa3"))
     val entryWithFacility = ongoingEntry.copy(facilityId = facility1.uuid)
 
-    whenever(userSession.ongoingRegistrationEntry()).thenReturn(ongoingEntry.toOptional())
     whenever(userSession.saveOngoingRegistrationEntryAsUser(entryWithFacility, currentTime)).thenReturn(Completable.complete())
     whenever(facilityRepository.facilities("")).thenReturn(Observable.just(listOf(facility1)))
     whenever(facilityRepository.recordCount()).thenReturn(Observable.just(1))

--- a/app/src/test/java/org/simple/clinic/registration/name/RegistrationNameScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/name/RegistrationNameScreenLogicTest.kt
@@ -13,7 +13,6 @@ import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.user.OngoingRegistrationEntry
-import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.scheduler.TrampolineSchedulersProvider
 import org.simple.clinic.widgets.UiEvent
@@ -28,7 +27,6 @@ class RegistrationNameScreenLogicTest {
   private val uiEvents = PublishSubject.create<UiEvent>()
   private val ui = mock<RegistrationNameUi>()
   private val uiActions = mock<RegistrationNameUiActions>()
-  private val userSession = mock<UserSession>()
 
   private val currentOngoingRegistrationEntry = OngoingRegistrationEntry(
       uuid = UUID.fromString("301a9ea3-caed-4e50-a144-bc5aad66a53d"),
@@ -54,7 +52,6 @@ class RegistrationNameScreenLogicTest {
     uiEvents.onNext(RegistrationFullNameDoneClicked())
 
     // then
-    verify(userSession).saveOngoingRegistrationEntry(entryWithName)
     verify(uiActions).openRegistrationPinEntryScreen(entryWithName)
     verify(uiActions).preFillUserDetails(currentOngoingRegistrationEntry)
     verify(ui, times(2)).hideValidationError()
@@ -100,7 +97,6 @@ class RegistrationNameScreenLogicTest {
 
     // then
     val entryWithName = currentOngoingRegistrationEntry.withName(validName)
-    verify(userSession).saveOngoingRegistrationEntry(entryWithName)
     verify(uiActions).openRegistrationPinEntryScreen(entryWithName)
     verify(ui, times(2)).hideValidationError()
     verifyNoMoreInteractions(ui)
@@ -115,7 +111,6 @@ class RegistrationNameScreenLogicTest {
     uiEvents.onNext(RegistrationFullNameDoneClicked())
 
     // then
-    verify(userSession, never()).saveOngoingRegistrationEntry(any())
     verify(uiActions).preFillUserDetails(currentOngoingRegistrationEntry)
     verify(ui).hideValidationError()
     verify(ui).showEmptyNameValidationError()
@@ -144,7 +139,6 @@ class RegistrationNameScreenLogicTest {
     val uiRenderer = RegistrationNameUiRenderer(ui)
     val effectHandler = RegistrationNameEffectHandler(
         schedulers = TrampolineSchedulersProvider(),
-        userSession = userSession,
         uiActions = uiActions
     )
 

--- a/app/src/test/java/org/simple/clinic/registration/name/RegistrationNameScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/name/RegistrationNameScreenLogicTest.kt
@@ -7,7 +7,6 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
-import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
 import org.junit.After
@@ -17,7 +16,6 @@ import org.simple.clinic.user.OngoingRegistrationEntry
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.scheduler.TrampolineSchedulersProvider
-import org.simple.clinic.util.toOptional
 import org.simple.clinic.widgets.UiEvent
 import org.simple.mobius.migration.MobiusTestFixture
 import java.util.UUID
@@ -50,8 +48,6 @@ class RegistrationNameScreenLogicTest {
     val input = "Ashok Kumar"
     val entryWithName = currentOngoingRegistrationEntry.withName(input)
 
-    whenever(userSession.ongoingRegistrationEntry()).thenReturn(currentOngoingRegistrationEntry.toOptional())
-
     // when
     setupController()
     uiEvents.onNext(RegistrationFullNameTextChanged(input))
@@ -70,7 +66,6 @@ class RegistrationNameScreenLogicTest {
   fun `when screen is created then user's existing details should be pre-filled`() {
     // given
     val ongoingEntry = currentOngoingRegistrationEntry.withName("Ashok Kumar")
-    whenever(userSession.ongoingRegistrationEntry()).thenReturn(ongoingEntry.toOptional())
 
     // when
     setupController(ongoingRegistrationEntry = ongoingEntry)
@@ -87,8 +82,6 @@ class RegistrationNameScreenLogicTest {
     // given
     val validName = "Ashok"
     val invalidName = "  "
-
-    whenever(userSession.ongoingRegistrationEntry()).thenReturn(currentOngoingRegistrationEntry.toOptional())
 
     // when
     setupController()

--- a/app/src/test/java/org/simple/clinic/registration/phone/RegistrationPhoneScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/phone/RegistrationPhoneScreenLogicTest.kt
@@ -70,7 +70,6 @@ class RegistrationPhoneScreenLogicTest {
     setupController(ongoingRegistrationEntry = ongoingEntry)
 
     // then
-    verify(userSession, never()).saveOngoingRegistrationEntry(any())
     verify(ui).preFillUserDetails(ongoingEntry)
   }
 
@@ -89,7 +88,6 @@ class RegistrationPhoneScreenLogicTest {
     uiEvents.onNext(RegistrationPhoneDoneClicked())
 
     // then
-    verify(userSession).saveOngoingRegistrationEntry(entryWithPhoneNumber)
     verify(ui).openRegistrationNameEntryScreen(entryWithPhoneNumber)
   }
 
@@ -110,13 +108,13 @@ class RegistrationPhoneScreenLogicTest {
 
     // then
     verifyZeroInteractions(userSession)
+    verify(ui, never()).openRegistrationNameEntryScreen(any())
 
     // when
     uiEvents.onNext(RegistrationPhoneNumberTextChanged(validNumber))
     uiEvents.onNext(RegistrationPhoneDoneClicked())
 
     // then
-    verify(userSession).saveOngoingRegistrationEntry(entryWithValidNumber)
     verify(ui).openRegistrationNameEntryScreen(entryWithValidNumber)
   }
 
@@ -132,7 +130,6 @@ class RegistrationPhoneScreenLogicTest {
 
     // then
     verify(ui).showInvalidNumberError()
-    verify(userSession, never()).saveOngoingRegistrationEntry(any())
     verify(ui, never()).openRegistrationNameEntryScreen(any())
   }
 

--- a/app/src/test/java/org/simple/clinic/registration/phone/RegistrationPhoneScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/phone/RegistrationPhoneScreenLogicTest.kt
@@ -224,7 +224,6 @@ class RegistrationPhoneScreenLogicTest {
 
     // then
     verify(userSession).saveOngoingLoginEntry(entryToBeSaved)
-    verify(userSession).clearOngoingRegistrationEntry()
     verify(ui).openLoginPinEntryScreen()
     verify(ui, never()).showAccessDeniedScreen(inputNumber)
   }
@@ -245,7 +244,6 @@ class RegistrationPhoneScreenLogicTest {
     // then
     verify(ui).showAccessDeniedScreen(inputNumber)
     verify(userSession, never()).saveOngoingLoginEntry(any())
-    verify(userSession, never()).clearOngoingRegistrationEntry()
     verify(ui, never()).openLoginPinEntryScreen()
   }
 

--- a/app/src/test/java/org/simple/clinic/registration/pin/RegistrationPinScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/pin/RegistrationPinScreenLogicTest.kt
@@ -13,7 +13,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.SECURITY_PIN_LENGTH
 import org.simple.clinic.user.OngoingRegistrationEntry
-import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.scheduler.TestSchedulersProvider
 import org.simple.clinic.widgets.UiEvent
@@ -28,7 +27,6 @@ class RegistrationPinScreenLogicTest {
   private val uiEvents = PublishSubject.create<UiEvent>()
   private val ui = mock<RegistrationPinUi>()
   private val uiActions = mock<RegistrationPinUiActions>()
-  private val userSession = mock<UserSession>()
 
   private val ongoingRegistrationEntry = OngoingRegistrationEntry(
       uuid = UUID.fromString("db466606-9c0d-4f5f-9283-3c3c4f9b37a7"),
@@ -54,10 +52,9 @@ class RegistrationPinScreenLogicTest {
 
     // then
     val entryWithPin = ongoingRegistrationEntry.withPin(input)
-    verify(userSession).saveOngoingRegistrationEntry(entryWithPin)
     verify(uiActions).openRegistrationConfirmPinScreen(entryWithPin)
     verify(ui, times(2)).hideIncompletePinError()
-    verifyNoMoreInteractions(ui, userSession, uiActions)
+    verifyNoMoreInteractions(ui, uiActions)
   }
 
   @Test
@@ -74,10 +71,9 @@ class RegistrationPinScreenLogicTest {
 
     // then
     val entryWithPin = ongoingRegistrationEntry.withPin(validPin)
-    verify(userSession).saveOngoingRegistrationEntry(entryWithPin)
     verify(uiActions).openRegistrationConfirmPinScreen(entryWithPin)
     verify(ui, times(2)).hideIncompletePinError()
-    verifyNoMoreInteractions(ui, userSession, uiActions)
+    verifyNoMoreInteractions(ui, uiActions)
   }
 
   @Test
@@ -88,11 +84,10 @@ class RegistrationPinScreenLogicTest {
     uiEvents.onNext(RegistrationPinDoneClicked())
 
     // then
-    verify(userSession, never()).saveOngoingRegistrationEntry(any())
     verify(ui).showIncompletePinError()
     verify(uiActions, never()).openRegistrationConfirmPinScreen(any())
     verify(ui).hideIncompletePinError()
-    verifyNoMoreInteractions(ui, userSession, uiActions)
+    verifyNoMoreInteractions(ui, uiActions)
   }
 
   @Test
@@ -104,7 +99,7 @@ class RegistrationPinScreenLogicTest {
     // then
     verify(ui).hideIncompletePinError()
     verify(ui).showIncompletePinError()
-    verifyNoMoreInteractions(ui, userSession, uiActions)
+    verifyNoMoreInteractions(ui, uiActions)
   }
 
   private fun setupController(
@@ -114,7 +109,6 @@ class RegistrationPinScreenLogicTest {
     val uiRenderer = RegistrationPinUiRenderer(ui)
 
     val effectHandler = RegistrationPinEffectHandler(
-        userSession = userSession,
         schedulers = TestSchedulersProvider.trampoline(),
         uiActions = uiActions
     )

--- a/app/src/test/java/org/simple/clinic/registration/register/RegistrationLoadingLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/registration/register/RegistrationLoadingLogicTest.kt
@@ -3,7 +3,6 @@ package org.simple.clinic.registration.register
 import com.nhaarman.mockitokotlin2.clearInvocations
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
@@ -16,7 +15,6 @@ import org.junit.After
 import org.junit.Test
 import org.simple.clinic.TestData
 import org.simple.clinic.user.User.LoggedInStatus.NOT_LOGGED_IN
-import org.simple.clinic.user.UserSession
 import org.simple.clinic.user.UserStatus.WaitingForApproval
 import org.simple.clinic.user.registeruser.RegisterUser
 import org.simple.clinic.user.registeruser.RegistrationResult
@@ -30,7 +28,6 @@ import java.util.UUID
 
 class RegistrationLoadingLogicTest {
 
-  private val userSession = mock<UserSession>()
   private val ui = mock<RegistrationLoadingUi>()
   private val uiActions = mock<RegistrationLoadingUiActions>()
   private val registerUser = mock<RegisterUser>()
@@ -64,14 +61,12 @@ class RegistrationLoadingLogicTest {
     // then
     verify(ui).showNetworkError()
     verifyNoMoreInteractions(ui, uiActions)
-    verify(userSession, never()).clearOngoingRegistrationEntry()
 
     // when
     clearInvocations(ui, uiActions)
     uiEvents.onNext(RegisterErrorRetryClicked)
 
     // then
-    verify(userSession).clearOngoingRegistrationEntry()
     verify(uiActions).openHomeScreen()
     verifyNoMoreInteractions(ui, uiActions)
   }
@@ -98,7 +93,6 @@ class RegistrationLoadingLogicTest {
     setupController()
 
     // then
-    verify(userSession).clearOngoingRegistrationEntry()
     verify(uiActions).openHomeScreen()
     verifyNoMoreInteractions(ui, uiActions)
   }
@@ -132,7 +126,6 @@ class RegistrationLoadingLogicTest {
   private fun setupController() {
     val effectHandler = RegistrationLoadingEffectHandler(
         schedulers = TestSchedulersProvider.trampoline(),
-        userSession = userSession,
         registerUser = registerUser,
         currentUser = Lazy { user },
         currentFacility = Lazy { facility },


### PR DESCRIPTION
This instance has been changed so that it is passed from screen to screen and managed by the Android state saving mechanism.