### PR TITLE
Fix `ProgressMaterialButton` AVD not animating when initial state is not `in-progress`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Changes
 - Made "SMS Reminders" to be the default consent label on the patient screen unless otherwise specified on a country level
 - Show toast message after saving prescription image on device
+- Fix `ProgressMaterialButton` AVD not animating when initial state is not `in-progress`
 
 ## Internal
 - Add `syncGroup` property to the `Facility` resource

--- a/app/src/main/java/org/simple/clinic/widgets/ProgressMaterialButton.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/ProgressMaterialButton.kt
@@ -53,12 +53,16 @@ class ProgressMaterialButton(
         icon = buttonIcon
         text = buttonText
         iconGravity = buttonIconGravity
+
+        progressDrawable.stop()
       }
       ButtonState.Disabled -> {
         isEnabled = false
         icon = buttonIcon
         text = buttonText
         iconGravity = buttonIconGravity
+
+        progressDrawable.stop()
       }
     }
     this.buttonState = buttonState

--- a/app/src/main/java/org/simple/clinic/widgets/ProgressMaterialButton.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/ProgressMaterialButton.kt
@@ -32,7 +32,6 @@ class ProgressMaterialButton(
     buttonState = ButtonState.values()[typeArray.getInt(R.styleable.ProgressMaterialButton_buttonState, 0)]
 
     setButtonState(buttonState)
-    progressDrawable.start()
 
     typeArray.recycle()
   }
@@ -45,6 +44,8 @@ class ProgressMaterialButton(
         icon = progressDrawable
         text = null
         iconGravity = ICON_GRAVITY_TEXT_START
+
+        progressDrawable.start()
       }
       ButtonState.Enabled -> {
         isEnabled = true


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/590/fix-progressmaterialbutton-avd-not-animating-when-initial-state-is-not-in-progress
