### PR TITLE
Remove WhatsApp as a channel from the reminder consent in the patient entry screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 ## Next Release
+## Changes
+- Made "SMS Reminders" to be the default consent label on the patient screen unless otherwise specified on a country level
+
 ## Internal
 - Add `syncGroup` property to the `Facility` resource
 - Show medicines required error in `TeleconsultPrescriptionScreen`

--- a/app/src/main/java/org/simple/clinic/appconfig/Country.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/Country.kt
@@ -33,6 +33,9 @@ data class Country(
       }
     }
 
+  val areWhatsAppRemindersSupported: Boolean
+    get() = isoCountryCode == INDIA
+
   companion object {
     const val INDIA = "IN"
     const val BANGLADESH = "BD"

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
@@ -240,10 +240,10 @@ class PatientEntryScreen(context: Context, attrs: AttributeSet) : RelativeLayout
   }
 
   private fun setConsentLabelText() {
-    val consentLabelTextResId = when (country.isoCountryCode) {
-      Country.BANGLADESH -> R.string.patiententry_consent_sms_reminders
-      else -> R.string.patiententry_consent_whatsapp_sms_reminders
-    }
+    val consentLabelTextResId = if (country.areWhatsAppRemindersSupported)
+      R.string.patiententry_consent_whatsapp_sms_reminders
+    else
+      R.string.patiententry_consent_sms_reminders
     consentLabel.setText(consentLabelTextResId)
   }
 


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/1535/remove-whatsapp-legal-text-for-ethiopia