### PR TITLE
Disable state saving and restoration for the search results screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Internal
 - [In Progress: 27 Aug 2020] Add support for sending teleconsult request via SMS
 - Add `Capabilities` to User
+- Disable state saving and restoration for the search results view
 
 ## On Demo
 ### Changes

--- a/app/src/main/java/org/simple/clinic/searchresultsview/PatientSearchView.kt
+++ b/app/src/main/java/org/simple/clinic/searchresultsview/PatientSearchView.kt
@@ -68,6 +68,7 @@ class PatientSearchView(context: Context, attrs: AttributeSet) : RelativeLayout(
 
     val screenDestroys = detaches().map { ScreenDestroyed() }
     setupScreen(screenDestroys)
+    isSaveEnabled = false
   }
 
   override fun onAttachedToWindow() {


### PR DESCRIPTION
This is temporarily done to stop crashes from persisting lists of
search results in the saved state bundle until paging library v3 is ready.