### PR TITLE
Move showing teleconsult log button to view renderer

### DIFF
--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -43,7 +43,6 @@ import org.simple.clinic.router.screen.BackPressInterceptor
 import org.simple.clinic.router.screen.RouterDirection.BACKWARD
 import org.simple.clinic.router.screen.ScreenRouter
 import org.simple.clinic.scheduleappointment.ScheduleAppointmentSheet
-import org.simple.clinic.summary.OpenIntention.ViewExistingPatientWithTeleconsultLog
 import org.simple.clinic.summary.addphone.AddPhoneNumberDialog
 import org.simple.clinic.summary.linkId.LinkIdWithPatientCancelled
 import org.simple.clinic.summary.linkId.LinkIdWithPatientLinked
@@ -173,16 +172,6 @@ class PatientSummaryScreen(
     val screenDestroys: Observable<ScreenDestroyed> = detaches().map { ScreenDestroyed() }
     alertFacilityChangeSheetClosed(screenDestroys)
     setupChildViewVisibility(screenDestroys)
-
-    when (screenKey.intention) {
-      is ViewExistingPatientWithTeleconsultLog -> {
-        doctorButton.setButtonState(Enabled)
-        doctorButton.icon = null
-        doctorButton.text = context.getString(R.string.patientsummary_log_teleconsult)
-        doneButton.visibility = View.GONE
-        buttonFrame.setBackgroundColor(ContextCompat.getColor(context, R.color.green3))
-      }
-    }
   }
 
   @SuppressLint("CheckResult")
@@ -558,6 +547,15 @@ class PatientSummaryScreen(
 
   override fun registerSummaryModelUpdateCallback(callback: PatientSummaryModelUpdateCallback?) {
     modelUpdateCallback = callback
+  }
+
+  override fun hideDoneButton() {
+    doneButton.visibility = View.GONE
+  }
+
+  override fun showTeleconsultLogButton() {
+    logTeleconsultButton.visibility = View.VISIBLE
+    buttonFrame.setBackgroundColor(ContextCompat.getColor(context, R.color.green3))
   }
 }
 

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreenUi.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreenUi.kt
@@ -12,4 +12,6 @@ interface PatientSummaryScreenUi {
   fun fetchingTeleconsultInfo()
   fun showAssignedFacilityView()
   fun hideAssignedFacilityView()
+  fun hideDoneButton()
+  fun showTeleconsultLogButton()
 }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryViewRenderer.kt
@@ -31,6 +31,20 @@ class PatientSummaryViewRenderer(
   }
 
   private fun setupUiForTeleconsult(model: PatientSummaryModel) {
+    if (model.openIntention is OpenIntention.ViewExistingPatientWithTeleconsultLog) {
+      renderMedicalOfficerView()
+    } else {
+      renderUserView(model)
+    }
+  }
+
+  private fun renderMedicalOfficerView() {
+    ui.hideContactDoctorButton()
+    ui.hideDoneButton()
+    ui.showTeleconsultLogButton()
+  }
+
+  private fun renderUserView(model: PatientSummaryModel) {
     if (model.isTeleconsultationEnabled && model.isUserLoggedIn) {
       renderContactDoctorButton(model)
     } else {

--- a/app/src/main/res/layout/screen_patient_summary.xml
+++ b/app/src/main/res/layout/screen_patient_summary.xml
@@ -231,6 +231,17 @@
       app:icon="@drawable/ic_whatsapp"
       app:iconTint="@android:color/white" />
 
+    <com.google.android.material.button.MaterialButton
+      android:id="@+id/logTeleconsultButton"
+      style="?attr/materialButtonStyle"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/spacing_8"
+      android:layout_marginEnd="@dimen/spacing_8"
+      android:text="@string/patientsummary_log_teleconsult"
+      android:textAppearance="@style/Clinic.V2.TextAppearance.Button1"
+      android:visibility="gone" />
+
   </LinearLayout>
 
   <org.simple.clinic.summary.linkId.LinkIdWithPatientView

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryViewRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryViewRendererTest.kt
@@ -273,4 +273,26 @@ class PatientSummaryViewRendererTest {
     verify(ui).hideAssignedFacilityView()
     verifyNoMoreInteractions(ui)
   }
+
+  @Test
+  fun `when open intention is view existing patient with teleconsultation log, then show teleconsult log button`() {
+    // given
+    val patientUuid = UUID.fromString("66bc73a4-29a1-4b07-8be1-9223dc5d7cbb")
+    val model = PatientSummaryModel.from(
+        openIntention = OpenIntention.ViewExistingPatientWithTeleconsultLog(
+            teleconsultRecordId = UUID.fromString("726fc0e5-9638-4ce2-a8ca-c14bc72852b5")
+        ),
+        patientUuid = patientUuid
+    ).currentFacilityLoaded(facilityWithTeleconsultationEnabled)
+
+    // when
+    uiRenderer.render(model)
+
+    // then
+    verify(ui).showDiabetesView()
+    verify(ui).hideContactDoctorButton()
+    verify(ui).hideDoneButton()
+    verify(ui).showTeleconsultLogButton()
+    verifyNoMoreInteractions(ui)
+  }
 }


### PR DESCRIPTION
A small change to #1659, I forgot to move the rendering of the teleconsult log button to view renderer. I have also added `logTeleconsultButton` instead of trying to reuse existing `doctorButton`.