### PR TITLE
Use manifest API endpoint in tests instead of the fallback API endpoint

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/di/TestRetrofitModule.kt
+++ b/app/src/androidTest/java/org/simple/clinic/di/TestRetrofitModule.kt
@@ -37,7 +37,7 @@ class TestRetrofitModule {
       moshi: Moshi,
       okHttpClient: OkHttpClient
   ): Retrofit {
-    val baseUrl = BuildConfig.FALLBACK_ENDPOINT
+    val baseUrl = BuildConfig.MANIFEST_ENDPOINT
 
     return Retrofit.Builder()
         .addConverterFactory(ScalarsConverterFactory.create())


### PR DESCRIPTION
We have less than five users who are current on a build before the country selection screen was added. This means that the fallback country mechanism is mostly unnecessary and we can think of removing it.

The first step in this would be to use the manifest endpoint in tests instead of the fallback. We will remove the fallback mechanism after reaching out to the users who are on older app versions in person and asking them to update.