### PR TITLE
Fix crash on returning to the home screen from any other screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixes
 - Fixed issue where recent and overdue patients on home screen would not update after changing facility ([#742](https://app.clubhouse.io/simpledotorg/story/742/home-screen-does-not-update-when-changing-facilities))
+- Fixed issue where the app would crash on restoring the home screen state ([#791](https://app.clubhouse.io/simpledotorg/story/791/the-app-crashes-when-navigating-back-to-the-home-screen-from-any-other-screen))
 
 ## 2020-08-03-7364
 ### Features

--- a/app/src/main/java/org/simple/clinic/home/HomeScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomeScreen.kt
@@ -80,7 +80,7 @@ class HomeScreen(context: Context, attrs: AttributeSet) : RelativeLayout(context
     setupHelpClicks()
 
     // Keyboard stays open after login finishes, not sure why.
-    rootLayout.hideKeyboard()
+    homeScreenRootLayout.hideKeyboard()
 
     viewPager.adapter = HomePagerAdapter(context)
     homeTabLayout.setupWithViewPager(viewPager)

--- a/app/src/main/res/layout/screen_home.xml
+++ b/app/src/main/res/layout/screen_home.xml
@@ -2,7 +2,7 @@
 <org.simple.clinic.home.HomeScreen xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
-  android:id="@+id/rootLayout"
+  android:id="@+id/homeScreenRootLayout"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   tools:context=".main.TheActivity">


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/791/the-app-crashes-when-navigating-back-to-the-home-screen-from-any-other-screen

This was caused due to a state restoration issue because the home screen
root layout ID was the same as the ID of the sync indicator view on
the patients tab, which cause the wrong state to be returned during
view inflation.

This commit fixes the issue by changing the layout ID of the home screen.