### PR TITLE
Update QUIRKS

### DIFF
--- a/doc/QUIRKS.md
+++ b/doc/QUIRKS.md
@@ -1,9 +1,5 @@
 # Quirks That You Should Probably Be Aware Of
 
-### lazythreetenbp for backported Java 8 date-time API
-
-Simple uses [lazythreetenbp](https://github.com/gabrielittner/lazythreetenbp) for working with date and time. Due to some limitations, the IDE does not understand how to download its sources. As a work around, the sources can be downloaded from [the maven repository](http://search.maven.org/#search%7Cga%7C1%7Cthreetenbp) and manually attached to Android Studio.
-
 ### Syncing of data using WorkManager
 
 [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager) is used for scheduling periodic syncing of patient-related data like blood pressures, prescribed medicines, and demographic information. For debugging the state of the jobs, use this command:


### PR DESCRIPTION
Starting android 8.0 and above we don't need to use `threeTenBp` for working with date and time, we are instead using the built-in `java-time`. Hence removing the explicit data mentioning `threeTenBp`