### PR TITLE
Change storage of app lock timestamps to be in-memory instead of in shared preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add `ImageSrcDetector` lint for warning when using `ImageView#src`
 - Add `TeleconsultRecord` and `TeleconsultRecordPayload`
 - Bumped internal SQLite version to 3.32.2
+- Change saving of app lock timestamp to an in-memory value
 
 ## 2020-09-03-7417
 ### Fixes

--- a/app/src/debug/java/org/simple/clinic/login/AppLockConfigModule.kt
+++ b/app/src/debug/java/org/simple/clinic/login/AppLockConfigModule.kt
@@ -5,6 +5,7 @@ import dagger.Provides
 import org.simple.clinic.di.AppScope
 import org.simple.clinic.login.applock.AppLockConfig
 import org.simple.clinic.storage.MemoryValue
+import org.simple.clinic.util.Optional
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
@@ -18,7 +19,7 @@ class AppLockConfigModule {
 
   @Provides
   @AppScope
-  fun provideAppLockAfterTimestamp(): MemoryValue<Instant> {
-    return MemoryValue(defaultValue = Instant.MAX)
+  fun provideAppLockAfterTimestamp(): MemoryValue<Optional<Instant>> {
+    return MemoryValue(defaultValue = Optional.empty())
   }
 }

--- a/app/src/debug/java/org/simple/clinic/login/AppLockConfigModule.kt
+++ b/app/src/debug/java/org/simple/clinic/login/AppLockConfigModule.kt
@@ -2,11 +2,7 @@ package org.simple.clinic.login
 
 import dagger.Module
 import dagger.Provides
-import org.simple.clinic.di.AppScope
 import org.simple.clinic.login.applock.AppLockConfig
-import org.simple.clinic.storage.MemoryValue
-import org.simple.clinic.util.Optional
-import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 @Module
@@ -15,11 +11,5 @@ class AppLockConfigModule {
   @Provides
   fun appLockConfig(): AppLockConfig {
     return AppLockConfig(lockAfterTimeMillis = TimeUnit.SECONDS.toMillis(30))
-  }
-
-  @Provides
-  @AppScope
-  fun provideAppLockAfterTimestamp(): MemoryValue<Optional<Instant>> {
-    return MemoryValue(defaultValue = Optional.empty())
   }
 }

--- a/app/src/debug/java/org/simple/clinic/login/AppLockConfigModule.kt
+++ b/app/src/debug/java/org/simple/clinic/login/AppLockConfigModule.kt
@@ -2,7 +2,10 @@ package org.simple.clinic.login
 
 import dagger.Module
 import dagger.Provides
+import org.simple.clinic.di.AppScope
 import org.simple.clinic.login.applock.AppLockConfig
+import org.simple.clinic.storage.MemoryValue
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 @Module
@@ -11,5 +14,11 @@ class AppLockConfigModule {
   @Provides
   fun appLockConfig(): AppLockConfig {
     return AppLockConfig(lockAfterTimeMillis = TimeUnit.SECONDS.toMillis(30))
+  }
+
+  @Provides
+  @AppScope
+  fun provideAppLockAfterTimestamp(): MemoryValue<Instant> {
+    return MemoryValue(defaultValue = Instant.MAX)
   }
 }

--- a/app/src/main/java/org/simple/clinic/appconfig/AppLockModule.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/AppLockModule.kt
@@ -1,0 +1,19 @@
+package org.simple.clinic.appconfig
+
+import dagger.Module
+import dagger.Provides
+import org.simple.clinic.di.AppScope
+import org.simple.clinic.login.AppLockConfigModule
+import org.simple.clinic.storage.MemoryValue
+import org.simple.clinic.util.Optional
+import java.time.Instant
+
+@Module(includes = [AppLockConfigModule::class])
+class AppLockModule {
+
+  @Provides
+  @AppScope
+  fun provideAppLockAfterTimestamp(): MemoryValue<Optional<Instant>> {
+    return MemoryValue(defaultValue = Optional.empty())
+  }
+}

--- a/app/src/main/java/org/simple/clinic/di/AppModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/AppModule.kt
@@ -10,6 +10,7 @@ import com.f2prateek.rx.preferences2.Preference
 import dagger.Module
 import dagger.Provides
 import org.simple.clinic.appconfig.AppConfigModule
+import org.simple.clinic.appconfig.AppLockModule
 import org.simple.clinic.appupdate.AppUpdateModule
 import org.simple.clinic.crash.CrashReporterModule
 import org.simple.clinic.di.network.HttpInterceptorsModule
@@ -80,7 +81,8 @@ import javax.inject.Named
   PinVerificationModule::class,
   SessionModule::class,
   UuidGeneratorModule::class,
-  SyncConfigModule::class
+  SyncConfigModule::class,
+  AppLockModule::class
 ])
 class AppModule(private val appContext: Application) {
 

--- a/app/src/main/java/org/simple/clinic/login/LoginModule.kt
+++ b/app/src/main/java/org/simple/clinic/login/LoginModule.kt
@@ -15,7 +15,7 @@ import org.simple.clinic.util.preference.StringPreferenceConverter
 import retrofit2.Retrofit
 import javax.inject.Named
 
-@Module(includes = [AppLockConfigModule::class])
+@Module
 class LoginModule {
 
   @Provides

--- a/app/src/main/java/org/simple/clinic/login/applock/AppLockEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/login/applock/AppLockEffectHandler.kt
@@ -9,6 +9,7 @@ import io.reactivex.ObservableTransformer
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.main.TypedPreference
 import org.simple.clinic.main.TypedPreference.Type.LockAtTime
+import org.simple.clinic.storage.MemoryValue
 import org.simple.clinic.user.User
 import org.simple.clinic.util.scheduler.SchedulersProvider
 import java.time.Instant
@@ -18,6 +19,7 @@ class AppLockEffectHandler @AssistedInject constructor(
     private val currentFacility: Lazy<Facility>,
     private val schedulersProvider: SchedulersProvider,
     @TypedPreference(LockAtTime) private val lockAfterTimestamp: Preference<Instant>,
+    private val lockAfterTimestampValue: MemoryValue<Instant>,
     @Assisted private val uiActions: AppLockUiActions
 ) {
 

--- a/app/src/main/java/org/simple/clinic/login/applock/AppLockEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/login/applock/AppLockEffectHandler.kt
@@ -1,14 +1,11 @@
 package org.simple.clinic.login.applock
 
-import com.f2prateek.rx.preferences2.Preference
 import com.spotify.mobius.rx2.RxMobius
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import dagger.Lazy
 import io.reactivex.ObservableTransformer
 import org.simple.clinic.facility.Facility
-import org.simple.clinic.main.TypedPreference
-import org.simple.clinic.main.TypedPreference.Type.LockAtTime
 import org.simple.clinic.storage.MemoryValue
 import org.simple.clinic.user.User
 import org.simple.clinic.util.scheduler.SchedulersProvider
@@ -18,7 +15,6 @@ class AppLockEffectHandler @AssistedInject constructor(
     private val currentUser: Lazy<User>,
     private val currentFacility: Lazy<Facility>,
     private val schedulersProvider: SchedulersProvider,
-    @TypedPreference(LockAtTime) private val lockAfterTimestamp: Preference<Instant>,
     private val lockAfterTimestampValue: MemoryValue<Instant>,
     @Assisted private val uiActions: AppLockUiActions
 ) {
@@ -59,9 +55,7 @@ class AppLockEffectHandler @AssistedInject constructor(
   private fun unlockOnAuthentication(): ObservableTransformer<UnlockOnAuthentication, AppLockEvent> {
     return ObservableTransformer { effects ->
       effects
-          .doOnNext {
-            lockAfterTimestamp.delete()
-          }
+          .doOnNext { lockAfterTimestampValue.clear() }
           .map { UnlockApp }
     }
   }

--- a/app/src/main/java/org/simple/clinic/login/applock/AppLockEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/login/applock/AppLockEffectHandler.kt
@@ -8,6 +8,7 @@ import io.reactivex.ObservableTransformer
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.storage.MemoryValue
 import org.simple.clinic.user.User
+import org.simple.clinic.util.Optional
 import org.simple.clinic.util.scheduler.SchedulersProvider
 import java.time.Instant
 
@@ -15,7 +16,7 @@ class AppLockEffectHandler @AssistedInject constructor(
     private val currentUser: Lazy<User>,
     private val currentFacility: Lazy<Facility>,
     private val schedulersProvider: SchedulersProvider,
-    private val lockAfterTimestampValue: MemoryValue<Instant>,
+    private val lockAfterTimestampValue: MemoryValue<Optional<Instant>>,
     @Assisted private val uiActions: AppLockUiActions
 ) {
 

--- a/app/src/main/java/org/simple/clinic/login/applock/AppLockScreenKey.kt
+++ b/app/src/main/java/org/simple/clinic/login/applock/AppLockScreenKey.kt
@@ -7,7 +7,7 @@ import org.simple.clinic.R
 import org.simple.clinic.router.screen.FullScreenKey
 
 @Parcelize
-class AppLockScreenKey : FullScreenKey, Parcelable {
+object AppLockScreenKey : FullScreenKey, Parcelable {
 
   @IgnoredOnParcel
   override val analyticsName = "App Lock"

--- a/app/src/main/java/org/simple/clinic/main/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivity.kt
@@ -51,6 +51,7 @@ import org.simple.clinic.user.User
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.user.UserStatus
 import org.simple.clinic.util.LocaleOverrideContextWrapper
+import org.simple.clinic.util.Optional
 import org.simple.clinic.util.UtcClock
 import org.simple.clinic.util.toNullable
 import org.simple.clinic.util.unsafeLazy
@@ -145,7 +146,7 @@ class TheActivity : AppCompatActivity(), TheActivityUi {
   lateinit var config: AppLockConfig
 
   @Inject
-  lateinit var unlockAfterTimestamp: MemoryValue<Instant>
+  lateinit var unlockAfterTimestamp: MemoryValue<Optional<Instant>>
 
   private val lifecycleEvents: Subject<LifecycleEvent> = PublishSubject.create()
 
@@ -229,7 +230,9 @@ class TheActivity : AppCompatActivity(), TheActivityUi {
   }
 
   override fun onStop() {
-    unlockAfterTimestamp.set(Instant.now(utcClock).plusMillis(config.lockAfterTimeMillis))
+    val lockAfterTimestamp = Instant.now(utcClock).plusMillis(config.lockAfterTimeMillis)
+    unlockAfterTimestamp.set(Optional.of(lockAfterTimestamp))
+
     delegate.stop()
     super.onStop()
   }

--- a/app/src/main/java/org/simple/clinic/main/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivity.kt
@@ -288,7 +288,7 @@ class TheActivity : AppCompatActivity(), TheActivityUi {
   }
 
   override fun showAppLockScreen() {
-    screenRouter.push(AppLockScreenKey())
+    screenRouter.push(AppLockScreenKey)
   }
 
   // This is here because we need to show the same alert in multiple

--- a/app/src/main/java/org/simple/clinic/main/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivity.kt
@@ -42,6 +42,7 @@ import org.simple.clinic.router.screen.FullScreenKeyChanger
 import org.simple.clinic.router.screen.NestedKeyChanger
 import org.simple.clinic.router.screen.RouterDirection
 import org.simple.clinic.router.screen.ScreenRouter
+import org.simple.clinic.storage.MemoryValue
 import org.simple.clinic.summary.OpenIntention
 import org.simple.clinic.summary.PatientSummaryScreenKey
 import org.simple.clinic.sync.SyncSetup
@@ -143,6 +144,9 @@ class TheActivity : AppCompatActivity(), TheActivityUi {
   @Inject
   lateinit var config: AppLockConfig
 
+  @Inject
+  lateinit var unlockAfterTimestamp: MemoryValue<Instant>
+
   private val lifecycleEvents: Subject<LifecycleEvent> = PublishSubject.create()
 
   private val disposables = CompositeDisposable()
@@ -225,7 +229,7 @@ class TheActivity : AppCompatActivity(), TheActivityUi {
   }
 
   override fun onStop() {
-    lifecycleEvents.onNext(LifecycleEvent.ActivityStopped(Instant.now(utcClock)))
+    unlockAfterTimestamp.set(Instant.now(utcClock).plusMillis(config.lockAfterTimeMillis))
     delegate.stop()
     super.onStop()
   }

--- a/app/src/main/java/org/simple/clinic/main/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivity.kt
@@ -169,7 +169,7 @@ class TheActivity : AppCompatActivity(), TheActivityUi {
     MobiusDelegate.forActivity(
         events = events.ofType(),
         defaultModel = TheActivityModel.create(),
-        update = TheActivityUpdate.create(config),
+        update = TheActivityUpdate(),
         effectHandler = effectHandlerFactory.create(this).build(),
         init = TheActivityInit(),
         modelUpdateListener = uiRenderer::render

--- a/app/src/main/java/org/simple/clinic/main/TheActivityComponent.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityComponent.kt
@@ -2,8 +2,6 @@ package org.simple.clinic.main
 
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.FragmentManager
-import com.f2prateek.rx.preferences2.Preference
-import com.f2prateek.rx.preferences2.RxSharedPreferences
 import dagger.Module
 import dagger.Provides
 import dagger.Subcomponent
@@ -37,7 +35,6 @@ import org.simple.clinic.introvideoscreen.IntroVideoScreenInjector
 import org.simple.clinic.login.applock.AppLockScreen
 import org.simple.clinic.login.applock.ConfirmResetPinDialog
 import org.simple.clinic.login.pin.LoginPinScreen
-import org.simple.clinic.main.TypedPreference.Type.LockAtTime
 import org.simple.clinic.medicalhistory.newentry.NewMedicalHistoryScreen
 import org.simple.clinic.newentry.PatientEntryScreen
 import org.simple.clinic.newentry.country.di.InputFieldsFactoryModule
@@ -71,11 +68,9 @@ import org.simple.clinic.summary.prescribeddrugs.DrugSummaryViewInjector
 import org.simple.clinic.summary.updatephone.UpdatePhoneNumberDialog
 import org.simple.clinic.sync.indicator.SyncIndicatorView
 import org.simple.clinic.teleconsultlog.success.TeleConsultSuccessScreen
-import org.simple.clinic.util.preference.InstantRxPreferencesConverter
 import org.simple.clinic.widgets.PatientSearchResultItemView
 import org.simple.clinic.widgets.qrcodescanner.QrCodeScannerView
 import org.simple.clinic.widgets.qrcodescanner.QrCodeScannerView_Old
-import java.time.Instant
 
 @Subcomponent(modules = [TheActivityModule::class])
 interface TheActivityComponent :
@@ -156,12 +151,6 @@ class TheActivityModule {
   @Provides
   fun theActivityLifecycle(activity: AppCompatActivity): Observable<ActivityLifecycle> {
     return RxActivityLifecycle.from(activity).stream()
-  }
-
-  @Provides
-  @TypedPreference(LockAtTime)
-  fun lastAppStopTimestamp(rxSharedPrefs: RxSharedPreferences): Preference<Instant> {
-    return rxSharedPrefs.getObject("should_lock_after", Instant.MAX, InstantRxPreferencesConverter())
   }
 
   @Provides

--- a/app/src/main/java/org/simple/clinic/main/TheActivityEffect.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityEffect.kt
@@ -1,7 +1,5 @@
 package org.simple.clinic.main
 
-import java.time.Instant
-
 sealed class TheActivityEffect
 
 object LoadAppLockInfo : TheActivityEffect()
@@ -9,8 +7,6 @@ object LoadAppLockInfo : TheActivityEffect()
 object ClearLockAfterTimestamp : TheActivityEffect()
 
 object ShowAppLockScreen : TheActivityEffect()
-
-data class UpdateLockTimestamp(val lockAt: Instant) : TheActivityEffect()
 
 object ListenForUserVerifications : TheActivityEffect()
 

--- a/app/src/main/java/org/simple/clinic/main/TheActivityEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityEffectHandler.kt
@@ -9,6 +9,7 @@ import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.storage.MemoryValue
 import org.simple.clinic.user.NewlyVerifiedUser
 import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.Optional
 import org.simple.clinic.util.UtcClock
 import org.simple.clinic.util.filterTrue
 import org.simple.clinic.util.scheduler.SchedulersProvider
@@ -19,7 +20,7 @@ class TheActivityEffectHandler @AssistedInject constructor(
     private val userSession: UserSession,
     private val utcClock: UtcClock,
     private val patientRepository: PatientRepository,
-    private val lockAfterTimestamp: MemoryValue<Instant>,
+    private val lockAfterTimestamp: MemoryValue<Optional<Instant>>,
     @Assisted private val uiActions: TheActivityUiActions
 ) {
 

--- a/app/src/main/java/org/simple/clinic/main/TheActivityEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityEffectHandler.kt
@@ -13,6 +13,7 @@ import org.simple.clinic.util.Optional
 import org.simple.clinic.util.UtcClock
 import org.simple.clinic.util.filterTrue
 import org.simple.clinic.util.scheduler.SchedulersProvider
+import org.simple.clinic.util.toOptional
 import java.time.Instant
 
 class TheActivityEffectHandler @AssistedInject constructor(
@@ -48,17 +49,14 @@ class TheActivityEffectHandler @AssistedInject constructor(
   private fun loadShowAppLockInto(): ObservableTransformer<LoadAppLockInfo, TheActivityEvent> {
     return ObservableTransformer { effects ->
       effects
-          .switchMap {
-            userSession
-                .loggedInUser()
-                .subscribeOn(schedulers.io())
-                .map {
-                  AppLockInfoLoaded(
-                      user = it,
-                      currentTimestamp = Instant.now(utcClock),
-                      lockAtTimestamp = lockAfterTimestamp.get()
-                  )
-                }
+          .observeOn(schedulers.io())
+          .map { userSession.loggedInUserImmediate().toOptional() }
+          .map {
+            AppLockInfoLoaded(
+                user = it,
+                currentTimestamp = Instant.now(utcClock),
+                lockAtTimestamp = lockAfterTimestamp.get()
+            )
           }
     }
   }

--- a/app/src/main/java/org/simple/clinic/main/TheActivityEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityEffectHandler.kt
@@ -34,7 +34,6 @@ class TheActivityEffectHandler @AssistedInject constructor(
         .addTransformer(LoadAppLockInfo::class.java, loadShowAppLockInto())
         .addAction(ClearLockAfterTimestamp::class.java, lockAfterTimestamp::clear)
         .addAction(ShowAppLockScreen::class.java, uiActions::showAppLockScreen, schedulers.ui())
-        .addTransformer(UpdateLockTimestamp::class.java, updateAppLockTime())
         .addTransformer(ListenForUserVerifications::class.java, listenForUserVerifications())
         .addAction(ShowUserLoggedOutOnOtherDeviceAlert::class.java, uiActions::showUserLoggedOutOnOtherDeviceAlert, schedulers.ui())
         .addTransformer(ListenForUserUnauthorizations::class.java, listenForUserUnauthorizations())
@@ -59,22 +58,6 @@ class TheActivityEffectHandler @AssistedInject constructor(
                       lockAtTimestamp = lockAfterTimestamp.get()
                   )
                 }
-          }
-    }
-  }
-
-  private fun updateAppLockTime(): ObservableTransformer<UpdateLockTimestamp, TheActivityEvent> {
-    return ObservableTransformer { effects ->
-      effects
-          .observeOn(schedulers.io())
-          .switchMap { effect ->
-            val shouldUpdateLockTimestamp = userSession.isUserLoggedIn() && !lockAfterTimestamp.hasValue
-
-            if (shouldUpdateLockTimestamp) {
-              lockAfterTimestamp.set(effect.lockAt)
-            }
-
-            Observable.empty()
           }
     }
   }

--- a/app/src/main/java/org/simple/clinic/main/TheActivityEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityEffectHandler.kt
@@ -8,6 +8,7 @@ import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
 import org.simple.clinic.main.TypedPreference.Type.LockAtTime
 import org.simple.clinic.patient.PatientRepository
+import org.simple.clinic.storage.MemoryValue
 import org.simple.clinic.user.NewlyVerifiedUser
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.UtcClock
@@ -21,6 +22,7 @@ class TheActivityEffectHandler @AssistedInject constructor(
     private val utcClock: UtcClock,
     private val patientRepository: PatientRepository,
     @TypedPreference(LockAtTime) private val lockAfterTimestamp: Preference<Instant>,
+    private val lockAfterTimestampValue: MemoryValue<Instant>,
     @Assisted private val uiActions: TheActivityUiActions
 ) {
 

--- a/app/src/main/java/org/simple/clinic/main/TheActivityEvent.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityEvent.kt
@@ -9,7 +9,6 @@ sealed class TheActivityEvent : UiEvent
 
 sealed class LifecycleEvent : TheActivityEvent() {
   object ActivityStarted : LifecycleEvent()
-  data class ActivityStopped(val timestamp: Instant) : LifecycleEvent()
   object ActivityDestroyed : LifecycleEvent()
 }
 

--- a/app/src/main/java/org/simple/clinic/main/TheActivityEvent.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityEvent.kt
@@ -15,7 +15,7 @@ sealed class LifecycleEvent : TheActivityEvent() {
 data class AppLockInfoLoaded(
     val user: Optional<User>,
     val currentTimestamp: Instant,
-    val lockAtTimestamp: Instant
+    val lockAtTimestamp: Optional<Instant>
 ) : TheActivityEvent()
 
 object UserWasJustVerified : TheActivityEvent()

--- a/app/src/main/java/org/simple/clinic/main/TheActivityEvent.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityEvent.kt
@@ -7,11 +7,6 @@ import java.time.Instant
 
 sealed class TheActivityEvent : UiEvent
 
-sealed class LifecycleEvent : TheActivityEvent() {
-  object ActivityStarted : LifecycleEvent()
-  object ActivityDestroyed : LifecycleEvent()
-}
-
 data class AppLockInfoLoaded(
     val user: Optional<User>,
     val currentTimestamp: Instant,

--- a/app/src/main/java/org/simple/clinic/main/TheActivityUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityUpdate.kt
@@ -3,14 +3,11 @@ package org.simple.clinic.main
 import com.spotify.mobius.Next
 import com.spotify.mobius.Next.noChange
 import com.spotify.mobius.Update
-import org.simple.clinic.login.applock.AppLockConfig
 import org.simple.clinic.main.LifecycleEvent.ActivityDestroyed
 import org.simple.clinic.main.LifecycleEvent.ActivityStarted
-import org.simple.clinic.main.LifecycleEvent.ActivityStopped
 import org.simple.clinic.mobius.dispatch
 import org.simple.clinic.user.User
 import org.simple.clinic.user.User.LoggedInStatus
-import java.time.Duration
 import java.time.Instant
 
 private val SHOW_APP_LOCK_FOR_USER_STATES = setOf(
@@ -19,20 +16,11 @@ private val SHOW_APP_LOCK_FOR_USER_STATES = setOf(
     LoggedInStatus.RESET_PIN_REQUESTED
 )
 
-class TheActivityUpdate(
-    private val lockScreenAfter: Duration
-) : Update<TheActivityModel, TheActivityEvent, TheActivityEffect> {
-
-  companion object {
-    fun create(appLockConfig: AppLockConfig) = TheActivityUpdate(
-        lockScreenAfter = Duration.ofMillis(appLockConfig.lockAfterTimeMillis)
-    )
-  }
+class TheActivityUpdate : Update<TheActivityModel, TheActivityEvent, TheActivityEffect> {
 
   override fun update(model: TheActivityModel, event: TheActivityEvent): Next<TheActivityModel, TheActivityEffect> {
     return when (event) {
       ActivityStarted -> dispatch(LoadAppLockInfo)
-      is ActivityStopped -> dispatch(UpdateLockTimestamp(lockAt = event.timestamp.plus(lockScreenAfter)))
       ActivityDestroyed -> noChange()
       is AppLockInfoLoaded -> handleScreenLock(event)
       UserWasJustVerified -> dispatch(ShowUserLoggedOutOnOtherDeviceAlert)

--- a/app/src/main/java/org/simple/clinic/main/TheActivityUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityUpdate.kt
@@ -8,6 +8,7 @@ import org.simple.clinic.main.LifecycleEvent.ActivityStarted
 import org.simple.clinic.mobius.dispatch
 import org.simple.clinic.user.User
 import org.simple.clinic.user.User.LoggedInStatus
+import org.simple.clinic.util.Optional
 import java.time.Instant
 
 private val SHOW_APP_LOCK_FOR_USER_STATES = setOf(
@@ -48,10 +49,13 @@ class TheActivityUpdate : Update<TheActivityModel, TheActivityEvent, TheActivity
 
   private fun screenLockEffect(
       currentTimestamp: Instant,
-      lockAtTimestamp: Instant,
+      lockAtTimestamp: Optional<Instant>,
       user: User
   ): TheActivityEffect {
-    val hasAppLockTimerExpired = currentTimestamp.isAfter(lockAtTimestamp)
+    val hasAppLockTimerExpired = lockAtTimestamp
+        .map(currentTimestamp::isAfter)
+        .orElse(true) // Handle the case where the app is opened after a cold start
+
     val shouldShowAppLockScreen = shouldShowAppLockScreenForUser(user) && hasAppLockTimerExpired
 
     return if (shouldShowAppLockScreen) ShowAppLockScreen else ClearLockAfterTimestamp

--- a/app/src/main/java/org/simple/clinic/main/TheActivityUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityUpdate.kt
@@ -3,8 +3,6 @@ package org.simple.clinic.main
 import com.spotify.mobius.Next
 import com.spotify.mobius.Next.noChange
 import com.spotify.mobius.Update
-import org.simple.clinic.main.LifecycleEvent.ActivityDestroyed
-import org.simple.clinic.main.LifecycleEvent.ActivityStarted
 import org.simple.clinic.mobius.dispatch
 import org.simple.clinic.user.User
 import org.simple.clinic.user.User.LoggedInStatus
@@ -21,8 +19,6 @@ class TheActivityUpdate : Update<TheActivityModel, TheActivityEvent, TheActivity
 
   override fun update(model: TheActivityModel, event: TheActivityEvent): Next<TheActivityModel, TheActivityEffect> {
     return when (event) {
-      ActivityStarted -> dispatch(LoadAppLockInfo)
-      ActivityDestroyed -> noChange()
       is AppLockInfoLoaded -> handleScreenLock(event)
       UserWasJustVerified -> dispatch(ShowUserLoggedOutOnOtherDeviceAlert)
       UserWasUnauthorized -> dispatch(RedirectToLoginScreen)

--- a/app/src/main/java/org/simple/clinic/main/TypedPreference.kt
+++ b/app/src/main/java/org/simple/clinic/main/TypedPreference.kt
@@ -6,6 +6,5 @@ import javax.inject.Qualifier
 annotation class TypedPreference(val value: Type) {
 
   enum class Type {
-    LockAtTime
   }
 }

--- a/app/src/main/java/org/simple/clinic/storage/MemoryValue.kt
+++ b/app/src/main/java/org/simple/clinic/storage/MemoryValue.kt
@@ -8,4 +8,22 @@ package org.simple.clinic.storage
 data class MemoryValue<T>(
     private val defaultValue: T,
     private var currentValue: T? = null
-)
+) {
+
+  val hasValue: Boolean
+    get() = currentValue != null
+
+  fun clear() {
+    synchronized(this) {
+      currentValue = null
+    }
+  }
+
+  fun set(newValue: T?) {
+    synchronized(this) {
+      currentValue = newValue
+    }
+  }
+
+  fun get(): T = currentValue ?: defaultValue
+}

--- a/app/src/main/java/org/simple/clinic/storage/MemoryValue.kt
+++ b/app/src/main/java/org/simple/clinic/storage/MemoryValue.kt
@@ -1,0 +1,11 @@
+package org.simple.clinic.storage
+
+/**
+ * A class that can be used to store a reference to a single, mutable
+ * value for the duration of a session. Not meant for persisting to disk
+ * and there are better options for those.
+ **/
+data class MemoryValue<T>(
+    private val defaultValue: T,
+    private var currentValue: T? = null
+)

--- a/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
@@ -28,6 +28,7 @@ import org.simple.clinic.main.TheActivityUi
 import org.simple.clinic.main.TheActivityUiRenderer
 import org.simple.clinic.main.TheActivityUpdate
 import org.simple.clinic.patient.PatientRepository
+import org.simple.clinic.storage.MemoryValue
 import org.simple.clinic.user.User
 import org.simple.clinic.user.User.LoggedInStatus.LOGGED_IN
 import org.simple.clinic.user.User.LoggedInStatus.NOT_LOGGED_IN
@@ -59,6 +60,7 @@ class TheActivityControllerTest {
   private val userSession = mock<UserSession>()
   private val patientRepository = mock<PatientRepository>()
   private val lockAfterTimestamp = mock<Preference<Instant>>()
+  private val lockAfterTimestampValue = MemoryValue(Instant.MAX)
   private val uiEvents = PublishSubject.create<UiEvent>()
 
   private val currentTimestamp = Instant.parse("2018-01-01T00:00:00Z")
@@ -417,6 +419,7 @@ class TheActivityControllerTest {
         utcClock = clock,
         patientRepository = patientRepository,
         lockAfterTimestamp = lockAfterTimestamp,
+        lockAfterTimestampValue = lockAfterTimestampValue,
         uiActions = ui
     )
     val uiRenderer = TheActivityUiRenderer(ui)

--- a/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
@@ -70,9 +70,6 @@ class TheActivityControllerTest {
 
   @Test
   fun `when activity is started and user is logged out then app lock shouldn't be shown`() {
-    // given
-    whenever(userSession.isUserLoggedIn()).thenReturn(false)
-
     // when
     setupController()
 
@@ -84,20 +81,15 @@ class TheActivityControllerTest {
   @Test
   fun `when activity is started, user has requested an OTP, and user was inactive then app lock should be shown`() {
     // given
-    whenever(userSession.isUserLoggedIn()).thenReturn(true)
-    val userStream: Observable<Optional<User>> = Observable.just(Optional.of(TestData.loggedInUser(
+    whenever(userSession.loggedInUserImmediate()).thenReturn(TestData.loggedInUser(
         uuid = UUID.fromString("049ee3e0-f5a8-4ba6-9270-b20231d3fe50"),
         loggedInStatus = OTP_REQUESTED,
         status = UserStatus.ApprovedForSyncing
-    )))
-
+    ))
     val lockAfterTime = currentTimestamp.minusSeconds(TimeUnit.MINUTES.toSeconds(1))
 
     // when
-    setupController(
-        userStream = userStream,
-        lockAtTime = lockAfterTime
-    )
+    setupController(lockAtTime = lockAfterTime)
 
     // then
     verify(ui).showAppLockScreen()
@@ -107,20 +99,16 @@ class TheActivityControllerTest {
   @Test
   fun `when activity is started, user is logged in, and user was inactive then app lock should be shown`() {
     // given
-    whenever(userSession.isUserLoggedIn()).thenReturn(true)
-    val userStream: Observable<Optional<User>> = Observable.just(Optional.of(TestData.loggedInUser(
+    whenever(userSession.loggedInUserImmediate()).thenReturn(TestData.loggedInUser(
         uuid = UUID.fromString("049ee3e0-f5a8-4ba6-9270-b20231d3fe50"),
         loggedInStatus = LOGGED_IN,
         status = UserStatus.ApprovedForSyncing
-    )))
+    ))
 
     val lockAfterTime = currentTimestamp.minusSeconds(TimeUnit.MINUTES.toSeconds(1))
 
     // when
-    setupController(
-        userStream = userStream,
-        lockAtTime = lockAfterTime
-    )
+    setupController(lockAtTime = lockAfterTime)
 
     // then
     verify(ui).showAppLockScreen()
@@ -130,20 +118,15 @@ class TheActivityControllerTest {
   @Test
   fun `when activity is started, user has requested a PIN reset, and user was inactive then app lock should be shown`() {
     // given
-    whenever(userSession.isUserLoggedIn()).thenReturn(true)
-    val userStream: Observable<Optional<User>> = Observable.just(Optional.of(TestData.loggedInUser(
+    whenever(userSession.loggedInUserImmediate()).thenReturn(TestData.loggedInUser(
         uuid = UUID.fromString("049ee3e0-f5a8-4ba6-9270-b20231d3fe50"),
         loggedInStatus = RESET_PIN_REQUESTED,
         status = UserStatus.ApprovedForSyncing
-    )))
-
+    ))
     val lockAfterTime = currentTimestamp.minusSeconds(TimeUnit.MINUTES.toSeconds(1))
 
     // when
-    setupController(
-        userStream = userStream,
-        lockAtTime = lockAfterTime
-    )
+    setupController(lockAtTime = lockAfterTime)
 
     // then
     verify(ui).showAppLockScreen()
@@ -153,13 +136,11 @@ class TheActivityControllerTest {
   @Test
   fun `when activity is started, user is not logged in and user was inactive then app lock should not be shown`() {
     // given
-    whenever(userSession.isUserLoggedIn()).thenReturn(true)
-    whenever(userSession.loggedInUser())
-        .thenReturn(Observable.just(Optional.of(TestData.loggedInUser(
-            uuid = UUID.fromString("049ee3e0-f5a8-4ba6-9270-b20231d3fe50"),
-            loggedInStatus = NOT_LOGGED_IN,
-            status = UserStatus.ApprovedForSyncing
-        ))))
+    whenever(userSession.loggedInUserImmediate()).thenReturn(TestData.loggedInUser(
+        uuid = UUID.fromString("049ee3e0-f5a8-4ba6-9270-b20231d3fe50"),
+        loggedInStatus = NOT_LOGGED_IN,
+        status = UserStatus.ApprovedForSyncing
+    ))
 
     val lockAfterTime = currentTimestamp.minusSeconds(TimeUnit.MINUTES.toSeconds(1))
 
@@ -174,13 +155,11 @@ class TheActivityControllerTest {
   @Test
   fun `when activity is started, user is resetting the PIN, and user was inactive then app lock should not be shown`() {
     // given
-    whenever(userSession.isUserLoggedIn()).thenReturn(true)
-    whenever(userSession.loggedInUser())
-        .thenReturn(Observable.just(Optional.of(TestData.loggedInUser(
-            uuid = UUID.fromString("049ee3e0-f5a8-4ba6-9270-b20231d3fe50"),
-            loggedInStatus = RESETTING_PIN,
-            status = UserStatus.ApprovedForSyncing
-        ))))
+    whenever(userSession.loggedInUserImmediate()).thenReturn(TestData.loggedInUser(
+        uuid = UUID.fromString("049ee3e0-f5a8-4ba6-9270-b20231d3fe50"),
+        loggedInStatus = RESETTING_PIN,
+        status = UserStatus.ApprovedForSyncing
+    ))
 
     val lockAfterTime = currentTimestamp.minusSeconds(TimeUnit.MINUTES.toSeconds(1))
 
@@ -195,12 +174,11 @@ class TheActivityControllerTest {
   @Test
   fun `when app is started unlocked and lock timer hasn't expired yet then the timer should be unset`() {
     // given
-    whenever(userSession.isUserLoggedIn()).thenReturn(true)
-    val userStream: Observable<Optional<User>> = Observable.just(Optional.of(TestData.loggedInUser(
+    whenever(userSession.loggedInUserImmediate()).thenReturn(TestData.loggedInUser(
         uuid = UUID.fromString("049ee3e0-f5a8-4ba6-9270-b20231d3fe50"),
         loggedInStatus = LOGGED_IN,
         status = UserStatus.ApprovedForSyncing
-    )))
+    ))
 
     val lockAfterTimestamp = MemoryValue(
         defaultValue = Optional.empty(),
@@ -208,7 +186,7 @@ class TheActivityControllerTest {
     )
 
     // when
-    setupController(userStream = userStream, lockAfterTimestamp = lockAfterTimestamp)
+    setupController(lockAfterTimestamp = lockAfterTimestamp)
 
     // then
     assertThat(lockAfterTimestamp.hasValue).isFalse()
@@ -218,7 +196,6 @@ class TheActivityControllerTest {
   @Test
   fun `when app is started locked and lock timer hasn't expired yet then the timer should not be unset`() {
     // given
-    whenever(userSession.isUserLoggedIn()).thenReturn(true)
     val lockAfterTimestamp = MemoryValue(
         defaultValue = Optional.empty(),
         currentValue = Optional.of(Instant.now().minusSeconds(TimeUnit.MINUTES.toSeconds(5)))
@@ -250,7 +227,7 @@ class TheActivityControllerTest {
     // when
     setupController(
         userStream = userStream,
-         lockAtTime = currentTimestamp.plus(Duration.ofMinutes(lockInMinutes))
+        lockAtTime = currentTimestamp.plus(Duration.ofMinutes(lockInMinutes))
     )
 
     // then
@@ -292,7 +269,6 @@ class TheActivityControllerTest {
         loggedInStatus = LOGGED_IN
     )
     whenever(userSession.loggedInUser()).thenReturn(Observable.just(loggedInUser.toOptional()))
-    whenever(userSession.isUserLoggedIn()).thenReturn(true)
     whenever(patientRepository.clearPatientData()).thenReturn(Completable.complete())
     whenever(userSession.loggedInUserImmediate()).thenReturn(loggedInUser)
     val userDisapprovedSubject = PublishSubject.create<Boolean>()
@@ -321,7 +297,6 @@ class TheActivityControllerTest {
         loggedInStatus = LOGGED_IN
     )
     whenever(userSession.loggedInUser()).thenReturn(Observable.just(loggedInUser.toOptional()))
-    whenever(userSession.isUserLoggedIn()).thenReturn(true)
 
     //when
     setupController(lockAtTime = Instant.now(clock))
@@ -354,7 +329,7 @@ class TheActivityControllerTest {
 
     // when
     userUnauthorizedSubject.onNext(true)
-    
+
     // then
     verifyZeroInteractions(ui)
 

--- a/app/src/test/java/org/simple/clinic/login/applock/AppLockScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/login/applock/AppLockScreenLogicTest.kt
@@ -1,6 +1,6 @@
 package org.simple.clinic.login.applock
 
-import com.f2prateek.rx.preferences2.Preference
+import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
@@ -26,7 +26,6 @@ class AppLockScreenLogicTest {
 
   private val ui = mock<AppLockScreenUi>()
   private val uiActions = mock<AppLockUiActions>()
-  private val lastUnlockTimestamp = mock<Preference<Instant>>()
   private val lockAfterTimestampValue = MemoryValue(Instant.MAX)
 
   private val loggedInUser = TestData.loggedInUser(
@@ -49,13 +48,15 @@ class AppLockScreenLogicTest {
 
   @Test
   fun `when PIN is authenticated, the last-unlock-timestamp should be updated and then the app should be unlocked`() {
+    // given
+    lockAfterTimestampValue.set(Instant.parse("2018-01-01T00:00:00Z"))
+
     // when
     setupController()
     uiEvents.onNext(AppLockPinAuthenticated)
 
     // then
-    verify(lastUnlockTimestamp).delete()
-
+    assertThat(lockAfterTimestampValue.hasValue).isFalse()
     verify(ui, times(2)).setUserFullName(loggedInUser.fullName)
     verify(ui).setFacilityName(facility.name)
     verify(uiActions).restorePreviousScreen()
@@ -108,7 +109,6 @@ class AppLockScreenLogicTest {
         currentUser = { loggedInUser },
         currentFacility = { facility },
         schedulersProvider = TestSchedulersProvider.trampoline(),
-        lockAfterTimestamp = lastUnlockTimestamp,
         lockAfterTimestampValue = lockAfterTimestampValue,
         uiActions = uiActions
     )

--- a/app/src/test/java/org/simple/clinic/login/applock/AppLockScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/login/applock/AppLockScreenLogicTest.kt
@@ -5,13 +5,13 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
-import dagger.Lazy
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.TestData
+import org.simple.clinic.storage.MemoryValue
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.scheduler.TestSchedulersProvider
 import org.simple.clinic.widgets.UiEvent
@@ -27,6 +27,7 @@ class AppLockScreenLogicTest {
   private val ui = mock<AppLockScreenUi>()
   private val uiActions = mock<AppLockUiActions>()
   private val lastUnlockTimestamp = mock<Preference<Instant>>()
+  private val lockAfterTimestampValue = MemoryValue(Instant.MAX)
 
   private val loggedInUser = TestData.loggedInUser(
       uuid = UUID.fromString("cdb08a78-7bae-44f4-9bb9-40257be58aa4"),
@@ -104,10 +105,11 @@ class AppLockScreenLogicTest {
 
   private fun setupController() {
     val effectHandler = AppLockEffectHandler(
-        currentUser = Lazy { loggedInUser },
-        currentFacility = Lazy { facility },
-        lockAfterTimestamp = lastUnlockTimestamp,
+        currentUser = { loggedInUser },
+        currentFacility = { facility },
         schedulersProvider = TestSchedulersProvider.trampoline(),
+        lockAfterTimestamp = lastUnlockTimestamp,
+        lockAfterTimestampValue = lockAfterTimestampValue,
         uiActions = uiActions
     )
 

--- a/app/src/test/java/org/simple/clinic/login/applock/AppLockScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/login/applock/AppLockScreenLogicTest.kt
@@ -12,6 +12,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.TestData
 import org.simple.clinic.storage.MemoryValue
+import org.simple.clinic.util.Optional
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.scheduler.TestSchedulersProvider
 import org.simple.clinic.widgets.UiEvent
@@ -26,7 +27,7 @@ class AppLockScreenLogicTest {
 
   private val ui = mock<AppLockScreenUi>()
   private val uiActions = mock<AppLockUiActions>()
-  private val lockAfterTimestampValue = MemoryValue(Instant.MAX)
+  private val lockAfterTimestampValue = MemoryValue(Optional.empty<Instant>())
 
   private val loggedInUser = TestData.loggedInUser(
       uuid = UUID.fromString("cdb08a78-7bae-44f4-9bb9-40257be58aa4"),
@@ -49,7 +50,7 @@ class AppLockScreenLogicTest {
   @Test
   fun `when PIN is authenticated, the last-unlock-timestamp should be updated and then the app should be unlocked`() {
     // given
-    lockAfterTimestampValue.set(Instant.parse("2018-01-01T00:00:00Z"))
+    lockAfterTimestampValue.set(Optional.of(Instant.parse("2018-01-01T00:00:00Z")))
 
     // when
     setupController()


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/1148/stop-storing-app-lock-timestamp-in-shared-preferences