### PR TITLE
Remove `process_token` usage from `TeleconsultationSync`

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/sync/TeleconsultationSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/TeleconsultationSyncIntegrationTest.kt
@@ -1,6 +1,5 @@
 package org.simple.clinic.sync
 
-import com.f2prateek.rx.preferences2.Preference
 import com.google.common.truth.Truth.assertThat
 import org.junit.After
 import org.junit.Before
@@ -10,15 +9,12 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.TestClinicApp
-import org.simple.clinic.main.TypedPreference
-import org.simple.clinic.main.TypedPreference.Type.LastTeleconsultationFacilityPullToken
 import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.rules.ServerAuthenticationRule
 import org.simple.clinic.summary.teleconsultation.sync.TeleconsultFacilityInfoApi
 import org.simple.clinic.summary.teleconsultation.sync.TeleconsultationFacilityRepository
 import org.simple.clinic.summary.teleconsultation.sync.TeleconsultationSync
 import org.simple.clinic.user.UserSession
-import org.simple.clinic.util.Optional
 import org.simple.clinic.util.Rules
 import javax.inject.Inject
 
@@ -30,10 +26,6 @@ class TeleconsultationSyncIntegrationTest {
 
   @Inject
   lateinit var repository: TeleconsultationFacilityRepository
-
-  @Inject
-  @TypedPreference(LastTeleconsultationFacilityPullToken)
-  lateinit var lastPullToken: Preference<Optional<String>>
 
   @Inject
   lateinit var syncApi: TeleconsultFacilityInfoApi
@@ -62,10 +54,8 @@ class TeleconsultationSyncIntegrationTest {
     resetLocalData()
 
     sync = TeleconsultationSync(
-        syncCoordinator = SyncCoordinator(),
         repository = repository,
         api = syncApi,
-        lastPullToken = lastPullToken,
         config = config
     )
   }
@@ -77,7 +67,6 @@ class TeleconsultationSyncIntegrationTest {
 
   private fun resetLocalData() {
     clearTeleconsultFacilityData()
-    lastPullToken.delete()
   }
 
   private fun clearTeleconsultFacilityData() {

--- a/app/src/main/java/org/simple/clinic/main/TypedPreference.kt
+++ b/app/src/main/java/org/simple/clinic/main/TypedPreference.kt
@@ -6,7 +6,6 @@ import javax.inject.Qualifier
 annotation class TypedPreference(val value: Type) {
 
   enum class Type {
-    LockAtTime,
-    LastTeleconsultationFacilityPullToken
+    LockAtTime
   }
 }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryModule.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryModule.kt
@@ -1,20 +1,13 @@
 package org.simple.clinic.summary
 
-import com.f2prateek.rx.preferences2.Preference
-import com.f2prateek.rx.preferences2.RxSharedPreferences
 import dagger.Module
 import dagger.Provides
 import org.simple.clinic.AppDatabase
-import org.simple.clinic.main.TypedPreference
-import org.simple.clinic.main.TypedPreference.Type.LastTeleconsultationFacilityPullToken
 import org.simple.clinic.remoteconfig.ConfigReader
 import org.simple.clinic.summary.bloodpressures.BloodPressureSummaryViewConfig
 import org.simple.clinic.summary.bloodsugar.BloodSugarSummaryConfigModule
 import org.simple.clinic.summary.teleconsultation.api.TeleconsultationApi
 import org.simple.clinic.summary.teleconsultation.sync.TeleconsultFacilityInfoApi
-import org.simple.clinic.util.Optional
-import org.simple.clinic.util.preference.OptionalRxPreferencesConverter
-import org.simple.clinic.util.preference.StringPreferenceConverter
 import retrofit2.Retrofit
 import retrofit2.create
 import javax.inject.Named
@@ -48,10 +41,4 @@ class PatientSummaryModule {
 
   @Provides
   fun teleconsultationFacilityWithMedicalOfficersDao(appDatabase: AppDatabase) = appDatabase.teleconsultFacilityWithMedicalOfficersDao()
-
-  @Provides
-  @TypedPreference(LastTeleconsultationFacilityPullToken)
-  fun lastPullToken(rxSharedPrefs: RxSharedPreferences): Preference<Optional<String>> {
-    return rxSharedPrefs.getObject("last_teleconsultation_facility_pull_token", Optional.empty(), OptionalRxPreferencesConverter(StringPreferenceConverter()))
-  }
 }

--- a/app/src/main/java/org/simple/clinic/summary/teleconsultation/sync/TeleconsultFacilityInfoApi.kt
+++ b/app/src/main/java/org/simple/clinic/summary/teleconsultation/sync/TeleconsultFacilityInfoApi.kt
@@ -3,13 +3,9 @@ package org.simple.clinic.summary.teleconsultation.sync
 import retrofit2.Call
 import retrofit2.http.GET
 import retrofit2.http.Headers
-import retrofit2.http.Query
 
 interface TeleconsultFacilityInfoApi {
   @Headers(value = ["X-RESYNC-TOKEN: 1"])
   @GET("v4/teleconsultation_medical_officers/sync")
-  fun pull(
-      @Query("limit") recordsToPull: Int,
-      @Query("process_token") lastPullToken: String? = null
-  ): Call<TeleconsultFacilityInfoPullResponse>
+  fun pull(): Call<TeleconsultFacilityInfoPullResponse>
 }

--- a/app/src/main/java/org/simple/clinic/summary/teleconsultation/sync/TeleconsultationSync.kt
+++ b/app/src/main/java/org/simple/clinic/summary/teleconsultation/sync/TeleconsultationSync.kt
@@ -1,22 +1,15 @@
 package org.simple.clinic.summary.teleconsultation.sync
 
-import com.f2prateek.rx.preferences2.Preference
 import io.reactivex.Completable
-import org.simple.clinic.main.TypedPreference
-import org.simple.clinic.main.TypedPreference.Type.LastTeleconsultationFacilityPullToken
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
-import org.simple.clinic.sync.SyncCoordinator
-import org.simple.clinic.util.Optional
 import org.simple.clinic.util.read
 import javax.inject.Inject
 import javax.inject.Named
 
 class TeleconsultationSync @Inject constructor(
-    private val syncCoordinator: SyncCoordinator,
     private val repository: TeleconsultationFacilityRepository,
     private val api: TeleconsultFacilityInfoApi,
-    @TypedPreference(LastTeleconsultationFacilityPullToken) private val lastPullToken: Preference<Optional<String>>,
     @Named("sync_config_daily") private val config: SyncConfig
 ) : ModelSync {
 
@@ -37,8 +30,8 @@ class TeleconsultationSync @Inject constructor(
   }
 
   override fun pull() {
-    val batchSize = config.batchSize
-    syncCoordinator.pull(repository, lastPullToken, batchSize) { api.pull(batchSize, it).execute().read()!! }
+    val teleconsultationInfoPullResponse = api.pull().execute().read()!!
+    repository.mergeWithLocalData(teleconsultationInfoPullResponse.payloads)
   }
 
   override fun syncConfig() = config


### PR DESCRIPTION
You can find the reference to the conversation where we decided to remove this [here](https://simpledotorg.slack.com/archives/CV9V1DWLV/p1598945680015200)