### PR TITLE
Add lint fix option to replace `ImageView#src` usage

### DIFF
--- a/lint/src/main/java/org/simple/clinic/lint/ImageSrcDetector.kt
+++ b/lint/src/main/java/org/simple/clinic/lint/ImageSrcDetector.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.lint
 import com.android.tools.lint.detector.api.Category
 import com.android.tools.lint.detector.api.Implementation
 import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.LintFix
 import com.android.tools.lint.detector.api.ResourceXmlDetector
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
@@ -14,6 +15,7 @@ class ImageSrcDetector : ResourceXmlDetector() {
 
   companion object {
     const val ANDROID_URI = "http://schemas.android.com/apk/res/android"
+    const val AUTO_URI = "http://schemas.android.com/apk/res-auto"
     const val IMAGE_VIEW = "ImageView"
     const val ATTR_SRC = "src"
 
@@ -24,7 +26,7 @@ class ImageSrcDetector : ResourceXmlDetector() {
         briefDescription = "ImageView should not use `android:src`",
         explanation = ImageSrcExplanation,
         category = Category.CORRECTNESS,
-        severity = Severity.WARNING,
+        severity = Severity.ERROR,
         implementation = Implementation(
             ImageSrcDetector::class.java,
             Scope.RESOURCE_FILE_SCOPE
@@ -45,8 +47,15 @@ class ImageSrcDetector : ResourceXmlDetector() {
     context.report(
         ImageSrcIssue,
         element,
-        context.getLocation(element),
-        ImageSrcExplanation
+        context.getLocation(element.getAttributeNodeNS(ANDROID_URI, "src")),
+        ImageSrcExplanation,
+        LintFix.create().composite(
+            LintFix.create().set(
+                AUTO_URI, "srcCompat",
+                element.getAttributeNS(ANDROID_URI, "src")
+            ).build(),
+            LintFix.create().unset(ANDROID_URI, "src").build()
+        )
     )
   }
 }

--- a/lint/src/test/java/org/simple/clinic/lint/ImageSrcDetectorTest.kt
+++ b/lint/src/test/java/org/simple/clinic/lint/ImageSrcDetectorTest.kt
@@ -19,10 +19,10 @@ class ImageSrcDetectorTest : LintDetectorTest() {
         )
         .run()
         .expect("""
-          res/layout/image_view.xml:1: Warning: Please use app:srcCompat when setting an image resource [ImageSrcIssueId]
-          <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
-          ^
-          0 errors, 1 warnings
+          res/layout/image_view.xml:4: Error: Please use app:srcCompat instead of android:src when setting an image resource [ImageViewSrc]
+              android:src="@drawable/ic_done"/>
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          1 errors, 0 warnings
         """)
   }
 


### PR DESCRIPTION
Added an option to provide lint fix option that can be used in Android Studio options to replace the existing usages with `app:srcCompat` usage.

In order to try this, please run `app:lintQaDebug` once and then replace any `app:srcCompat` usage with `android:src` and Android Studio should show the error and option to replace the usage.