### PR TITLE
Disable Telemedicine Facility Info sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Change `HomeScreen` to save and restore the state correctly
 - Improved the user experience of loading the patient summary screen
 - Optimized fetching of current facility by removing the unnecessary `User` parameter
-- Add teleconsultation facility sync
+- Add teleconsultation facility sync (Disabled for now until API endpoint is live: ETA 04-09-2020)
 - Added `MedicineFrequencyBottomSheet` to update medicine frequency
 
 ## On Demo

--- a/app/src/main/java/org/simple/clinic/sync/SyncModule.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncModule.kt
@@ -32,7 +32,6 @@ import org.simple.clinic.remoteconfig.ConfigReader
 import org.simple.clinic.remoteconfig.RemoteConfigSync
 import org.simple.clinic.reports.ReportsModule
 import org.simple.clinic.reports.ReportsSync
-import org.simple.clinic.summary.teleconsultation.sync.TeleconsultationSync
 import java.util.Locale
 import javax.inject.Named
 
@@ -84,14 +83,13 @@ class SyncModule {
       reportsSync: ReportsSync,
       remoteConfigSync: RemoteConfigSync,
       helpSync: HelpSync,
-      bloodSugarSync: BloodSugarSync,
-      teleconsultationSync: TeleconsultationSync
+      bloodSugarSync: BloodSugarSync
   ): ArrayList<ModelSync> {
     return arrayListOf(
         facilitySync, protocolSync, patientSync,
         bloodPressureSync, medicalHistorySync, appointmentSync,
         prescriptionSync, reportsSync, remoteConfigSync, helpSync,
-        bloodSugarSync, teleconsultationSync
+        bloodSugarSync
     )
   }
 


### PR DESCRIPTION
Disabled the sync since the APIs are not yet available.

See [this Slack discussion](https://simpledotorg.slack.com/archives/CV9V1DWLV/p1598425138008400) for further info.