### PR TITLE
Change `ModelSync` instances to be tagged instead of grouped

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/di/TestSyncConfigModule.kt
+++ b/app/src/androidTest/java/org/simple/clinic/di/TestSyncConfigModule.kt
@@ -3,7 +3,7 @@ package org.simple.clinic.di
 import dagger.Module
 import dagger.Provides
 import org.simple.clinic.sync.SyncConfig
-import org.simple.clinic.sync.SyncGroup
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.sync.SyncInterval
 import javax.inject.Named
 
@@ -16,7 +16,7 @@ class TestSyncConfigModule {
     return SyncConfig(
         syncInterval = SyncInterval.FREQUENT,
         batchSize = 1000,
-        syncGroup = SyncGroup.FREQUENT
+        syncTag = SyncTag.FREQUENT
     )
   }
 
@@ -26,7 +26,7 @@ class TestSyncConfigModule {
     return SyncConfig(
         syncInterval = SyncInterval.DAILY,
         batchSize = 1000,
-        syncGroup = SyncGroup.DAILY
+        syncTag = SyncTag.DAILY
     )
   }
 }

--- a/app/src/androidTest/java/org/simple/clinic/di/TestSyncConfigModule.kt
+++ b/app/src/androidTest/java/org/simple/clinic/di/TestSyncConfigModule.kt
@@ -3,7 +3,6 @@ package org.simple.clinic.di
 import dagger.Module
 import dagger.Provides
 import org.simple.clinic.sync.SyncConfig
-import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.sync.SyncInterval
 import javax.inject.Named
 
