### PR TITLE
Save teleconsult prescribed drugs when creating teleconsult record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `Capabilities` to User
 - Disable state saving and restoration for the search results view
 - Stop querying for redundant facility in `LoggedInUserHttpInterceptor`
+- Save teleconsult prescribed drugs when saving teleconsult record
 
 ### Changes
 - Updated translations for: `om-ET`, `ta-IN`, `bn-BD`, `mr-IN`, `hi-IN`, `ti-ET`

--- a/app/src/androidTest/java/org/simple/clinic/drugs/PrescriptionRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/drugs/PrescriptionRepositoryAndroidTest.kt
@@ -14,8 +14,6 @@ import org.simple.clinic.rules.LocalAuthenticationRule
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.Rules
 import org.simple.clinic.util.TestUtcClock
-import java.time.Duration
-import java.time.Instant
 import java.time.LocalDate
 import java.time.Month
 import java.util.UUID
@@ -128,5 +126,38 @@ class PrescriptionRepositoryAndroidTest {
 
     val storedPrescription = database.prescriptionDao().getOne(correctedPrescription.uuid)!!
     assertThat(storedPrescription.name).isEqualTo(correctedPrescription.name)
+  }
+
+  @Test
+  fun getting_prescribed_drugs_uuid_for_patient_should_work_correctly() {
+    // given
+    val patient1Uuid = UUID.fromString("a1b8d50c-1d7b-4428-9b3c-3507cd7b723d")
+    val patient2Uuid = UUID.fromString("c4b21e94-079b-49db-b70c-5b4d500d6cae")
+
+    val prescribedDrug1Uuid = UUID.fromString("a6269313-90f0-47be-b23d-615d2ee0956a")
+    val prescribedDrug1 = TestData.prescription(
+        uuid = prescribedDrug1Uuid,
+        patientUuid = patient1Uuid
+    )
+
+    val prescribedDrug2Uuid = UUID.fromString("cfcb33d1-7fac-40fa-a335-39f5f3099fe0")
+    val prescribedDrug2 = TestData.prescription(
+        uuid = prescribedDrug2Uuid,
+        patientUuid = patient1Uuid
+    )
+
+    val prescribedDrug3Uuid = UUID.fromString("6fe649ef-9edb-450f-9037-1bb5d3a0420b")
+    val prescribedDrug3 = TestData.prescription(
+        uuid = prescribedDrug3Uuid,
+        patientUuid = patient2Uuid
+    )
+
+    repository.save(listOf(prescribedDrug1, prescribedDrug2, prescribedDrug3)).blockingAwait()
+
+    // when
+    val prescribedDrugsUuidForPatient = repository.prescribedDrugsUuidForPatient(patient1Uuid)
+
+    // then
+    assertThat(prescribedDrugsUuidForPatient).isEqualTo(listOf(prescribedDrug1Uuid, prescribedDrug2Uuid))
   }
 }

--- a/app/src/androidTest/java/org/simple/clinic/teleconsultlog/teleconsultrecord/TeleconsultRecordRepositoryTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/teleconsultlog/teleconsultrecord/TeleconsultRecordRepositoryTest.kt
@@ -66,4 +66,49 @@ class TeleconsultRecordRepositoryTest {
     // then
     assertThat(teleconsultRecordWithPrescribedDrugs!!.teleconsultRecord).isEqualTo(teleconsultRecord)
   }
