### PR TITLE
Bump Dagger to 2.28.3

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/bloodsugar/BloodSugarHistoryListItemDataSourceTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/bloodsugar/BloodSugarHistoryListItemDataSourceTest.kt
@@ -39,10 +39,12 @@ class BloodSugarHistoryListItemDataSourceTest {
   @Inject
   lateinit var userClock: TestUserClock
 
-  @field:[Inject Named("full_date")]
+  @Inject
+  @Named("full_date")
   lateinit var dateFormatter: DateTimeFormatter
 
-  @field:[Inject Named("time_for_measurement_history")]
+  @Inject
+  @Named("time_for_measurement_history")
   lateinit var timeFormatter: DateTimeFormatter
 
   @get:Rule

--- a/app/src/androidTest/java/org/simple/clinic/bloodsugar/sync/BloodSugarSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/bloodsugar/sync/BloodSugarSyncAndroidTest.kt
@@ -31,7 +31,7 @@ class BloodSugarSyncAndroidTest : BaseSyncCoordinatorAndroidTest<BloodSugarMeasu
   lateinit var repository: BloodSugarRepository
 
   @Inject
-  @field:Named("last_blood_sugar_pull_token")
+  @Named("last_blood_sugar_pull_token")
   lateinit var lastPullToken: Preference<Optional<String>>
 
   @Inject

--- a/app/src/androidTest/java/org/simple/clinic/bp/BloodPressureHistoryListItemDataSourceTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/bp/BloodPressureHistoryListItemDataSourceTest.kt
@@ -39,10 +39,12 @@ class BloodPressureHistoryListItemDataSourceTest {
   @Inject
   lateinit var userClock: TestUserClock
 
-  @field:[Inject Named("full_date")]
+  @Inject
+  @Named("full_date")
   lateinit var dateFormatter: DateTimeFormatter
 
-  @field:[Inject Named("time_for_measurement_history")]
+  @Inject
+  @Named("time_for_measurement_history")
   lateinit var timeFormatter: DateTimeFormatter
 
   @get:Rule

--- a/app/src/androidTest/java/org/simple/clinic/bp/sync/BloodPressureSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/bp/sync/BloodPressureSyncAndroidTest.kt
@@ -30,7 +30,7 @@ class BloodPressureSyncAndroidTest : BaseSyncCoordinatorAndroidTest<BloodPressur
   lateinit var repository: BloodPressureRepository
 
   @Inject
-  @field:Named("last_bp_pull_token")
+  @Named("last_bp_pull_token")
   lateinit var lastPullToken: Preference<Optional<String>>
 
   @Inject

--- a/app/src/androidTest/java/org/simple/clinic/drugs/sync/PrescriptionSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/drugs/sync/PrescriptionSyncAndroidTest.kt
@@ -33,7 +33,7 @@ class PrescriptionSyncAndroidTest : BaseSyncCoordinatorAndroidTest<PrescribedDru
   lateinit var repository: PrescriptionRepository
 
   @Inject
-  @field:Named("last_prescription_pull_token")
+  @Named("last_prescription_pull_token")
   lateinit var lastPullToken: Preference<Optional<String>>
 
   @Inject

--- a/app/src/androidTest/java/org/simple/clinic/login/LoginUserWithOtpServerIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/login/LoginUserWithOtpServerIntegrationTest.kt
@@ -32,10 +32,12 @@ class LoginUserWithOtpServerIntegrationTest {
   @Inject
   lateinit var usersApi: UsersApi
 
-  @field:[Inject Named("user_pin")]
+  @Inject
+  @Named("user_pin")
   lateinit var userPin: String
 
-  @field:[Inject Named("user_otp")]
+  @Inject
+  @Named("user_otp")
   lateinit var userOtp: String
 
   @Before

--- a/app/src/androidTest/java/org/simple/clinic/medicalhistory/MedicalHistorySyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/medicalhistory/MedicalHistorySyncAndroidTest.kt
@@ -32,7 +32,7 @@ import javax.inject.Named
 class MedicalHistorySyncAndroidTest : BaseSyncCoordinatorAndroidTest<MedicalHistory, MedicalHistoryPayload>() {
 
   @Inject
-  @field:Named("last_medicalhistory_pull_token")
+  @Named("last_medicalhistory_pull_token")
   lateinit var lastPullToken: Preference<Optional<String>>
 
   @Inject

--- a/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentSyncAndroidTest.kt
@@ -28,7 +28,7 @@ class AppointmentSyncAndroidTest : BaseSyncCoordinatorAndroidTest<Appointment, A
   lateinit var repository: AppointmentRepository
 
   @Inject
-  @field:Named("last_appointment_pull_token")
+  @Named("last_appointment_pull_token")
   lateinit var lastPullToken: Preference<Optional<String>>
 
   @Inject

--- a/app/src/androidTest/java/org/simple/clinic/patient/PatientSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/patient/PatientSyncAndroidTest.kt
@@ -29,7 +29,7 @@ class PatientSyncAndroidTest : BaseSyncCoordinatorAndroidTest<PatientProfile, Pa
   lateinit var repository: PatientRepository
 
   @Inject
-  @field:Named("last_patient_pull_token")
+  @Named("last_patient_pull_token")
   lateinit var lastPullToken: Preference<Optional<String>>
 
   @Inject

--- a/app/src/androidTest/java/org/simple/clinic/patient/businessid/BusinessIdMetaDataAdapterAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/patient/businessid/BusinessIdMetaDataAdapterAndroidTest.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 class BusinessIdMetaDataAdapterAndroidTest {
 
-  @field:Inject
+  @Inject
   lateinit var businessIdMetaDataAdapter: BusinessIdMetaDataAdapter
 
   @get:Rule

--- a/app/src/androidTest/java/org/simple/clinic/protocolv2/sync/ProtocolSyncAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/protocolv2/sync/ProtocolSyncAndroidTest.kt
@@ -30,7 +30,7 @@ class ProtocolSyncAndroidTest {
   lateinit var appDatabase: AppDatabase
 
   @Inject
-  @field:Named("last_protocol_pull_token")
+  @Named("last_protocol_pull_token")
   lateinit var lastPullToken: Preference<Optional<String>>
 
   @get:Rule

--- a/app/src/androidTest/java/org/simple/clinic/rules/ServerAuthenticationRule.kt
+++ b/app/src/androidTest/java/org/simple/clinic/rules/ServerAuthenticationRule.kt
@@ -16,9 +16,9 @@ import org.simple.clinic.TestData
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.facility.FacilityPullResult
 import org.simple.clinic.facility.FacilitySync
-import org.simple.clinic.login.UsersApi
 import org.simple.clinic.login.LoginRequest
 import org.simple.clinic.login.UserPayload
+import org.simple.clinic.login.UsersApi
 import org.simple.clinic.login.activateuser.ActivateUserRequest
 import org.simple.clinic.security.PasswordHasher
 import org.simple.clinic.user.User
@@ -75,10 +75,12 @@ class ServerAuthenticationRule : TestRule {
   @Inject
   lateinit var passwordHasher: PasswordHasher
 
-  @field:[Inject Named("user_pin")]
+  @Inject
+  @Named("user_pin")
   lateinit var userPin: String
 
-  @field:[Inject Named("user_otp")]
+  @Inject
+  @Named("user_otp")
   lateinit var userOtp: String
 
   private val cachedUserInformationAdapter by unsafeLazy { moshi.adapter(CachedUserInformation::class.java) }

--- a/app/src/androidTest/java/org/simple/clinic/storage/migrations/DatabaseMigrationAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/storage/migrations/DatabaseMigrationAndroidTest.kt
@@ -58,11 +58,11 @@ class DatabaseMigrationAndroidTest {
   lateinit var migrations: List<@JvmSuppressWildcards Migration>
 
   @Inject
-  @field:Named("last_facility_pull_token")
+  @Named("last_facility_pull_token")
   lateinit var lastFacilityPullToken: Preference<Optional<String>>
 
   @Inject
-  @field:Named("last_patient_pull_token")
+  @Named("last_patient_pull_token")
   lateinit var lastPatientPullToken: Preference<Optional<String>>
 
   @Inject

--- a/app/src/androidTest/java/org/simple/clinic/user/RegisterUserServerIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/user/RegisterUserServerIntegrationTest.kt
@@ -48,7 +48,8 @@ class RegisterUserServerIntegrationTest {
   @Inject
   lateinit var passwordHasher: PasswordHasher
 
-  @field:[Inject Named("user_pin")]
+  @Inject
+  @Named("user_pin")
   lateinit var userPin: String
 
   @get:Rule

--- a/app/src/main/java/org/simple/clinic/bloodsugar/entry/BloodSugarEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/bloodsugar/entry/BloodSugarEntrySheet.kt
@@ -83,7 +83,8 @@ class BloodSugarEntrySheet : BottomSheetActivity(), BloodSugarEntryUi, RemoveBlo
     }
   }
 
-  @field:[Inject Named("exact_date")]
+  @Inject
+  @Named("exact_date")
   lateinit var dateFormatter: DateTimeFormatter
 
   @Inject

--- a/app/src/main/java/org/simple/clinic/bloodsugar/history/BloodSugarHistoryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/bloodsugar/history/BloodSugarHistoryScreen.kt
@@ -58,10 +58,12 @@ class BloodSugarHistoryScreen(
   @Inject
   lateinit var userClock: UserClock
 
-  @field:[Inject Named("full_date")]
+  @Inject
+  @Named("full_date")
   lateinit var dateFormatter: DateTimeFormatter
 
-  @field:[Inject Named("time_for_measurement_history")]
+  @Inject
+  @Named("time_for_measurement_history")
   lateinit var timeFormatter: DateTimeFormatter
 
   @Inject
@@ -79,7 +81,8 @@ class BloodSugarHistoryScreen(
   @Inject
   lateinit var utcClock: UtcClock
 
-  @field:[Inject Named("for_measurement_history")]
+  @Inject
+  @Named("for_measurement_history")
   lateinit var measurementHistoryPaginationConfig: PagedList.Config
 
   private val bloodSugarHistoryAdapter = PagingItemAdapter(BloodSugarHistoryListItemDiffCallback())

--- a/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/bp/entry/BloodPressureEntrySheet.kt
@@ -51,7 +51,8 @@ import javax.inject.Named
 
 class BloodPressureEntrySheet : BottomSheetActivity(), BloodPressureEntryUi, RemoveBloodPressureListener {
 
-  @field:[Inject Named("exact_date")]
+  @Inject
+  @Named("exact_date")
   lateinit var dateFormatter: DateTimeFormatter
 
   @Inject

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
@@ -58,13 +58,16 @@ class BloodPressureHistoryScreen(
   @Inject
   lateinit var effectHandler: BloodPressureHistoryScreenEffectHandler.Factory
 
-  @field:[Inject Named("full_date")]
+  @Inject
+  @Named("full_date")
   lateinit var dateFormatter: DateTimeFormatter
 
-  @field:[Inject Named("time_for_measurement_history")]
+  @Inject
+  @Named("time_for_measurement_history")
   lateinit var timeFormatter: DateTimeFormatter
 
-  @field:[Inject Named("for_measurement_history")]
+  @Inject
+  @Named("for_measurement_history")
   lateinit var measurementHistoryPaginationConfig: PagedList.Config
 
   private val bloodPressureHistoryAdapter = PagingItemAdapter(BloodPressureHistoryListItemDiffCallback())

--- a/app/src/main/java/org/simple/clinic/contactpatient/views/SetAppointmentReminderView.kt
+++ b/app/src/main/java/org/simple/clinic/contactpatient/views/SetAppointmentReminderView.kt
@@ -26,7 +26,8 @@ class SetAppointmentReminderView(
     attributeSet: AttributeSet
 ) : ConstraintLayout(context, attributeSet) {
 
-  @field:[Inject Named("date_for_user_input")]
+  @Inject
+  @Named("date_for_user_input")
   lateinit var dateFormatter: DateTimeFormatter
 
   var decrementStepperClicked: DecrementStepperClicked? = null

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
@@ -88,7 +88,8 @@ class EditPatientScreen(context: Context, attributeSet: AttributeSet) : Relative
   @Inject
   lateinit var screenRouter: ScreenRouter
 
-  @field:[Inject Named("date_for_user_input")]
+  @Inject
+  @Named("date_for_user_input")
   lateinit var dateOfBirthFormat: DateTimeFormatter
 
   @Inject

--- a/app/src/main/java/org/simple/clinic/facility/alertchange/AlertFacilityChangeSheet.kt
+++ b/app/src/main/java/org/simple/clinic/facility/alertchange/AlertFacilityChangeSheet.kt
@@ -27,7 +27,8 @@ class AlertFacilityChangeSheet : BottomSheetActivity() {
   @Inject
   lateinit var locale: Locale
 
-  @field:[Inject Named("is_facility_switched")]
+  @Inject
+  @Named("is_facility_switched")
   lateinit var isFacilitySwitchedPreference: Preference<Boolean>
 
   private lateinit var component: AlertFacilityChangeComponent

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
@@ -40,13 +40,15 @@ class OverdueScreen(
   @Inject
   lateinit var userClock: UserClock
 
-  @field:[Inject Named("full_date")]
+  @Inject
+  @Named("full_date")
   lateinit var dateFormatter: DateTimeFormatter
 
   @Inject
   lateinit var effectHandlerFactory: OverdueEffectHandler.Factory
 
-  @field:[Inject Named("for_overdue_appointments")]
+  @Inject
+  @Named("for_overdue_appointments")
   lateinit var pagedListConfig: PagedList.Config
 
   private val overdueListAdapter = PagingItemAdapter(OverdueAppointmentRow.DiffCallback())

--- a/app/src/main/java/org/simple/clinic/home/patients/PatientsTabScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/patients/PatientsTabScreen.kt
@@ -57,7 +57,8 @@ class PatientsTabScreen(context: Context, attrs: AttributeSet) : RelativeLayout(
   @Inject
   lateinit var country: Country
 
-  @field:[Inject Named("training_video_youtube_id")]
+  @Inject
+  @Named("training_video_youtube_id")
   lateinit var youTubeVideoId: String
 
   @Inject

--- a/app/src/main/java/org/simple/clinic/introvideoscreen/IntroVideoScreen.kt
+++ b/app/src/main/java/org/simple/clinic/introvideoscreen/IntroVideoScreen.kt
@@ -29,7 +29,8 @@ class IntroVideoScreen(
   @Inject
   lateinit var screenRouter: ScreenRouter
 
-  @field:[Inject Named("training_video_youtube_id")]
+  @Inject
+  @Named("training_video_youtube_id")
   lateinit var youTubeVideoId: String
 
   @Inject

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
@@ -101,7 +101,8 @@ class PatientEntryScreen(context: Context, attrs: AttributeSet) : RelativeLayout
   @Inject
   lateinit var schedulersProvider: SchedulersProvider
 
-  @field:[Inject Named("number_of_patients_registered")]
+  @Inject
+  @Named("number_of_patients_registered")
   lateinit var patientRegisteredCount: Preference<Int>
 
   @Inject

--- a/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheet.kt
+++ b/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheet.kt
@@ -64,7 +64,8 @@ class ScheduleAppointmentSheet : BottomSheetActivity(), ScheduleAppointmentUi, S
   @Inject
   lateinit var userClock: UserClock
 
-  @field:[Inject Named("full_date")]
+  @Inject
+  @Named("full_date")
   lateinit var dateFormatter: DateTimeFormatter
 
   @Inject

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -84,7 +84,8 @@ class PatientSummaryScreen(
   @Inject
   lateinit var userClock: UserClock
 
-  @field:[Inject Named("full_date")]
+  @Inject
+  @Named("full_date")
   lateinit var dateFormatter: DateTimeFormatter
 
   @Inject

--- a/app/src/main/java/org/simple/clinic/summary/bloodpressures/view/BloodPressureSummaryView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/bloodpressures/view/BloodPressureSummaryView.kt
@@ -87,10 +87,12 @@ class BloodPressureSummaryView(
   @Inject
   lateinit var userClock: UserClock
 
-  @field:[Inject Named("full_date")]
+  @Inject
+  @Named("full_date")
   lateinit var dateFormatter: DateTimeFormatter
 
-  @field:[Inject Named("time_for_measurement_history")]
+  @Inject
+  @Named("time_for_measurement_history")
   lateinit var timeFormatter: DateTimeFormatter
 
   @Inject

--- a/app/src/main/java/org/simple/clinic/summary/bloodsugar/view/BloodSugarSummaryView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/bloodsugar/view/BloodSugarSummaryView.kt
@@ -98,10 +98,12 @@ class BloodSugarSummaryView(
   @Inject
   lateinit var crashReporter: CrashReporter
 
-  @field:[Inject Named("full_date")]
+  @Inject
+  @Named("full_date")
   lateinit var dateFormatter: DateTimeFormatter
 
-  @field:[Inject Named("time_for_measurement_history")]
+  @Inject
+  @Named("time_for_measurement_history")
   lateinit var timeFormatter: DateTimeFormatter
 
   @Inject

--- a/app/src/main/java/org/simple/clinic/summary/prescribeddrugs/DrugSummaryView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/prescribeddrugs/DrugSummaryView.kt
@@ -46,7 +46,8 @@ class DrugSummaryView(
     attributeSet: AttributeSet
 ) : CardView(context, attributeSet), DrugSummaryUi, DrugSummaryUiActions {
 
-  @field:[Inject Named("full_date")]
+  @Inject
+  @Named("full_date")
   lateinit var fullDateFormatter: DateTimeFormatter
 
   @Inject

--- a/app/src/main/java/org/simple/clinic/widgets/PatientSearchResultItemView.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/PatientSearchResultItemView.kt
@@ -27,10 +27,11 @@ class PatientSearchResultItemView(
     attributeSet: AttributeSet
 ) : CardView(context, attributeSet) {
 
-  @field:[Inject Named("full_date")]
+  @Inject
+  @Named("full_date")
   lateinit var dateTimeFormatter: DateTimeFormatter
 
-  @field:Inject
+  @Inject
   lateinit var userClock: UserClock
 
   override fun onFinishInflate() {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
       androidXTestExt     : '1.1.1',
       androidXTest        : '1.2.0',
       timber              : '4.7.0',
-      dagger              : '2.24',
+      dagger              : '2.28.3',
       butterKnife         : '8.8.1',
       kotterKnife         : 'e157638df1',
       coreTesting         : '2.0.0',


### PR DESCRIPTION
Since Dagger 2.25 they have added the support to add annotation like `Named`, `Qualifier`s without using Kotlin `field`. I have migrated that usage in this commit as well.

So when injecting a dependency with `Named` or `Qualifier` we can do this
```kt
@Inject
@Named("sample_dependency")
```
instead of these
```kt
// Approach 1
@field:[Inject Named("sample_dependency")]

// Approach 2
@Inject
@field:Named("sample_dependency")
```

This dependency update will also allow us to use new Dagger changes like
- Dagger lint
- Improved error messaging
- Hilt (if interested)