### PR TITLE
Fix issue where recent and overdue patients on home screen would not update after changing facilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 - Migrated `HelpScreen` to Mobius
 - [In Progress: 05 Aug 2020] Migrate `HelpScreen` to Mobius
 
+### Fixes
+- Fixed issue where recent and overdue patients on home screen would not update after changing facility ([#742](https://app.clubhouse.io/simpledotorg/story/742/home-screen-does-not-update-when-changing-facilities))
+
 ## 2020-08-03-7364
 ### Features
 - Show assigned facility in the patient summary screen

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueInit.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueInit.kt
@@ -1,23 +1,12 @@
 package org.simple.clinic.home.overdue
 
 import com.spotify.mobius.First
-import com.spotify.mobius.First.first
 import com.spotify.mobius.Init
-import java.time.LocalDate
+import org.simple.clinic.mobius.first
 
-class OverdueInit(
-    private val date: LocalDate
-) : Init<OverdueModel, OverdueEffect> {
+class OverdueInit : Init<OverdueModel, OverdueEffect> {
 
   override fun init(model: OverdueModel): First<OverdueModel, OverdueEffect> {
-    val effects = mutableSetOf<OverdueEffect>()
-
-    if (!model.hasLoadedCurrentFacility) {
-      effects.add(LoadCurrentFacility)
-    } else {
-      effects.add(LoadOverdueAppointments(date, model.facility!!))
-    }
-
-    return first(model, effects)
+    return first(model, LoadCurrentFacility)
   }
 }

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
@@ -66,7 +66,7 @@ class OverdueScreen(
         defaultModel = OverdueModel.create(),
         update = OverdueUpdate(date),
         effectHandler = effectHandlerFactory.create(this).build(),
-        init = OverdueInit(date),
+        init = OverdueInit(),
         modelUpdateListener = { /* Nothing to do here */ }
     )
   }

--- a/app/src/main/java/org/simple/clinic/user/SessionModule.kt
+++ b/app/src/main/java/org/simple/clinic/user/SessionModule.kt
@@ -2,6 +2,7 @@ package org.simple.clinic.user
 
 import dagger.Module
 import dagger.Provides
+import io.reactivex.Observable
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.facility.Facility
 
@@ -17,5 +18,16 @@ class SessionModule {
   fun currentFacility(appDatabase: AppDatabase): Facility {
     val user = appDatabase.userDao().userImmediate()!!
     return appDatabase.userDao().currentFacilityImmediate(user.uuid)!!
+  }
+
+  @Provides
+  fun currentFacilityNotifications(appDatabase: AppDatabase): Observable<Facility> {
+    return appDatabase
+        .userDao()
+        .user()
+        .filter { it.isNotEmpty() }
+        .map { it.first().uuid }
+        .switchMap(appDatabase.userDao()::currentFacility)
+        .toObservable()
   }
 }

--- a/app/src/test/java/org/simple/clinic/home/overdue/OverdueLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/OverdueLogicTest.kt
@@ -5,7 +5,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
-import dagger.Lazy
+import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
 import org.junit.After
@@ -74,7 +74,7 @@ class OverdueLogicTest {
     val effectHandler = OverdueEffectHandler(
         schedulers = TestSchedulersProvider.trampoline(),
         appointmentRepository = repository,
-        currentFacility = Lazy { facility },
+        currentFacilityChanges = Observable.just(facility),
         dataSourceFactory = overdueAppointmentRowDataSourceFactoryInjectionFactory,
         uiActions = uiActions
     )

--- a/app/src/test/java/org/simple/clinic/home/overdue/OverdueLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/OverdueLogicTest.kt
@@ -84,7 +84,7 @@ class OverdueLogicTest {
         update = OverdueUpdate(dateOnClock),
         effectHandler = effectHandler.build(),
         modelUpdateListener = { /* Nothing to do here */ },
-        init = OverdueInit(dateOnClock)
+        init = OverdueInit()
     )
     testFixture.start()
   }

--- a/app/src/test/java/org/simple/clinic/recentpatientsview/LatestRecentPatientsLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/recentpatientsview/LatestRecentPatientsLogicTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
-import dagger.Lazy
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
@@ -275,7 +274,7 @@ class LatestRecentPatientsLogicTest {
     val effectHandler = LatestRecentPatientsEffectHandler(
         schedulers = TestSchedulersProvider.trampoline(),
         patientRepository = patientRepository,
-        currentFacility = Lazy { facility },
+        currentFacilityChanges = Observable.just(facility),
         uiActions = uiActions
     )
 


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/742/home-screen-does-not-update-when-changing-facilities

## Reason
Both `HomeScreen` and `OverdueScreen` are in the screen where the changing of current facility happens. Since `FacilityChangeActivity` is a new activity and not a new screen in `TheActivity`, returning to `HomeScreen` after switching the current facility does not cause the screen to be reinitialized and thus, does not notify a change in the current facility.

## Fix
This PR fixes the issue by changing the two screen to observe the current facility for changes instead of just loading it once.