### PR TITLE
Remove `FacilityChanged` event in `AssignedFacilityView`

### DIFF
--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityEffectHandler.kt
@@ -27,19 +27,13 @@ class AssignedFacilityEffectHandler @AssistedInject constructor(
   fun build(): ObservableTransformer<AssignedFacilityEffect, AssignedFacilityEvent> = RxMobius
       .subtypeEffectHandler<AssignedFacilityEffect, AssignedFacilityEvent>()
       .addTransformer(LoadAssignedFacility::class.java, loadAssignedFacility())
-      .addTransformer(ChangeAssignedFacility::class.java, changeAssignedFacility())
+      .addConsumer(ChangeAssignedFacility::class.java, { changeAssignedFacility(it) }, schedulersProvider.io())
       .addAction(OpenFacilitySelection::class.java, uiActions::openFacilitySelection, schedulersProvider.ui())
       .build()
 
-  private fun changeAssignedFacility(): ObservableTransformer<ChangeAssignedFacility, AssignedFacilityEvent> {
-    return ObservableTransformer { effects ->
-      effects
-          .observeOn(schedulersProvider.io())
-          .doOnNext { (patientUuid, assignedFacilityId) ->
-            patientRepository.updateAssignedFacilityId(patientUuid, assignedFacilityId)
-          }
-          .map { FacilityChanged }
-    }
+  private fun changeAssignedFacility(effect: ChangeAssignedFacility) {
+    val (patientUuid, assignedFacilityId) = effect
+    patientRepository.updateAssignedFacilityId(patientUuid, assignedFacilityId)
   }
 
   private fun loadAssignedFacility(): ObservableTransformer<LoadAssignedFacility, AssignedFacilityEvent> {

--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityEvent.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityEvent.kt
@@ -8,8 +8,6 @@ sealed class AssignedFacilityEvent : UiEvent
 
 data class AssignedFacilityLoaded(val facility: Optional<Facility>) : AssignedFacilityEvent()
 
-object FacilityChanged : AssignedFacilityEvent()
-
 object ChangeAssignedFacilityButtonClicked : AssignedFacilityEvent()
 
 data class AssignedFacilitySelected(val facility: Facility) : AssignedFacilityEvent()

--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityUpdate.kt
@@ -12,7 +12,6 @@ class AssignedFacilityUpdate : Update<AssignedFacilityModel, AssignedFacilityEve
   override fun update(model: AssignedFacilityModel, event: AssignedFacilityEvent): Next<AssignedFacilityModel, AssignedFacilityEffect> {
     return when (event) {
       is AssignedFacilityLoaded -> next(model.assignedFacilityUpdated(event.facility.toNullable()))
-      FacilityChanged -> noChange()
       ChangeAssignedFacilityButtonClicked -> dispatch(OpenFacilitySelection)
       is AssignedFacilitySelected -> next(
           model.assignedFacilityUpdated(event.facility),

--- a/app/src/test/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityEffectHandlerTest.kt
@@ -77,8 +77,7 @@ class AssignedFacilityEffectHandlerTest {
         assignedFacilityId = updatedAssignedFacilityId
     )
 
-    effectHandlerTestCase.assertOutgoingEvents(FacilityChanged)
-
+    effectHandlerTestCase.assertNoOutgoingEvents()
     verifyZeroInteractions(uiActions)
   }
 

--- a/app/src/test/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityUpdateTest.kt
@@ -35,16 +35,6 @@ class AssignedFacilityUpdateTest {
   }
 
   @Test
-  fun `when assigned facility is changed, then do nothing`() {
-    updateSpec
-        .given(model)
-        .whenEvent(FacilityChanged)
-        .then(assertThatNext(
-            hasNothing()
-        ))
-  }
-
-  @Test
   fun `when change assign facility button is clicked, then open facility selection`() {
     updateSpec
         .given(model)


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/323/display-patient-s-assigned-facility-in-the-patient-summary-screen

Since this is still part of the assigned facility PR feedback, haven't updated the CHANGELOG.

[*original feedback*](https://github.com/simpledotorg/simple-android/pull/1514#pullrequestreview-451485895)