@@ -15,8 +14,7 @@ class TestSyncConfigModule {
   fun frequentSyncConfig(): SyncConfig {
     return SyncConfig(
         syncInterval = SyncInterval.FREQUENT,
-        batchSize = 1000,
-        syncTag = SyncTag.FREQUENT
+        batchSize = 1000
     )
   }
 
@@ -25,8 +23,7 @@ class TestSyncConfigModule {
   fun dailySyncConfig(): SyncConfig {
     return SyncConfig(
         syncInterval = SyncInterval.DAILY,
-        batchSize = 1000,
-        syncTag = SyncTag.DAILY
+        batchSize = 1000
     )
   }
 }

--- a/app/src/androidTest/java/org/simple/clinic/sync/AppointmentSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/AppointmentSyncIntegrationTest.kt
@@ -52,8 +52,7 @@ class AppointmentSyncIntegrationTest {
   private val batchSize = 3
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
-      batchSize = batchSize,
-      syncTag = SyncTag.FREQUENT
+      batchSize = batchSize
   )
 
   private val currentFacilityUuid: UUID by unsafeLazy { userSession.loggedInUserImmediate()!!.currentFacilityUuid }

--- a/app/src/androidTest/java/org/simple/clinic/sync/AppointmentSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/AppointmentSyncIntegrationTest.kt
@@ -53,7 +53,7 @@ class AppointmentSyncIntegrationTest {
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
       batchSize = batchSize,
-      syncGroup = SyncGroup.FREQUENT
+      syncTag = SyncTag.FREQUENT
   )
 
   private val currentFacilityUuid: UUID by unsafeLazy { userSession.loggedInUserImmediate()!!.currentFacilityUuid }

--- a/app/src/androidTest/java/org/simple/clinic/sync/BloodPressureSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/BloodPressureSyncIntegrationTest.kt
@@ -52,8 +52,7 @@ class BloodPressureSyncIntegrationTest {
   private val batchSize = 3
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
-      batchSize = batchSize,
-      syncTag = SyncTag.FREQUENT
+      batchSize = batchSize
   )
 
   private val currentFacilityUuid: UUID by unsafeLazy { userSession.loggedInUserImmediate()!!.currentFacilityUuid }

--- a/app/src/androidTest/java/org/simple/clinic/sync/BloodPressureSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/BloodPressureSyncIntegrationTest.kt
@@ -53,7 +53,7 @@ class BloodPressureSyncIntegrationTest {
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
       batchSize = batchSize,
-      syncGroup = SyncGroup.FREQUENT
+      syncTag = SyncTag.FREQUENT
   )
 
   private val currentFacilityUuid: UUID by unsafeLazy { userSession.loggedInUserImmediate()!!.currentFacilityUuid }

--- a/app/src/androidTest/java/org/simple/clinic/sync/BloodSugarSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/BloodSugarSyncIntegrationTest.kt
@@ -52,8 +52,7 @@ class BloodSugarSyncIntegrationTest {
   private val batchSize = 3
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
-      batchSize = batchSize,
-      syncTag = SyncTag.FREQUENT
+      batchSize = batchSize
   )
 
   private val currentFacilityUuid: UUID by unsafeLazy { userSession.loggedInUserImmediate()!!.currentFacilityUuid }

--- a/app/src/androidTest/java/org/simple/clinic/sync/BloodSugarSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/BloodSugarSyncIntegrationTest.kt
@@ -53,7 +53,7 @@ class BloodSugarSyncIntegrationTest {
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
       batchSize = batchSize,
-      syncGroup = SyncGroup.FREQUENT
+      syncTag = SyncTag.FREQUENT
   )
 
   private val currentFacilityUuid: UUID by unsafeLazy { userSession.loggedInUserImmediate()!!.currentFacilityUuid }

--- a/app/src/androidTest/java/org/simple/clinic/sync/MedicalHistorySyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/MedicalHistorySyncIntegrationTest.kt
@@ -60,8 +60,7 @@ class MedicalHistorySyncIntegrationTest {
   private val batchSize = 3
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
-      batchSize = batchSize,
-      syncTag = SyncTag.FREQUENT
+      batchSize = batchSize
   )
 
   @Before

--- a/app/src/androidTest/java/org/simple/clinic/sync/MedicalHistorySyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/MedicalHistorySyncIntegrationTest.kt
@@ -61,7 +61,7 @@ class MedicalHistorySyncIntegrationTest {
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
       batchSize = batchSize,
-      syncGroup = SyncGroup.FREQUENT
+      syncTag = SyncTag.FREQUENT
   )
 
   @Before

--- a/app/src/androidTest/java/org/simple/clinic/sync/PatientSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/PatientSyncIntegrationTest.kt
@@ -52,8 +52,7 @@ class PatientSyncIntegrationTest {
   private val batchSize = 3
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
-      batchSize = batchSize,
-      syncTag = SyncTag.FREQUENT
+      batchSize = batchSize
   )
 
   private val currentFacilityUuid: UUID by unsafeLazy { userSession.loggedInUserImmediate()!!.currentFacilityUuid }

--- a/app/src/androidTest/java/org/simple/clinic/sync/PatientSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/PatientSyncIntegrationTest.kt
@@ -53,7 +53,7 @@ class PatientSyncIntegrationTest {
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
       batchSize = batchSize,
-      syncGroup = SyncGroup.FREQUENT
+      syncTag = SyncTag.FREQUENT
   )
 
   private val currentFacilityUuid: UUID by unsafeLazy { userSession.loggedInUserImmediate()!!.currentFacilityUuid }

--- a/app/src/androidTest/java/org/simple/clinic/sync/PrescriptionSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/PrescriptionSyncIntegrationTest.kt
@@ -53,7 +53,7 @@ class PrescriptionSyncIntegrationTest {
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
       batchSize = batchSize,
-      syncGroup = SyncGroup.FREQUENT
+      syncTag = SyncTag.FREQUENT
   )
 
   private val currentFacilityUuid: UUID by unsafeLazy { userSession.loggedInUserImmediate()!!.currentFacilityUuid }

--- a/app/src/androidTest/java/org/simple/clinic/sync/PrescriptionSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/PrescriptionSyncIntegrationTest.kt
@@ -52,8 +52,7 @@ class PrescriptionSyncIntegrationTest {
   private val batchSize = 3
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
-      batchSize = batchSize,
-      syncTag = SyncTag.FREQUENT
+      batchSize = batchSize
   )
 
   private val currentFacilityUuid: UUID by unsafeLazy { userSession.loggedInUserImmediate()!!.currentFacilityUuid }

--- a/app/src/androidTest/java/org/simple/clinic/sync/ProtocolSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/ProtocolSyncIntegrationTest.kt
@@ -48,8 +48,7 @@ class ProtocolSyncIntegrationTest {
   private val batchSize = 3
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
-      batchSize = batchSize,
-      syncTag = SyncTag.FREQUENT
+      batchSize = batchSize
   )
 
   @Before

--- a/app/src/androidTest/java/org/simple/clinic/sync/ProtocolSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/ProtocolSyncIntegrationTest.kt
@@ -49,7 +49,7 @@ class ProtocolSyncIntegrationTest {
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
       batchSize = batchSize,
-      syncGroup = SyncGroup.FREQUENT
+      syncTag = SyncTag.FREQUENT
   )
 
   @Before

--- a/app/src/androidTest/java/org/simple/clinic/sync/TeleconsultationSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/TeleconsultationSyncIntegrationTest.kt
@@ -41,8 +41,7 @@ class TeleconsultationSyncIntegrationTest {
   private val batchSize = 3
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
-      batchSize = batchSize,
-      syncTag = SyncTag.FREQUENT
+      batchSize = batchSize
   )
 
   @Before

--- a/app/src/androidTest/java/org/simple/clinic/sync/TeleconsultationSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/sync/TeleconsultationSyncIntegrationTest.kt
@@ -42,7 +42,7 @@ class TeleconsultationSyncIntegrationTest {
   private val config = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
       batchSize = batchSize,
-      syncGroup = SyncGroup.FREQUENT
+      syncTag = SyncTag.FREQUENT
   )
 
   @Before

--- a/app/src/androidTest/java/org/simple/clinic/teleconsultlog/teleconsultrecord/TeleconsultRecordSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/teleconsultlog/teleconsultrecord/TeleconsultRecordSyncIntegrationTest.kt
@@ -14,7 +14,6 @@ import org.simple.clinic.rules.ServerAuthenticationRule
 import org.simple.clinic.storage.Timestamps
 import org.simple.clinic.sync.SyncConfig
 import org.simple.clinic.sync.SyncCoordinator
-import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.sync.SyncInterval
 import org.simple.clinic.util.Rules
 import org.simple.clinic.util.TestUtcClock
@@ -47,8 +46,7 @@ class TeleconsultRecordSyncIntegrationTest {
   private val batchSize = 0
   private val config = SyncConfig(
       syncInterval = SyncInterval.DAILY,
-      batchSize = batchSize,
-      syncTag = SyncTag.DAILY
+      batchSize = batchSize
   )
 
   @Before

--- a/app/src/androidTest/java/org/simple/clinic/teleconsultlog/teleconsultrecord/TeleconsultRecordSyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/teleconsultlog/teleconsultrecord/TeleconsultRecordSyncIntegrationTest.kt
@@ -14,7 +14,7 @@ import org.simple.clinic.rules.ServerAuthenticationRule
 import org.simple.clinic.storage.Timestamps
 import org.simple.clinic.sync.SyncConfig
 import org.simple.clinic.sync.SyncCoordinator
-import org.simple.clinic.sync.SyncGroup
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.sync.SyncInterval
 import org.simple.clinic.util.Rules
 import org.simple.clinic.util.TestUtcClock
@@ -48,7 +48,7 @@ class TeleconsultRecordSyncIntegrationTest {
   private val config = SyncConfig(
       syncInterval = SyncInterval.DAILY,
       batchSize = batchSize,
-      syncGroup = SyncGroup.DAILY
+      syncTag = SyncTag.DAILY
   )
 
   @Before

--- a/app/src/main/java/org/simple/clinic/bloodsugar/sync/BloodSugarSync.kt
+++ b/app/src/main/java/org/simple/clinic/bloodsugar/sync/BloodSugarSync.kt
@@ -7,6 +7,7 @@ import org.simple.clinic.bloodsugar.BloodSugarRepository
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
 import org.simple.clinic.sync.SyncCoordinator
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.read
 import javax.inject.Inject
@@ -40,6 +41,8 @@ class BloodSugarSync @Inject constructor(
   }
 
   override fun syncConfig(): SyncConfig = config
+
+  override fun syncTag() = SyncTag.FREQUENT
 
   private fun toRequest(measurements: List<BloodSugarMeasurement>): BloodSugarPushRequest {
     val payloads = measurements.map { it.toPayload() }

--- a/app/src/main/java/org/simple/clinic/bloodsugar/sync/BloodSugarSync.kt
+++ b/app/src/main/java/org/simple/clinic/bloodsugar/sync/BloodSugarSync.kt
@@ -42,7 +42,7 @@ class BloodSugarSync @Inject constructor(
 
   override fun syncConfig(): SyncConfig = config
 
-  override fun syncTag() = SyncTag.FREQUENT
+  override fun syncTags() = setOf(SyncTag.FREQUENT)
 
   private fun toRequest(measurements: List<BloodSugarMeasurement>): BloodSugarPushRequest {
     val payloads = measurements.map { it.toPayload() }

--- a/app/src/main/java/org/simple/clinic/bp/sync/BloodPressureSync.kt
+++ b/app/src/main/java/org/simple/clinic/bp/sync/BloodPressureSync.kt
@@ -40,7 +40,7 @@ class BloodPressureSync @Inject constructor(
 
   override fun syncConfig(): SyncConfig = config
 
-  override fun syncTag() = SyncTag.FREQUENT
+  override fun syncTags() = setOf(SyncTag.FREQUENT)
 
   private fun toRequest(measurements: List<BloodPressureMeasurement>): BloodPressurePushRequest {
     val payloads = measurements.map { it.toPayload() }

--- a/app/src/main/java/org/simple/clinic/bp/sync/BloodPressureSync.kt
+++ b/app/src/main/java/org/simple/clinic/bp/sync/BloodPressureSync.kt
@@ -7,6 +7,7 @@ import org.simple.clinic.bp.BloodPressureRepository
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
 import org.simple.clinic.sync.SyncCoordinator
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.read
 import javax.inject.Inject
@@ -38,6 +39,8 @@ class BloodPressureSync @Inject constructor(
   }
 
   override fun syncConfig(): SyncConfig = config
+
+  override fun syncTag() = SyncTag.FREQUENT
 
   private fun toRequest(measurements: List<BloodPressureMeasurement>): BloodPressurePushRequest {
     val payloads = measurements.map { it.toPayload() }

--- a/app/src/main/java/org/simple/clinic/drugs/sync/PrescriptionSync.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/sync/PrescriptionSync.kt
@@ -42,7 +42,7 @@ class PrescriptionSync @Inject constructor(
 
   override fun syncConfig(): SyncConfig = config
 
-  override fun syncTag() = SyncTag.FREQUENT
+  override fun syncTags() = setOf(SyncTag.FREQUENT)
 
   private fun toRequest(drugs: List<PrescribedDrug>): PrescriptionPushRequest {
     val payloads = drugs.map { it.toPayload() }

--- a/app/src/main/java/org/simple/clinic/drugs/sync/PrescriptionSync.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/sync/PrescriptionSync.kt
@@ -7,6 +7,7 @@ import org.simple.clinic.drugs.PrescriptionRepository
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
 import org.simple.clinic.sync.SyncCoordinator
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.read
 import javax.inject.Inject
@@ -40,6 +41,8 @@ class PrescriptionSync @Inject constructor(
   }
 
   override fun syncConfig(): SyncConfig = config
+
+  override fun syncTag() = SyncTag.FREQUENT
 
   private fun toRequest(drugs: List<PrescribedDrug>): PrescriptionPushRequest {
     val payloads = drugs.map { it.toPayload() }

--- a/app/src/main/java/org/simple/clinic/facility/FacilitySync.kt
+++ b/app/src/main/java/org/simple/clinic/facility/FacilitySync.kt
@@ -41,7 +41,7 @@ class FacilitySync @Inject constructor(
 
   override fun syncConfig(): SyncConfig = config
 
-  override fun syncTag() = SyncTag.DAILY
+  override fun syncTags() = setOf(SyncTag.DAILY)
 
   fun pullWithResult(): FacilityPullResult {
     return try {

--- a/app/src/main/java/org/simple/clinic/facility/FacilitySync.kt
+++ b/app/src/main/java/org/simple/clinic/facility/FacilitySync.kt
@@ -5,6 +5,7 @@ import io.reactivex.Completable
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
 import org.simple.clinic.sync.SyncCoordinator
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.read
 import java.io.IOException
@@ -39,6 +40,8 @@ class FacilitySync @Inject constructor(
   }
 
   override fun syncConfig(): SyncConfig = config
+
+  override fun syncTag() = SyncTag.DAILY
 
   fun pullWithResult(): FacilityPullResult {
     return try {

--- a/app/src/main/java/org/simple/clinic/help/HelpSync.kt
+++ b/app/src/main/java/org/simple/clinic/help/HelpSync.kt
@@ -36,7 +36,7 @@ class HelpSync @Inject constructor(
 
   override fun syncConfig(): SyncConfig = config
 
-  override fun syncTag() = SyncTag.DAILY
+  override fun syncTags() = setOf(SyncTag.DAILY)
 
   fun pullWithResult(): Single<HelpPullResult> {
     return Completable

--- a/app/src/main/java/org/simple/clinic/help/HelpSync.kt
+++ b/app/src/main/java/org/simple/clinic/help/HelpSync.kt
@@ -4,6 +4,7 @@ import io.reactivex.Completable
 import io.reactivex.Single
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
+import org.simple.clinic.sync.SyncTag
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Named
@@ -34,6 +35,8 @@ class HelpSync @Inject constructor(
   }
 
   override fun syncConfig(): SyncConfig = config
+
+  override fun syncTag() = SyncTag.DAILY
 
   fun pullWithResult(): Single<HelpPullResult> {
     return Completable

--- a/app/src/main/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryEffectHandler.kt
@@ -11,7 +11,7 @@ import org.simple.clinic.medicalhistory.MedicalHistoryRepository
 import org.simple.clinic.medicalhistory.OngoingMedicalHistoryEntry
 import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.sync.DataSync
-import org.simple.clinic.sync.SyncGroup.FREQUENT
+import org.simple.clinic.sync.SyncTag.FREQUENT
 import org.simple.clinic.user.User
 import org.simple.clinic.util.scheduler.SchedulersProvider
 import org.simple.clinic.uuid.UuidGenerator

--- a/app/src/main/java/org/simple/clinic/medicalhistory/sync/MedicalHistorySync.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/sync/MedicalHistorySync.kt
@@ -8,6 +8,7 @@ import org.simple.clinic.medicalhistory.MedicalHistoryRepository
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
 import org.simple.clinic.sync.SyncCoordinator
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.read
 import javax.inject.Inject
@@ -41,6 +42,8 @@ class MedicalHistorySync @Inject constructor(
   }
 
   override fun syncConfig(): SyncConfig = config
+
+  override fun syncTag() = SyncTag.FREQUENT
 
   private fun toRequest(histories: List<MedicalHistory>): MedicalHistoryPushRequest {
     val payloads = histories

--- a/app/src/main/java/org/simple/clinic/medicalhistory/sync/MedicalHistorySync.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/sync/MedicalHistorySync.kt
@@ -43,7 +43,7 @@ class MedicalHistorySync @Inject constructor(
 
   override fun syncConfig(): SyncConfig = config
 
-  override fun syncTag() = SyncTag.FREQUENT
+  override fun syncTags() = setOf(SyncTag.FREQUENT)
 
   private fun toRequest(histories: List<MedicalHistory>): MedicalHistoryPushRequest {
     val payloads = histories

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentSync.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentSync.kt
@@ -40,7 +40,7 @@ class AppointmentSync @Inject constructor(
 
   override fun syncConfig(): SyncConfig = config
 
-  override fun syncTag() = SyncTag.FREQUENT
+  override fun syncTags() = setOf(SyncTag.FREQUENT)
 
   private fun toRequest(appointments: List<Appointment>): AppointmentPushRequest {
     val payloads = appointments

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentSync.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentSync.kt
@@ -5,6 +5,7 @@ import io.reactivex.Completable
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
 import org.simple.clinic.sync.SyncCoordinator
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.read
 import javax.inject.Inject
@@ -38,6 +39,8 @@ class AppointmentSync @Inject constructor(
   }
 
   override fun syncConfig(): SyncConfig = config
+
+  override fun syncTag() = SyncTag.FREQUENT
 
   private fun toRequest(appointments: List<Appointment>): AppointmentPushRequest {
     val payloads = appointments

--- a/app/src/main/java/org/simple/clinic/patient/sync/PatientSync.kt
+++ b/app/src/main/java/org/simple/clinic/patient/sync/PatientSync.kt
@@ -43,7 +43,7 @@ class PatientSync @Inject constructor(
 
   override fun syncConfig(): SyncConfig = config
 
-  override fun syncTag() = SyncTag.FREQUENT
+  override fun syncTags() = setOf(SyncTag.FREQUENT)
 
   private fun toRequest(patients: List<PatientProfile>): PatientPushRequest {
     return PatientPushRequest(

--- a/app/src/main/java/org/simple/clinic/patient/sync/PatientSync.kt
+++ b/app/src/main/java/org/simple/clinic/patient/sync/PatientSync.kt
@@ -8,6 +8,7 @@ import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
 import org.simple.clinic.sync.SyncCoordinator
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.read
 import javax.inject.Inject
@@ -41,6 +42,8 @@ class PatientSync @Inject constructor(
   }
 
   override fun syncConfig(): SyncConfig = config
+
+  override fun syncTag() = SyncTag.FREQUENT
 
   private fun toRequest(patients: List<PatientProfile>): PatientPushRequest {
     return PatientPushRequest(

--- a/app/src/main/java/org/simple/clinic/protocol/sync/ProtocolSync.kt
+++ b/app/src/main/java/org/simple/clinic/protocol/sync/ProtocolSync.kt
@@ -7,6 +7,7 @@ import org.simple.clinic.protocol.ProtocolSyncApi
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
 import org.simple.clinic.sync.SyncCoordinator
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.read
 import javax.inject.Inject
@@ -36,4 +37,6 @@ class ProtocolSync @Inject constructor(
   }
 
   override fun syncConfig(): SyncConfig = config
+
+  override fun syncTag() = SyncTag.DAILY
 }

--- a/app/src/main/java/org/simple/clinic/protocol/sync/ProtocolSync.kt
+++ b/app/src/main/java/org/simple/clinic/protocol/sync/ProtocolSync.kt
@@ -38,5 +38,5 @@ class ProtocolSync @Inject constructor(
 
   override fun syncConfig(): SyncConfig = config
 
-  override fun syncTag() = SyncTag.DAILY
+  override fun syncTags() = setOf(SyncTag.DAILY)
 }

--- a/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
+++ b/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
@@ -28,8 +28,7 @@ class RemoteConfigSync @Inject constructor(
   override fun syncConfig(): SyncConfig {
     return SyncConfig(
         syncInterval = SyncInterval.FREQUENT,
-        batchSize = 0, // Unused for remote config sync
-        syncTag = SyncTag.FREQUENT
+        batchSize = 0
     )
   }
 

--- a/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
+++ b/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
@@ -3,8 +3,8 @@ package org.simple.clinic.remoteconfig
 import io.reactivex.Completable
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
-import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.sync.SyncInterval
+import org.simple.clinic.sync.SyncTag
 import javax.inject.Inject
 
 class RemoteConfigSync @Inject constructor(
@@ -32,4 +32,6 @@ class RemoteConfigSync @Inject constructor(
         syncTag = SyncTag.FREQUENT
     )
   }
+
+  override fun syncTag() = SyncTag.FREQUENT
 }

--- a/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
+++ b/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
@@ -3,7 +3,7 @@ package org.simple.clinic.remoteconfig
 import io.reactivex.Completable
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
-import org.simple.clinic.sync.SyncGroup
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.sync.SyncInterval
 import javax.inject.Inject
 
@@ -29,7 +29,7 @@ class RemoteConfigSync @Inject constructor(
     return SyncConfig(
         syncInterval = SyncInterval.FREQUENT,
         batchSize = 0, // Unused for remote config sync
-        syncGroup = SyncGroup.FREQUENT
+        syncTag = SyncTag.FREQUENT
     )
   }
 }

--- a/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
+++ b/app/src/main/java/org/simple/clinic/remoteconfig/RemoteConfigSync.kt
@@ -32,5 +32,5 @@ class RemoteConfigSync @Inject constructor(
     )
   }
 
-  override fun syncTag() = SyncTag.FREQUENT
+  override fun syncTags() = setOf(SyncTag.FREQUENT)
 }

--- a/app/src/main/java/org/simple/clinic/reports/ReportsSync.kt
+++ b/app/src/main/java/org/simple/clinic/reports/ReportsSync.kt
@@ -35,5 +35,5 @@ class ReportsSync @Inject constructor(
 
   override fun syncConfig(): SyncConfig = config
 
-  override fun syncTag() = SyncTag.FREQUENT
+  override fun syncTags() = setOf(SyncTag.FREQUENT)
 }

--- a/app/src/main/java/org/simple/clinic/reports/ReportsSync.kt
+++ b/app/src/main/java/org/simple/clinic/reports/ReportsSync.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.reports
 import io.reactivex.Completable
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
+import org.simple.clinic.sync.SyncTag
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -33,4 +34,6 @@ class ReportsSync @Inject constructor(
   }
 
   override fun syncConfig(): SyncConfig = config
+
+  override fun syncTag() = SyncTag.FREQUENT
 }

--- a/app/src/main/java/org/simple/clinic/settings/changelanguage/ChangeLanguageEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/settings/changelanguage/ChangeLanguageEffectHandler.kt
@@ -7,7 +7,7 @@ import io.reactivex.ObservableTransformer
 import io.reactivex.Scheduler
 import org.simple.clinic.settings.SettingsRepository
 import org.simple.clinic.sync.DataSync
-import org.simple.clinic.sync.SyncGroup.DAILY
+import org.simple.clinic.sync.SyncTag.DAILY
 import org.simple.clinic.util.scheduler.SchedulersProvider
 
 class ChangeLanguageEffectHandler @AssistedInject constructor(

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
@@ -21,7 +21,7 @@ import org.simple.clinic.patient.businessid.Identifier.IdentifierType.BpPassport
 import org.simple.clinic.summary.addphone.MissingPhoneReminderRepository
 import org.simple.clinic.summary.teleconsultation.sync.TeleconsultationFacilityRepository
 import org.simple.clinic.sync.DataSync
-import org.simple.clinic.sync.SyncGroup.FREQUENT
+import org.simple.clinic.sync.SyncTag.FREQUENT
 import org.simple.clinic.user.User
 import org.simple.clinic.util.Just
 import org.simple.clinic.util.Optional

--- a/app/src/main/java/org/simple/clinic/summary/teleconsultation/sync/TeleconsultationSync.kt
+++ b/app/src/main/java/org/simple/clinic/summary/teleconsultation/sync/TeleconsultationSync.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.summary.teleconsultation.sync
 import io.reactivex.Completable
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.util.read
 import javax.inject.Inject
 import javax.inject.Named
@@ -35,4 +36,6 @@ class TeleconsultationSync @Inject constructor(
   }
 
   override fun syncConfig() = config
+
+  override fun syncTag() = SyncTag.DAILY
 }

--- a/app/src/main/java/org/simple/clinic/summary/teleconsultation/sync/TeleconsultationSync.kt
+++ b/app/src/main/java/org/simple/clinic/summary/teleconsultation/sync/TeleconsultationSync.kt
@@ -37,5 +37,5 @@ class TeleconsultationSync @Inject constructor(
 
   override fun syncConfig() = config
 
-  override fun syncTag() = SyncTag.DAILY
+  override fun syncTags() = setOf(SyncTag.DAILY)
 }

--- a/app/src/main/java/org/simple/clinic/sync/DataSync.kt
+++ b/app/src/main/java/org/simple/clinic/sync/DataSync.kt
@@ -73,7 +73,7 @@ class DataSync(
   }
 
   private fun syncsForGroup(syncTag: SyncTag): Completable {
-    val syncsInGroup = modelSyncs.filter { it.syncTag() == syncTag }
+    val syncsInGroup = modelSyncs.filter { syncTag in it.syncTags() }
 
     return Single
         .fromCallable { userSession.loggedInUserImmediate().toOptional() }

--- a/app/src/main/java/org/simple/clinic/sync/DataSync.kt
+++ b/app/src/main/java/org/simple/clinic/sync/DataSync.kt
@@ -73,7 +73,7 @@ class DataSync(
   }
 
   private fun syncsForGroup(syncTag: SyncTag): Completable {
-    val syncsInGroup = modelSyncs.filter { it.syncConfig().syncTag == syncTag }
+    val syncsInGroup = modelSyncs.filter { it.syncTag() == syncTag }
 
     return Single
         .fromCallable { userSession.loggedInUserImmediate().toOptional() }

--- a/app/src/main/java/org/simple/clinic/sync/ModelSync.kt
+++ b/app/src/main/java/org/simple/clinic/sync/ModelSync.kt
@@ -17,5 +17,5 @@ interface ModelSync {
   fun push()
   fun pull()
   fun syncConfig(): SyncConfig
-  fun syncTag(): SyncTag
+  fun syncTags(): Set<SyncTag>
 }

--- a/app/src/main/java/org/simple/clinic/sync/ModelSync.kt
+++ b/app/src/main/java/org/simple/clinic/sync/ModelSync.kt
@@ -17,4 +17,5 @@ interface ModelSync {
   fun push()
   fun pull()
   fun syncConfig(): SyncConfig
+  fun syncTag(): SyncTag
 }

--- a/app/src/main/java/org/simple/clinic/sync/SyncConfig.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncConfig.kt
@@ -3,5 +3,5 @@ package org.simple.clinic.sync
 data class SyncConfig(
     val syncInterval: SyncInterval,
     val batchSize: Int,
-    val syncGroup: SyncGroup
+    val syncTag: SyncTag
 )

--- a/app/src/main/java/org/simple/clinic/sync/SyncConfig.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncConfig.kt
@@ -2,6 +2,5 @@ package org.simple.clinic.sync
 
 data class SyncConfig(
     val syncInterval: SyncInterval,
-    val batchSize: Int,
-    val syncTag: SyncTag
+    val batchSize: Int
 )

--- a/app/src/main/java/org/simple/clinic/sync/SyncConfigModule.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncConfigModule.kt
@@ -14,8 +14,7 @@ class SyncConfigModule {
   fun frequentSyncConfig(syncModuleConfig: SyncModuleConfig): SyncConfig {
     return SyncConfig(
         syncInterval = SyncInterval.FREQUENT,
-        batchSize = syncModuleConfig.frequentSyncBatchSize,
-        syncTag = SyncTag.FREQUENT
+        batchSize = syncModuleConfig.frequentSyncBatchSize
     )
   }
 
@@ -24,8 +23,7 @@ class SyncConfigModule {
   fun dailySyncConfig(syncModuleConfig: SyncModuleConfig): SyncConfig {
     return SyncConfig(
         syncInterval = SyncInterval.DAILY,
-        batchSize = syncModuleConfig.dailySyncBatchSize,
-        syncTag = SyncTag.DAILY
+        batchSize = syncModuleConfig.dailySyncBatchSize
     )
   }
 

--- a/app/src/main/java/org/simple/clinic/sync/SyncConfigModule.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncConfigModule.kt
@@ -15,7 +15,7 @@ class SyncConfigModule {
     return SyncConfig(
         syncInterval = SyncInterval.FREQUENT,
         batchSize = syncModuleConfig.frequentSyncBatchSize,
-        syncGroup = SyncGroup.FREQUENT
+        syncTag = SyncTag.FREQUENT
     )
   }
 
@@ -25,7 +25,7 @@ class SyncConfigModule {
     return SyncConfig(
         syncInterval = SyncInterval.DAILY,
         batchSize = syncModuleConfig.dailySyncBatchSize,
-        syncGroup = SyncGroup.DAILY
+        syncTag = SyncTag.DAILY
     )
   }
 

--- a/app/src/main/java/org/simple/clinic/sync/SyncInterval.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncInterval.kt
@@ -3,6 +3,12 @@ package org.simple.clinic.sync
 import java.time.Duration
 
 enum class SyncInterval(val frequency: Duration, val backOffDelay: Duration) {
+  /*
+  * If you decide to rename these values, keep in mind that the names of
+  * these enums are persisted by WorkManager in org.simple.clinic.sync.SyncScheduler
+  * to uniquely identify periodic syncs. You might need to write some
+  * additional code to handle this scenario.
+  **/
   FREQUENT(frequency = Duration.ofMinutes(16L), backOffDelay = Duration.ofMinutes(5L)),
   DAILY(frequency = Duration.ofDays(1L), backOffDelay = Duration.ofMinutes(5L));
 

--- a/app/src/main/java/org/simple/clinic/sync/SyncScheduler.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncScheduler.kt
@@ -21,8 +21,8 @@ class SyncScheduler @Inject constructor(
     return Observable
         .fromIterable(syncs)
         .map { it.syncConfig() }
-        .distinct { it.syncGroup }
-        .map { config -> createWorkRequest(config) to config.syncGroup.name }
+        .distinct { it.syncTag }
+        .map { config -> createWorkRequest(config) to config.syncTag.name }
         .toList()
         .doOnSuccess { cancelPreviouslyScheduledPeriodicWork() }
         .flatMapCompletable(this::scheduleWorkRequests)

--- a/app/src/main/java/org/simple/clinic/sync/SyncScheduler.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncScheduler.kt
@@ -21,8 +21,8 @@ class SyncScheduler @Inject constructor(
     return Observable
         .fromIterable(syncs)
         .map { it.syncConfig() }
-        .distinct { it.syncTag }
-        .map { config -> createWorkRequest(config) to config.syncTag.name }
+        .distinct { it.syncInterval }
+        .map { config -> createWorkRequest(config) to config.syncInterval.name }
         .toList()
         .doOnSuccess { cancelPreviouslyScheduledPeriodicWork() }
         .flatMapCompletable(this::scheduleWorkRequests)

--- a/app/src/main/java/org/simple/clinic/sync/SyncTag.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncTag.kt
@@ -1,6 +1,6 @@
 package org.simple.clinic.sync
 
-enum class SyncGroup {
+enum class SyncTag {
   FREQUENT,
   DAILY
 }

--- a/app/src/main/java/org/simple/clinic/sync/SyncWorker.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncWorker.kt
@@ -16,7 +16,7 @@ class SyncWorker(context: Context, private val workerParams: WorkerParameters) :
     fun createWorkDataForSyncConfig(syncConfig: SyncConfig): Data {
       return Data
           .Builder()
-          .putString(SYNC_GROUP, syncConfig.syncGroup.name)
+          .putString(SYNC_GROUP, syncConfig.syncTag.name)
           .build()
     }
 
@@ -47,7 +47,7 @@ class SyncWorker(context: Context, private val workerParams: WorkerParameters) :
     if (syncGroup == NO_GROUP) {
       dataSync.syncTheWorld()
     } else {
-      dataSync.sync(SyncGroup.valueOf(syncGroup))
+      dataSync.sync(SyncTag.valueOf(syncGroup))
     }
   }
 }

--- a/app/src/main/java/org/simple/clinic/sync/SyncWorker.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncWorker.kt
@@ -16,7 +16,7 @@ class SyncWorker(context: Context, private val workerParams: WorkerParameters) :
     fun createWorkDataForSyncConfig(syncConfig: SyncConfig): Data {
       return Data
           .Builder()
-          .putString(SYNC_GROUP, syncConfig.syncTag.name)
+          .putString(SYNC_GROUP, syncConfig.syncInterval.name)
           .build()
     }
 

--- a/app/src/main/java/org/simple/clinic/sync/indicator/SyncIndicatorEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/sync/indicator/SyncIndicatorEffectHandler.kt
@@ -10,7 +10,7 @@ import io.reactivex.rxkotlin.Observables
 import io.reactivex.rxkotlin.combineLatest
 import org.simple.clinic.sync.DataSync
 import org.simple.clinic.sync.LastSyncedState
-import org.simple.clinic.sync.SyncGroup
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.sync.SynceableRepository
 import org.simple.clinic.util.UtcClock
 import org.simple.clinic.util.interval
@@ -91,7 +91,7 @@ class SyncIndicatorEffectHandler @AssistedInject constructor(
   private fun startDataSync(): ObservableTransformer<InitiateDataSync, SyncIndicatorEvent> {
     return ObservableTransformer { effect ->
       effect
-          .doOnNext { dataSync.fireAndForgetSync(SyncGroup.FREQUENT) }
+          .doOnNext { dataSync.fireAndForgetSync(SyncTag.FREQUENT) }
           // We are listening for errors here after the data sync is initiated.
           // This is applicable for manual sync triggers only.
           .switchMap { dataSync.streamSyncErrors() }

--- a/app/src/main/java/org/simple/clinic/sync/indicator/SyncIndicatorStatusCalculator.kt
+++ b/app/src/main/java/org/simple/clinic/sync/indicator/SyncIndicatorStatusCalculator.kt
@@ -5,7 +5,7 @@ import io.reactivex.disposables.Disposable
 import org.simple.clinic.di.AppScope
 import org.simple.clinic.sync.DataSync
 import org.simple.clinic.sync.LastSyncedState
-import org.simple.clinic.sync.SyncGroup.FREQUENT
+import org.simple.clinic.sync.SyncTag.FREQUENT
 import org.simple.clinic.sync.SyncProgress
 import org.simple.clinic.sync.SyncProgress.FAILURE
 import org.simple.clinic.sync.SyncProgress.SUCCESS
@@ -31,7 +31,7 @@ class SyncIndicatorStatusCalculator @Inject constructor(
 
     return syncResultsStream
         .subscribeOn(schedulersProvider.io())
-        .filter { it.syncGroup == FREQUENT }
+        .filter { it.syncTag == FREQUENT }
         .map { it.syncProgress }
         .map(this::updateLastSyncedState)
         .subscribe(lastSyncedStatePreference::set)

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/teleconsultrecord/TeleconsultRecordSync.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/teleconsultrecord/TeleconsultRecordSync.kt
@@ -4,6 +4,7 @@ import io.reactivex.Completable
 import org.simple.clinic.sync.ModelSync
 import org.simple.clinic.sync.SyncConfig
 import org.simple.clinic.sync.SyncCoordinator
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.util.read
 import javax.inject.Inject
 import javax.inject.Named
@@ -81,4 +82,6 @@ class TeleconsultRecordSync @Inject constructor(
       null
     }
   }
+
+  override fun syncTag() = SyncTag.FREQUENT
 }

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/teleconsultrecord/TeleconsultRecordSync.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/teleconsultrecord/TeleconsultRecordSync.kt
@@ -83,5 +83,5 @@ class TeleconsultRecordSync @Inject constructor(
     }
   }
 
-  override fun syncTag() = SyncTag.FREQUENT
+  override fun syncTags() = setOf(SyncTag.FREQUENT)
 }

--- a/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryEffectHandlerTest.kt
@@ -10,7 +10,7 @@ import org.junit.Test
 import org.simple.clinic.TestData
 import org.simple.clinic.mobius.EffectHandlerTestCase
 import org.simple.clinic.sync.DataSync
-import org.simple.clinic.sync.SyncGroup.FREQUENT
+import org.simple.clinic.sync.SyncTag.FREQUENT
 import org.simple.clinic.util.scheduler.TrampolineSchedulersProvider
 import org.simple.clinic.uuid.FakeUuidGenerator
 import java.util.UUID

--- a/app/src/test/java/org/simple/clinic/settings/changelanguage/ChangeLanguageEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/settings/changelanguage/ChangeLanguageEffectHandlerTest.kt
@@ -16,7 +16,7 @@ import org.simple.clinic.settings.ProvidedLanguage
 import org.simple.clinic.settings.SettingsRepository
 import org.simple.clinic.settings.SystemDefaultLanguage
 import org.simple.clinic.sync.DataSync
-import org.simple.clinic.sync.SyncGroup
+import org.simple.clinic.sync.SyncTag
 import org.simple.clinic.util.scheduler.TrampolineSchedulersProvider
 
 class ChangeLanguageEffectHandlerTest {
@@ -110,7 +110,7 @@ class ChangeLanguageEffectHandlerTest {
 
     // then
     testCase.assertNoOutgoingEvents()
-    verify(dataSync).fireAndForgetSync(SyncGroup.DAILY)
+    verify(dataSync).fireAndForgetSync(SyncTag.DAILY)
     verifyZeroInteractions(uiActions)
   }
 

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
@@ -27,7 +27,7 @@ import org.simple.clinic.summary.AppointmentSheetOpenedFrom.BACK_CLICK
 import org.simple.clinic.summary.addphone.MissingPhoneReminderRepository
 import org.simple.clinic.summary.teleconsultation.sync.TeleconsultationFacilityRepository
 import org.simple.clinic.sync.DataSync
-import org.simple.clinic.sync.SyncGroup.FREQUENT
+import org.simple.clinic.sync.SyncTag.FREQUENT
 import org.simple.clinic.util.Just
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.scheduler.TrampolineSchedulersProvider

--- a/app/src/test/java/org/simple/clinic/sync/DataSyncTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/DataSyncTest.kt
@@ -721,10 +721,26 @@ class DataSyncTest {
       _name: String,
       _requiresSyncApprovedUser: Boolean = false,
       private val config: SyncConfig,
-      private val syncTag: SyncTag,
+      private val syncTags: Set<SyncTag>,
       private val pushError: Throwable? = null,
       private val pullError: Throwable? = null,
   ) : ModelSync {
+
+    constructor(
+        _name: String,
+        _requiresSyncApprovedUser: Boolean = false,
+        config: SyncConfig,
+        syncTag: SyncTag,
+        pushError: Throwable? = null,
+        pullError: Throwable? = null,
+    ): this(
+        _name = _name,
+        _requiresSyncApprovedUser = _requiresSyncApprovedUser,
+        config = config,
+        syncTags = setOf(syncTag),
+        pushError = pushError,
+        pullError = pullError
+    )
 
     override val name: String = _name
 
@@ -748,6 +764,6 @@ class DataSyncTest {
 
     override fun syncConfig(): SyncConfig = config
 
-    override fun syncTag() = syncTag
+    override fun syncTags() = syncTags
   }
 }

--- a/app/src/test/java/org/simple/clinic/sync/DataSyncTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/DataSyncTest.kt
@@ -6,6 +6,8 @@ import io.reactivex.Completable
 import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.TestData
+import org.simple.clinic.sync.SyncTag.DAILY
+import org.simple.clinic.sync.SyncTag.FREQUENT
 import org.simple.clinic.user.User
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.user.UserStatus
@@ -27,30 +29,33 @@ class DataSyncTest {
   private val frequentSyncConfig = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
       batchSize = 10,
-      syncTag = SyncTag.FREQUENT
+      syncTag = FREQUENT
   )
 
   private val dailySyncConfig = SyncConfig(
       syncInterval = SyncInterval.DAILY,
       batchSize = 10,
-      syncTag = SyncTag.DAILY
+      syncTag = DAILY
   )
 
   @Test
   fun `when syncing everything, all the model syncs should be invoked`() {
     val modelSync1 = FakeModelSync(
         _name = "sync1",
-        config = dailySyncConfig
+        config = dailySyncConfig,
+        syncTag = DAILY
     )
 
     val modelSync2 = FakeModelSync(
         _name = "sync2",
-        config = dailySyncConfig
+        config = dailySyncConfig,
+        syncTag = DAILY
     )
 
     val modelSync3 = FakeModelSync(
         _name = "sync3",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val dataSync = DataSync(
@@ -77,19 +82,22 @@ class DataSyncTest {
   fun `when syncing everything, if any of the syncs throws an error, the other syncs must not be affected`() {
     val modelSync1 = FakeModelSync(
         _name = "sync1",
-        config = dailySyncConfig
+        config = dailySyncConfig,
+        syncTag = DAILY
     )
 
     val runtimeException = RuntimeException("TEST")
     val modelSync2 = FakeModelSync(
         _name = "sync2",
         config = dailySyncConfig,
+        syncTag = DAILY,
         pullError = runtimeException
     )
 
     val modelSync3 = FakeModelSync(
         _name = "sync3",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val dataSync = DataSync(
@@ -117,21 +125,25 @@ class DataSyncTest {
   fun `when syncing a particular group, only the syncs which are a part of that group must be synced`() {
     val modelSync1 = FakeModelSync(
         _name = "sync1",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
     val modelSync2 = FakeModelSync(
         _name = "sync2",
         config = dailySyncConfig,
+        syncTag = DAILY,
         pushError = RuntimeException()
     )
     val modelSync3 = FakeModelSync(
         _name = "sync3",
         config = dailySyncConfig,
+        syncTag = DAILY,
         pullError = RuntimeException()
     )
     val modelSync4 = FakeModelSync(
         _name = "sync4",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val dataSync = DataSync(
@@ -146,7 +158,7 @@ class DataSyncTest {
         .streamSyncErrors()
         .test()
 
-    dataSync.sync(SyncTag.FREQUENT)
+    dataSync.sync(FREQUENT)
 
     syncErrors
         .assertNoErrors()
@@ -158,24 +170,28 @@ class DataSyncTest {
   fun `when syncing a particular group, errors in syncing any should not affect another syncs`() {
     val modelSync1 = FakeModelSync(
         _name = "sync1",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val runtimeException = RuntimeException("TEST")
     val modelSync2 = FakeModelSync(
         _name = "sync2",
         config = dailySyncConfig,
+        syncTag = DAILY,
         pushError = runtimeException
     )
 
     val modelSync3 = FakeModelSync(
         _name = "sync3",
         config = dailySyncConfig,
+        syncTag = DAILY,
     )
 
     val modelSync4 = FakeModelSync(
         _name = "sync4",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val dataSync = DataSync(
@@ -191,7 +207,7 @@ class DataSyncTest {
         .test()
         .assertNoErrors()
 
-    dataSync.sync(SyncTag.DAILY)
+    dataSync.sync(DAILY)
 
     syncErrors
         .assertValue(ResolvedError.Unexpected(runtimeException))
@@ -204,19 +220,22 @@ class DataSyncTest {
 
     val modelSync1 = FakeModelSync(
         _name = "sync1",
-        config = dailySyncConfig
+        config = dailySyncConfig,
+        syncTag = DAILY
     )
 
     val modelSync2 = FakeModelSync(
         _name = "sync2",
         _requiresSyncApprovedUser = true,
         config = dailySyncConfig,
+        syncTag = DAILY,
         pullError = RuntimeException("TEST"),
     )
 
     val modelSync3 = FakeModelSync(
         _name = "sync3",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val dataSync = DataSync(
@@ -251,19 +270,22 @@ class DataSyncTest {
 
     val modelSync1 = FakeModelSync(
         _name = "sync1",
-        config = dailySyncConfig
+        config = dailySyncConfig,
+        syncTag = DAILY
     )
 
     val modelSync2 = FakeModelSync(
         _name = "sync2",
         _requiresSyncApprovedUser = true,
         config = dailySyncConfig,
+        syncTag = DAILY,
         pullError = RuntimeException("TEST"),
     )
 
     val modelSync3 = FakeModelSync(
         _name = "sync3",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val dataSync = DataSync(
@@ -298,19 +320,22 @@ class DataSyncTest {
 
     val modelSync1 = FakeModelSync(
         _name = "sync1",
-        config = dailySyncConfig
+        config = dailySyncConfig,
+        syncTag = DAILY
     )
 
     val modelSync2 = FakeModelSync(
         _name = "sync2",
         _requiresSyncApprovedUser = true,
         config = dailySyncConfig,
+        syncTag = DAILY,
         pullError = RuntimeException("TEST"),
     )
 
     val modelSync3 = FakeModelSync(
         _name = "sync3",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val dataSync = DataSync(
@@ -345,19 +370,22 @@ class DataSyncTest {
 
     val modelSync1 = FakeModelSync(
         _name = "sync1",
-        config = dailySyncConfig
+        config = dailySyncConfig,
+        syncTag = DAILY
     )
 
     val modelSync2 = FakeModelSync(
         _name = "sync2",
         _requiresSyncApprovedUser = true,
         config = dailySyncConfig,
+        syncTag = DAILY,
         pullError = RuntimeException("TEST"),
     )
 
     val modelSync3 = FakeModelSync(
         _name = "sync3",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val dataSync = DataSync(
@@ -392,19 +420,22 @@ class DataSyncTest {
 
     val modelSync1 = FakeModelSync(
         _name = "sync1",
-        config = dailySyncConfig
+        config = dailySyncConfig,
+        syncTag = DAILY
     )
 
     val modelSync2 = FakeModelSync(
         _name = "sync2",
         _requiresSyncApprovedUser = true,
         config = dailySyncConfig,
+        syncTag = DAILY,
         pullError = RuntimeException("TEST"),
     )
 
     val modelSync3 = FakeModelSync(
         _name = "sync3",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val dataSync = DataSync(
@@ -439,19 +470,22 @@ class DataSyncTest {
 
     val modelSync1 = FakeModelSync(
         _name = "sync1",
-        config = dailySyncConfig
+        config = dailySyncConfig,
+        syncTag = DAILY
     )
 
     val modelSync2 = FakeModelSync(
         _name = "sync2",
         _requiresSyncApprovedUser = true,
         config = dailySyncConfig,
+        syncTag = DAILY,
         pullError = RuntimeException("TEST"),
     )
 
     val modelSync3 = FakeModelSync(
         _name = "sync3",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val dataSync = DataSync(
@@ -486,7 +520,8 @@ class DataSyncTest {
 
     val modelSync1 = FakeModelSync(
         _name = "sync1",
-        config = dailySyncConfig
+        config = dailySyncConfig,
+        syncTag = DAILY
     )
 
     val exception = RuntimeException("TEST")
@@ -494,12 +529,14 @@ class DataSyncTest {
         _name = "sync2",
         _requiresSyncApprovedUser = true,
         config = dailySyncConfig,
+        syncTag = DAILY,
         pullError = exception,
     )
 
     val modelSync3 = FakeModelSync(
         _name = "sync3",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val dataSync = DataSync(
@@ -534,19 +571,22 @@ class DataSyncTest {
 
     val modelSync1 = FakeModelSync(
         _name = "sync1",
-        config = dailySyncConfig
+        config = dailySyncConfig,
+        syncTag = DAILY
     )
 
     val modelSync2 = FakeModelSync(
         _name = "sync2",
         _requiresSyncApprovedUser = true,
         config = dailySyncConfig,
+        syncTag = DAILY,
         pullError = RuntimeException("TEST"),
     )
 
     val modelSync3 = FakeModelSync(
         _name = "sync3",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val dataSync = DataSync(
@@ -581,19 +621,22 @@ class DataSyncTest {
 
     val modelSync1 = FakeModelSync(
         _name = "sync1",
-        config = dailySyncConfig
+        config = dailySyncConfig,
+        syncTag = DAILY
     )
 
     val modelSync2 = FakeModelSync(
         _name = "sync2",
         _requiresSyncApprovedUser = true,
         config = dailySyncConfig,
+        syncTag = DAILY,
         pullError = RuntimeException("TEST"),
     )
 
     val modelSync3 = FakeModelSync(
         _name = "sync3",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val dataSync = DataSync(
@@ -621,7 +664,8 @@ class DataSyncTest {
   fun `when syncing a group, if multiple syncs throws an error, the overall sync result must be a failure`() {
     val modelSync1 = FakeModelSync(
         _name = "sync1",
-        config = frequentSyncConfig
+        config = frequentSyncConfig,
+        syncTag = FREQUENT
     )
 
     val runtimeException = RuntimeException("TEST")
@@ -630,12 +674,14 @@ class DataSyncTest {
     val modelSync2 = FakeModelSync(
         _name = "sync2",
         config = frequentSyncConfig,
+        syncTag = FREQUENT,
         pullError = runtimeException
     )
 
     val modelSync3 = FakeModelSync(
         _name = "sync3",
         config = frequentSyncConfig,
+        syncTag = FREQUENT,
         pushError = ioException
     )
 
@@ -657,7 +703,7 @@ class DataSyncTest {
         .test()
         .assertNoErrors()
 
-    dataSync.sync(SyncTag.FREQUENT)
+    dataSync.sync(FREQUENT)
 
     syncErrors
         .assertValue(ErrorResolver.resolve(ioException)) // IOException because it is a push error and pushes are executed first
@@ -666,8 +712,8 @@ class DataSyncTest {
 
     syncResults
         .assertValues(
-            DataSync.SyncGroupResult(SyncTag.FREQUENT, SyncProgress.SYNCING),
-            DataSync.SyncGroupResult(SyncTag.FREQUENT, SyncProgress.FAILURE)
+            DataSync.SyncGroupResult(FREQUENT, SyncProgress.SYNCING),
+            DataSync.SyncGroupResult(FREQUENT, SyncProgress.FAILURE)
         )
         .assertNoErrors()
         .dispose()
@@ -677,6 +723,7 @@ class DataSyncTest {
       _name: String,
       _requiresSyncApprovedUser: Boolean = false,
       private val config: SyncConfig,
+      private val syncTag: SyncTag,
       private val pushError: Throwable? = null,
       private val pullError: Throwable? = null,
   ) : ModelSync {
@@ -702,5 +749,7 @@ class DataSyncTest {
     }
 
     override fun syncConfig(): SyncConfig = config
+
+    override fun syncTag() = syncTag
   }
 }

--- a/app/src/test/java/org/simple/clinic/sync/DataSyncTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/DataSyncTest.kt
@@ -27,13 +27,13 @@ class DataSyncTest {
   private val frequentSyncConfig = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
       batchSize = 10,
-      syncGroup = SyncGroup.FREQUENT
+      syncTag = SyncTag.FREQUENT
   )
 
   private val dailySyncConfig = SyncConfig(
       syncInterval = SyncInterval.DAILY,
       batchSize = 10,
-      syncGroup = SyncGroup.DAILY
+      syncTag = SyncTag.DAILY
   )
 
   @Test
@@ -146,7 +146,7 @@ class DataSyncTest {
         .streamSyncErrors()
         .test()
 
-    dataSync.sync(SyncGroup.FREQUENT)
+    dataSync.sync(SyncTag.FREQUENT)
 
     syncErrors
         .assertNoErrors()
@@ -191,7 +191,7 @@ class DataSyncTest {
         .test()
         .assertNoErrors()
 
-    dataSync.sync(SyncGroup.DAILY)
+    dataSync.sync(SyncTag.DAILY)
 
     syncErrors
         .assertValue(ResolvedError.Unexpected(runtimeException))
@@ -657,7 +657,7 @@ class DataSyncTest {
         .test()
         .assertNoErrors()
 
-    dataSync.sync(SyncGroup.FREQUENT)
+    dataSync.sync(SyncTag.FREQUENT)
 
     syncErrors
         .assertValue(ErrorResolver.resolve(ioException)) // IOException because it is a push error and pushes are executed first
@@ -666,8 +666,8 @@ class DataSyncTest {
 
     syncResults
         .assertValues(
-            DataSync.SyncGroupResult(SyncGroup.FREQUENT, SyncProgress.SYNCING),
-            DataSync.SyncGroupResult(SyncGroup.FREQUENT, SyncProgress.FAILURE)
+            DataSync.SyncGroupResult(SyncTag.FREQUENT, SyncProgress.SYNCING),
+            DataSync.SyncGroupResult(SyncTag.FREQUENT, SyncProgress.FAILURE)
         )
         .assertNoErrors()
         .dispose()

--- a/app/src/test/java/org/simple/clinic/sync/DataSyncTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/DataSyncTest.kt
@@ -28,14 +28,12 @@ class DataSyncTest {
 
   private val frequentSyncConfig = SyncConfig(
       syncInterval = SyncInterval.FREQUENT,
-      batchSize = 10,
-      syncTag = FREQUENT
+      batchSize = 10
   )
 
   private val dailySyncConfig = SyncConfig(
       syncInterval = SyncInterval.DAILY,
-      batchSize = 10,
-      syncTag = DAILY
+      batchSize = 10
   )
 
   @Test

--- a/app/src/test/java/org/simple/clinic/sync/indicator/SyncIndicatorLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/indicator/SyncIndicatorLogicTest.kt
@@ -22,7 +22,7 @@ import org.simple.clinic.overdue.AppointmentRepository
 import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.sync.DataSync
 import org.simple.clinic.sync.LastSyncedState
-import org.simple.clinic.sync.SyncGroup.FREQUENT
+import org.simple.clinic.sync.SyncTag.FREQUENT
 import org.simple.clinic.sync.SyncProgress.FAILURE
 import org.simple.clinic.sync.SyncProgress.SUCCESS
 import org.simple.clinic.sync.SyncProgress.SYNCING

--- a/app/src/test/java/org/simple/clinic/sync/indicator/SyncIndicatorStatusCalculatorTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/indicator/SyncIndicatorStatusCalculatorTest.kt
@@ -15,9 +15,8 @@ import org.junit.runner.RunWith
 import org.simple.clinic.sync.DataSync
 import org.simple.clinic.sync.DataSync.SyncGroupResult
 import org.simple.clinic.sync.LastSyncedState
-import org.simple.clinic.sync.SyncGroup
-import org.simple.clinic.sync.SyncGroup.DAILY
-import org.simple.clinic.sync.SyncGroup.FREQUENT
+import org.simple.clinic.sync.SyncTag.DAILY
+import org.simple.clinic.sync.SyncTag.FREQUENT
 import org.simple.clinic.sync.SyncProgress
 import org.simple.clinic.sync.SyncProgress.FAILURE
 import org.simple.clinic.sync.SyncProgress.SUCCESS


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/1570/change-modelsync-to-have-a-set-of-tags-instead-of-a-single-sync-group