### PR TITLE
Fix crash on saving the state during registration facility selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Fixes
 - Fixed native crash on Android 9 with animated vector drawables ([#364](https://app.clubhouse.io/simpledotorg/story/364/fix-vectordrawable-native-crash))
+- Fixed crash on putting the app in the background during registration facility selection ([#1030](https://app.clubhouse.io/simpledotorg/story/1030/app-crashes-during-registration-when-it-is-backgrounded))
 
 ## On Demo
 ### Features

--- a/app/src/main/java/org/simple/clinic/facilitypicker/FacilityPickerView.kt
+++ b/app/src/main/java/org/simple/clinic/facilitypicker/FacilityPickerView.kt
@@ -74,6 +74,8 @@ class FacilityPickerView(
     // Hiding the keyboard without adding a post{} block doesn't seem to work.
     post { hideKeyboard() }
     hideKeyboardOnListScroll()
+
+    isSaveEnabled = false
   }
 
   private val events: Observable<FacilityPickerEvent> by unsafeLazy {


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/1030/app-crashes-during-registration-when-it-is-backgrounded