### PR TITLE
Check the current screen before updating the app lock time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@
 - Add teleconsult record sync
 
 ### Fixes
-- Fix deeplink screens & warning dialogs displaying again after activity restart. 
+- Fix deeplink screens & warning dialogs displaying again after activity restart.
+- App lock screen does not show if the app is exited and opened again while it is on the lock screen
 
 ## 2020-09-15-7432
 ### Features

--- a/app/src/main/java/org/simple/clinic/login/applock/ConfirmResetPinDialog.kt
+++ b/app/src/main/java/org/simple/clinic/login/applock/ConfirmResetPinDialog.kt
@@ -2,14 +2,13 @@ package org.simple.clinic.login.applock
 
 import android.app.Dialog
 import android.os.Bundle
-import androidx.fragment.app.FragmentManager
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.fragment.app.FragmentManager
 import org.simple.clinic.R
-import org.simple.clinic.main.TheActivity
 import org.simple.clinic.forgotpin.createnewpin.ForgotPinCreateNewPinScreenKey
+import org.simple.clinic.main.TheActivity
 import org.simple.clinic.patient.PatientRepository
-import org.simple.clinic.router.screen.RouterDirection
 import org.simple.clinic.router.screen.ScreenRouter
 import org.simple.clinic.user.UserSession
 import javax.inject.Inject
@@ -42,9 +41,7 @@ class ConfirmResetPinDialog : AppCompatDialogFragment() {
     return AlertDialog.Builder(requireContext(), R.style.Clinic_V2_DialogStyle_Destructive)
         .setTitle(R.string.applock_reset_pin_alert_title)
         .setMessage(R.string.applock_reset_pin_alert_message)
-        .setPositiveButton(R.string.applock_reset_pin_alert_confirm) { _, _ ->
-          screenRouter.clearHistoryAndPush(ForgotPinCreateNewPinScreenKey(), RouterDirection.REPLACE)
-        }
+        .setPositiveButton(R.string.applock_reset_pin_alert_confirm) { _, _ -> screenRouter.push(ForgotPinCreateNewPinScreenKey()) }
         .setNegativeButton(R.string.applock_reset_pin_alert_cancel, null)
         .create()
   }

--- a/app/src/main/java/org/simple/clinic/main/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivity.kt
@@ -228,8 +228,10 @@ class TheActivity : AppCompatActivity(), TheActivityUi {
   }
 
   override fun onStop() {
-    val lockAfterTimestamp = Instant.now(utcClock).plusMillis(config.lockAfterTimeMillis)
-    unlockAfterTimestamp.set(Optional.of(lockAfterTimestamp))
+    if (!screenRouter.hasKeyOfType<AppLockScreenKey>()) {
+      val lockAfterTimestamp = Instant.now(utcClock).plusMillis(config.lockAfterTimeMillis)
+      unlockAfterTimestamp.set(Optional.of(lockAfterTimestamp))
+    }
 
     delegate.stop()
     super.onStop()

--- a/router/src/main/java/org/simple/clinic/router/screen/ScreenRouter.kt
+++ b/router/src/main/java/org/simple/clinic/router/screen/ScreenRouter.kt
@@ -150,7 +150,11 @@ class ScreenRouter(
     }
   }
 
-  private fun flow(): Flow {
+  inline fun <reified T> hasKeyOfType(): Boolean {
+    return flow().history.any { it is T }
+  }
+
+  fun flow(): Flow {
     try {
       return flowSupplier.get()
     } catch (e: IllegalStateException) {


### PR DESCRIPTION
We introduced a bug in a previous commit where the app lock screen could be bypassed by hitting back on the app lock screen and then opening it again before the app lock timer runs out.

This was happening because `TheActivity` would update the app lock timer in `onStop` regardless of whether the app lock was successfully completed or not and the lock at time would be advanced to some point in the future. 