### PR TITLE
Pass `TeleconsultationType` to `DoneClicked.analyticsName`

### DIFF
--- a/app/src/main/java/org/simple/clinic/teleconsultlog/teleconsultrecord/screen/TeleconsultRecordEvent.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/teleconsultrecord/screen/TeleconsultRecordEvent.kt
@@ -21,7 +21,7 @@ data class DoneClicked(
     val patientTookMedicines: Answer,
     val patientConsented: Answer
 ) : TeleconsultRecordEvent() {
-  override val analyticsName: String = "Teleconsult Record:Done Clicked"
+  override val analyticsName: String = "Teleconsult Record:Done Clicked with Teleconsultation Type: $teleconsultationType"
 }
 
 data class PatientDetailsLoaded(


### PR DESCRIPTION
We would like to know which `TeleconsultationType` is selected when creating the teleconsultation record.