### PR TITLE
Fix deeplink screens & warning dialogs are displayed again when activity is restarted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Change registration and current facility ID columns to regular columns without foreign keys in `User`
 - Add teleconsult record sync
 
+### Fixes
+- Fix deeplink screens & warning dialogs displaying again after activity restart. 
+
 ## 2020-09-15-7432
 ### Features
 - Add `TeleconsultRecordScreen`

--- a/app/src/main/java/org/simple/clinic/main/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivity.kt
@@ -207,6 +207,7 @@ class TheActivity : AppCompatActivity(), TheActivityUi {
       is OpenPatientSummaryWithTeleconsultLog -> showPatientSummaryWithTeleconsultLogForDeepLink(deepLinkResult)
       is ShowTeleconsultNotAllowed -> showTeleconsultNotAllowedErrorDialog()
     }
+    intent.removeExtra(EXTRA_DEEP_LINK_RESULT)
   }
 
   override fun attachBaseContext(baseContext: Context) {


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/1406/fix-deeplink-screens-warning-dialogs-are-displayed-again-when-activity-is-restarted