+
+  @Test
+  fun saving_teleconsult_prescribed_drugs_should_work_correctly() {
+    // given
+    val teleconsultRecordId = UUID.fromString("700ee55d-7f49-4bda-9a4a-c5ce903ce485")
+    val patientUuid = UUID.fromString("3c00cdf9-4304-4dc7-8d32-6fbd5cd8f14d")
+    val medicalOfficerUuid = UUID.fromString("7142092e-24b1-4757-b7b6-a00fbd60332b")
+    val medicalOfficerRegistrationId = "1111111111111"
+
+    val teleconsultRecordInfo = TestData.teleconsultRecordInfo(
+        recordedAt = Instant.parse("2018-01-01T00:00:00Z"),
+        teleconsultationType = Audio,
+        patientTookMedicines = Yes,
+        patientConsented = Yes,
+        medicalOfficerNumber = medicalOfficerRegistrationId
+    )
+
+    teleconsultRecordRepository.createTeleconsultRecordForMedicalOfficer(
+        teleconsultRecordId = teleconsultRecordId,
+        patientUuid = patientUuid,
+        medicalOfficerId = medicalOfficerUuid,
+        teleconsultRecordInfo = teleconsultRecordInfo
+    )
+
+    val teleconsultPrescribedDrugsUuid = listOf(
+        UUID.fromString("31c0145b-2f52-4ff2-ad80-481e1c5e562b"),
+        UUID.fromString("38f21cd5-0f36-44ca-886c-f4ba50ae18a0"),
+        UUID.fromString("be1d4679-4d97-4ede-bcc6-835c858c2e08")
+    )
+
+    teleconsultRecordRepository.saveTeleconsultPrescribedDrug(teleconsultRecordId, teleconsultPrescribedDrugsUuid)
+
+    // when
+    val teleconsultRecordWithPrescribedDrugs = teleconsultRecordRepository.getTeleconsultRecordWithPrescribedDrugs(teleconsultRecordId)
+
+    // then
+    assertThat(teleconsultRecordWithPrescribedDrugs!!.prescribedDrugs).isEqualTo(
+        teleconsultPrescribedDrugsUuid.map { drugUuid ->
+          TestData.teleconsultationRecordPrescribedDrug(
+              teleconsultRecordId = teleconsultRecordId,
+              prescribedDrugUuid = drugUuid
+          )
+        }
+    )
+  }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/PrescribedDrug.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/PrescribedDrug.kt
@@ -134,5 +134,8 @@ data class PrescribedDrug(
         instantToCompare: Instant,
         pendingStatus: SyncStatus
     ): Boolean
+
+    @Query("SELECT uuid FROM PrescribedDrug WHERE patientUuid = :patientUuid")
+    fun prescribedDrugsUuidForPatient(patientUuid: UUID): List<UUID>
   }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/PrescriptionRepository.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/PrescriptionRepository.kt
@@ -137,4 +137,8 @@ class PrescriptionRepository @Inject constructor(
         .count(SyncStatus.PENDING)
         .toObservable()
   }
+
+  fun prescribedDrugsUuidForPatient(patientUuid: UUID): List<UUID> {
+    return dao.prescribedDrugsUuidForPatient(patientUuid)
+  }
 }

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/teleconsultrecord/TeleconsultRecordRepository.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/teleconsultrecord/TeleconsultRecordRepository.kt
@@ -8,6 +8,7 @@ import javax.inject.Inject
 class TeleconsultRecordRepository @Inject constructor(
     private val teleconsultRecordDao: TeleconsultRecord.RoomDao,
     private val teleconsultRecordWithPrescribedDrugsDao: TeleconsultRecordWithPrescribedDrugs.RoomDao,
+    private val teleconsultPrescribedDrugDao: TeleconsultRecordPrescribedDrug.RoomDao,
     private val utcClock: UtcClock
 ) {
 
@@ -31,5 +32,18 @@ class TeleconsultRecordRepository @Inject constructor(
     )
 
     teleconsultRecordDao.save(listOf(teleconsultRecord))
+  }
+
+  fun saveTeleconsultPrescribedDrug(
+      teleconsultRecordId: UUID,
+      prescribedDrugsUuids: List<UUID>
+  ) {
+    val teleconsultPrescribedDrugs = prescribedDrugsUuids.map { drugUuid ->
+      TeleconsultRecordPrescribedDrug(
+          teleconsultRecordId = teleconsultRecordId,
+          prescribedDrugUuid = drugUuid
+      )
+    }
+    teleconsultPrescribedDrugDao.save(teleconsultPrescribedDrugs)
   }
 }


### PR DESCRIPTION
When creating the teleconsult record, we should also be getting the existing prescriptions UUID for the patient and saving them as part of a teleconsult record. Initially, I thought of saving these during the prescription screen, but the medical officer may or may not create a prescription after creating a teleconsult record.