### PR TITLE
Add global error handler to catch RxJava errors that can be ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 - Fixed issue where patient details would not load for patients without an assigned facility ([#1127](https://app.clubhouse.io/simpledotorg/story/1127/patient-details-screen-does-not-load-for-patients-who-don-t-have-an-assigned-facility))
+- Add a default RxJava error handler to ignore some classes of errors safely
 
 ## 2020-09-01-7409
 ### Changes


### PR DESCRIPTION
Since we were using Retrofit observable calls earlier, certain exceptions were being swallowed by them internally when the stream was disposed and a request was ongoing.

However, since we have moved to synchronous calls, it is up to us to manage disposal of the streams ourselves. I've elected to use the method prescribed by the RxJava error handling docs (See [HERE](https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling)) and swallow these exceptions globally.