### PR TITLE
Delay purging of sync group data for a specified time after switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Mark strings used in prescription image as un-translatable
 - Use `ENGLISH` locale when formatting prescription date
 - Rename `TeleconsultRecord` `requestCompleted` to `requesterCompletionStatus`
+- Delay purging of data from a different sync group for a fixed duration (remotely configurable) after switching facilities
 
 ### Changes
 - Update translations: `kn-IN`, `ta-IN`, `bn-IN`, `ti`, `bn-BD`, `pa-IN`

--- a/app/src/androidTest/java/org/simple/clinic/facility/FacilityRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/facility/FacilityRepositoryAndroidTest.kt
@@ -80,8 +80,8 @@ class FacilityRepositoryAndroidTest {
     userDao.createOrUpdate(user)
 
     val facilityIds = facilities.map { it.uuid }
-    repository.setCurrentFacility(facility3).blockingAwait()
-    repository.setCurrentFacility(facility4).blockingAwait()
+    repository.setCurrentFacilityImmediate(facility3)
+    repository.setCurrentFacilityImmediate(facility4)
 
     val currentFacility = repository.currentFacility().blockingFirst()
     assertThat(currentFacility).isEqualTo(facility4)
@@ -103,9 +103,8 @@ class FacilityRepositoryAndroidTest {
     )
     userDao.createOrUpdate(user)
 
-    repository.setCurrentFacility(facility2)
-        .andThen(repository.setCurrentFacility(facility3))
-        .blockingAwait()
+    repository.setCurrentFacilityImmediate(facility2)
+    repository.setCurrentFacilityImmediate(facility3)
 
     assertThat(repository.currentFacilityImmediate()).isEqualTo(facility3)
   }
@@ -159,7 +158,7 @@ class FacilityRepositoryAndroidTest {
   }
 
   private fun associateCurrentFacilityToUser(facility: Facility) {
-    repository.setCurrentFacility(facility).blockingAwait()
+    repository.setCurrentFacilityImmediate(facility)
   }
 
   @Test

--- a/app/src/main/java/org/simple/clinic/facility/FacilityRepository.kt
+++ b/app/src/main/java/org/simple/clinic/facility/FacilityRepository.kt
@@ -51,8 +51,8 @@ class FacilityRepository @Inject constructor(
         }
   }
 
-  fun setCurrentFacility(facility: Facility): Completable {
-    return setCurrentFacility(facility.uuid)
+  fun setCurrentFacilityImmediate(facility: Facility) {
+    userDao.setCurrentFacility(facility.uuid)
   }
 
   fun setCurrentFacility(facilityUuid: UUID): Completable {

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffect.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffect.kt
@@ -9,3 +9,5 @@ data class ChangeFacilityEffect(val selectedFacility: Facility) : ConfirmFacilit
 object CloseSheet : ConfirmFacilityChangeEffect()
 
 object LoadCurrentFacility: ConfirmFacilityChangeEffect()
+
+object TouchFacilitySyncGroupSwitchedAtTime: ConfirmFacilityChangeEffect()

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffect.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffect.kt
@@ -7,3 +7,5 @@ sealed class ConfirmFacilityChangeEffect
 data class ChangeFacilityEffect(val selectedFacility: Facility) : ConfirmFacilityChangeEffect()
 
 object CloseSheet : ConfirmFacilityChangeEffect()
+
+object LoadCurrentFacility: ConfirmFacilityChangeEffect()

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandler.kt
@@ -31,6 +31,7 @@ class ConfirmFacilityChangeEffectHandler @AssistedInject constructor(
         .subtypeEffectHandler<ConfirmFacilityChangeEffect, ConfirmFacilityChangeEvent>()
         .addTransformer(ChangeFacilityEffect::class.java, changeFacility(schedulersProvider.io()))
         .addAction(CloseSheet::class.java, { uiActions.closeSheet() }, schedulersProvider.ui())
+        .addTransformer(LoadCurrentFacility::class.java, loadCurrentFacility())
         .build()
   }
 
@@ -54,5 +55,14 @@ class ConfirmFacilityChangeEffectHandler @AssistedInject constructor(
         .andThen(reportsSync.sync().onErrorComplete())
         .subscribeOn(scheduler)
         .subscribe()
+  }
+
+  private fun loadCurrentFacility(): ObservableTransformer<LoadCurrentFacility, ConfirmFacilityChangeEvent> {
+    return ObservableTransformer { effects ->
+      effects
+          .observeOn(schedulersProvider.io())
+          .map { facilityRepository.currentFacilityImmediate() }
+          .map(::CurrentFacilityLoaded)
+    }
   }
 }

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandler.kt
@@ -40,12 +40,8 @@ class ConfirmFacilityChangeEffectHandler @AssistedInject constructor(
     return ObservableTransformer { changeFacilityStream ->
       changeFacilityStream
           .map { it.selectedFacility }
-          .switchMapSingle {
-            facilityRepository
-                .setCurrentFacility(it)
-                .subscribeOn(io)
-                .toSingleDefault(it)
-          }
+          .observeOn(io)
+          .doOnNext(facilityRepository::setCurrentFacilityImmediate)
           .doOnNext { isFacilitySwitchedPreference.set(true) }
           .doOnNext { clearAndSyncReports(io) }
           .map { FacilityChanged }

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandler.kt
@@ -7,9 +7,13 @@ import com.squareup.inject.assisted.AssistedInject
 import io.reactivex.ObservableTransformer
 import io.reactivex.Scheduler
 import org.simple.clinic.facility.FacilityRepository
+import org.simple.clinic.main.TypedPreference
+import org.simple.clinic.main.TypedPreference.Type.FacilitySyncGroupSwitchedAt
 import org.simple.clinic.reports.ReportsRepository
 import org.simple.clinic.reports.ReportsSync
+import org.simple.clinic.util.Optional
 import org.simple.clinic.util.scheduler.SchedulersProvider
+import java.time.Instant
 import javax.inject.Named
 
 class ConfirmFacilityChangeEffectHandler @AssistedInject constructor(
@@ -18,7 +22,8 @@ class ConfirmFacilityChangeEffectHandler @AssistedInject constructor(
     private val reportsSync: ReportsSync,
     private val schedulersProvider: SchedulersProvider,
     @Assisted private val uiActions: ConfirmFacilityChangeUiActions,
-    @Named("is_facility_switched") private val isFacilitySwitchedPreference: Preference<Boolean>
+    @Named("is_facility_switched") private val isFacilitySwitchedPreference: Preference<Boolean>,
+    @TypedPreference(FacilitySyncGroupSwitchedAt) private val facilitySyncGroupSwitchAtPreference: Preference<Optional<Instant>>
 ) {
 
   @AssistedInject.Factory

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandler.kt
@@ -45,7 +45,7 @@ class ConfirmFacilityChangeEffectHandler @AssistedInject constructor(
           .doOnNext(facilityRepository::setCurrentFacilityImmediate)
           .doOnNext { isFacilitySwitchedPreference.set(true) }
           .doOnNext { clearAndSyncReports(io) }
-          .map { FacilityChanged }
+          .map(::FacilityChanged)
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEvent.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEvent.kt
@@ -10,3 +10,5 @@ data class FacilityChangeConfirmed(val selectedFacility: Facility) : ConfirmFaci
 data class FacilityChanged(val newFacility: Facility) : ConfirmFacilityChangeEvent()
 
 data class CurrentFacilityLoaded(val currentFacility: Facility): ConfirmFacilityChangeEvent()
+
+object FacilitySyncGroupSwitchedAtTimeTouched: ConfirmFacilityChangeEvent()

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEvent.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEvent.kt
@@ -8,3 +8,5 @@ sealed class ConfirmFacilityChangeEvent : UiEvent
 data class FacilityChangeConfirmed(val selectedFacility: Facility) : ConfirmFacilityChangeEvent()
 
 object FacilityChanged : ConfirmFacilityChangeEvent()
+
+data class CurrentFacilityLoaded(val currentFacility: Facility): ConfirmFacilityChangeEvent()

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEvent.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEvent.kt
@@ -7,6 +7,6 @@ sealed class ConfirmFacilityChangeEvent : UiEvent
 
 data class FacilityChangeConfirmed(val selectedFacility: Facility) : ConfirmFacilityChangeEvent()
 
-object FacilityChanged : ConfirmFacilityChangeEvent()
+data class FacilityChanged(val newFacility: Facility) : ConfirmFacilityChangeEvent()
 
 data class CurrentFacilityLoaded(val currentFacility: Facility): ConfirmFacilityChangeEvent()

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeInit.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeInit.kt
@@ -5,6 +5,6 @@ import com.spotify.mobius.Init
 
 class ConfirmFacilityChangeInit : Init<ConfirmFacilityChangeModel, ConfirmFacilityChangeEffect> {
   override fun init(model: ConfirmFacilityChangeModel): First<ConfirmFacilityChangeModel, ConfirmFacilityChangeEffect> {
-    return First.first(ConfirmFacilityChangeModel())
+    return First.first(ConfirmFacilityChangeModel.create())
   }
 }

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeInit.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeInit.kt
@@ -1,10 +1,16 @@
 package org.simple.clinic.facility.change.confirm
 
 import com.spotify.mobius.First
+import com.spotify.mobius.First.first
 import com.spotify.mobius.Init
 
 class ConfirmFacilityChangeInit : Init<ConfirmFacilityChangeModel, ConfirmFacilityChangeEffect> {
   override fun init(model: ConfirmFacilityChangeModel): First<ConfirmFacilityChangeModel, ConfirmFacilityChangeEffect> {
-    return First.first(ConfirmFacilityChangeModel.create())
+    val effects = mutableSetOf<ConfirmFacilityChangeEffect>()
+
+    if (!model.hasLoadedCurrentFacility)
+      effects.add(LoadCurrentFacility)
+
+    return first(model, effects)
   }
 }

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeModel.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeModel.kt
@@ -2,6 +2,16 @@ package org.simple.clinic.facility.change.confirm
 
 import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
+import org.simple.clinic.facility.Facility
 
 @Parcelize
-class ConfirmFacilityChangeModel : Parcelable
+data class ConfirmFacilityChangeModel(
+    val currentFacility: Facility?
+) : Parcelable {
+
+  companion object {
+    fun create(): ConfirmFacilityChangeModel = ConfirmFacilityChangeModel(
+        currentFacility = null
+    )
+  }
+}

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeModel.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeModel.kt
@@ -18,6 +18,10 @@ data class ConfirmFacilityChangeModel(
     )
   }
 
+  fun hasFacilitySyncGroupSwitched(newFacility: Facility): Boolean {
+    return currentFacility!!.syncGroup != newFacility.syncGroup
+  }
+
   fun currentFacilityLoaded(facility: Facility): ConfirmFacilityChangeModel {
     return copy(currentFacility = facility)
   }

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeModel.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeModel.kt
@@ -9,9 +9,16 @@ data class ConfirmFacilityChangeModel(
     val currentFacility: Facility?
 ) : Parcelable {
 
+  val hasLoadedCurrentFacility: Boolean
+    get() = currentFacility != null
+
   companion object {
     fun create(): ConfirmFacilityChangeModel = ConfirmFacilityChangeModel(
         currentFacility = null
     )
+  }
+
+  fun currentFacilityLoaded(facility: Facility): ConfirmFacilityChangeModel {
+    return copy(currentFacility = facility)
   }
 }

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeSheet.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeSheet.kt
@@ -57,7 +57,7 @@ class ConfirmFacilityChangeSheet : BottomSheetActivity(), ConfirmFacilityChangeU
   private val delegate by unsafeLazy {
     MobiusDelegate.forActivity(
         events.ofType(),
-        ConfirmFacilityChangeModel(),
+        ConfirmFacilityChangeModel.create(),
         ConfirmFacilityChangeUpdate(),
         effectHandlerFactory.create(this).build(),
         ConfirmFacilityChangeInit()

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdate.kt
@@ -1,6 +1,7 @@
 package org.simple.clinic.facility.change.confirm
 
 import com.spotify.mobius.Next
+import com.spotify.mobius.Next.noChange
 import com.spotify.mobius.Update
 import org.simple.clinic.mobius.dispatch
 
@@ -12,6 +13,7 @@ class ConfirmFacilityChangeUpdate : Update<ConfirmFacilityChangeModel, ConfirmFa
     return when (event) {
       is FacilityChangeConfirmed -> dispatch(ChangeFacilityEffect(event.selectedFacility))
       FacilityChanged -> dispatch(CloseSheet)
+      is CurrentFacilityLoaded -> noChange()
     }
   }
 }

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdate.kt
@@ -1,6 +1,7 @@
 package org.simple.clinic.facility.change.confirm
 
 import com.spotify.mobius.Next
+import com.spotify.mobius.Next.noChange
 import com.spotify.mobius.Update
 import org.simple.clinic.mobius.dispatch
 import org.simple.clinic.mobius.next
@@ -14,6 +15,7 @@ class ConfirmFacilityChangeUpdate : Update<ConfirmFacilityChangeModel, ConfirmFa
       is FacilityChangeConfirmed -> dispatch(ChangeFacilityEffect(event.selectedFacility))
       is FacilityChanged -> dispatch(CloseSheet)
       is CurrentFacilityLoaded -> next(model.currentFacilityLoaded(event.currentFacility))
+      FacilitySyncGroupSwitchedAtTimeTouched -> noChange()
     }
   }
 }

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdate.kt
@@ -1,9 +1,9 @@
 package org.simple.clinic.facility.change.confirm
 
 import com.spotify.mobius.Next
-import com.spotify.mobius.Next.noChange
 import com.spotify.mobius.Update
 import org.simple.clinic.mobius.dispatch
+import org.simple.clinic.mobius.next
 
 class ConfirmFacilityChangeUpdate : Update<ConfirmFacilityChangeModel, ConfirmFacilityChangeEvent, ConfirmFacilityChangeEffect> {
   override fun update(
@@ -13,7 +13,7 @@ class ConfirmFacilityChangeUpdate : Update<ConfirmFacilityChangeModel, ConfirmFa
     return when (event) {
       is FacilityChangeConfirmed -> dispatch(ChangeFacilityEffect(event.selectedFacility))
       FacilityChanged -> dispatch(CloseSheet)
-      is CurrentFacilityLoaded -> noChange()
+      is CurrentFacilityLoaded -> next(model.currentFacilityLoaded(event.currentFacility))
     }
   }
 }

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdate.kt
@@ -12,7 +12,7 @@ class ConfirmFacilityChangeUpdate : Update<ConfirmFacilityChangeModel, ConfirmFa
   ): Next<ConfirmFacilityChangeModel, ConfirmFacilityChangeEffect> {
     return when (event) {
       is FacilityChangeConfirmed -> dispatch(ChangeFacilityEffect(event.selectedFacility))
-      FacilityChanged -> dispatch(CloseSheet)
+      is FacilityChanged -> dispatch(CloseSheet)
       is CurrentFacilityLoaded -> next(model.currentFacilityLoaded(event.currentFacility))
     }
   }

--- a/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdate.kt
@@ -1,7 +1,6 @@
 package org.simple.clinic.facility.change.confirm
 
 import com.spotify.mobius.Next
-import com.spotify.mobius.Next.noChange
 import com.spotify.mobius.Update
 import org.simple.clinic.mobius.dispatch
 import org.simple.clinic.mobius.next
@@ -13,9 +12,21 @@ class ConfirmFacilityChangeUpdate : Update<ConfirmFacilityChangeModel, ConfirmFa
   ): Next<ConfirmFacilityChangeModel, ConfirmFacilityChangeEffect> {
     return when (event) {
       is FacilityChangeConfirmed -> dispatch(ChangeFacilityEffect(event.selectedFacility))
-      is FacilityChanged -> dispatch(CloseSheet)
+      is FacilityChanged -> closeSheet(model, event)
       is CurrentFacilityLoaded -> next(model.currentFacilityLoaded(event.currentFacility))
-      FacilitySyncGroupSwitchedAtTimeTouched -> noChange()
+      FacilitySyncGroupSwitchedAtTimeTouched -> dispatch(CloseSheet)
     }
+  }
+
+  private fun closeSheet(
+      model: ConfirmFacilityChangeModel,
+      event: FacilityChanged
+  ): Next<ConfirmFacilityChangeModel, ConfirmFacilityChangeEffect> {
+    val effect = if (model.hasFacilitySyncGroupSwitched(event.newFacility))
+      TouchFacilitySyncGroupSwitchedAtTime
+    else
+      CloseSheet
+
+    return dispatch(effect)
   }
 }

--- a/app/src/main/java/org/simple/clinic/main/TypedPreference.kt
+++ b/app/src/main/java/org/simple/clinic/main/TypedPreference.kt
@@ -9,6 +9,7 @@ annotation class TypedPreference(val value: Type) {
     OnboardingComplete,
     FallbackCountry,
     DatabaseMaintenanceRunAt,
-    MedicalRegistrationId
+    MedicalRegistrationId,
+    FacilitySyncGroupSwitchedAt
   }
 }

--- a/app/src/main/java/org/simple/clinic/sync/PurgeOnSync.kt
+++ b/app/src/main/java/org/simple/clinic/sync/PurgeOnSync.kt
@@ -7,6 +7,7 @@ import org.simple.clinic.facility.Facility
 import org.simple.clinic.main.TypedPreference
 import org.simple.clinic.main.TypedPreference.Type.FacilitySyncGroupSwitchedAt
 import org.simple.clinic.util.Optional
+import org.simple.clinic.util.UtcClock
 import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
@@ -16,19 +17,22 @@ class PurgeOnSync(
     private val currentFacility: Provider<Facility>,
     private val appDatabase: AppDatabase,
     private val facilitySyncGroupSwitchedAt: Preference<Optional<Instant>>,
-    private val delayPurgeAfterSwitchFor: Duration
+    private val delayPurgeAfterSwitchFor: Duration,
+    private val clock: UtcClock
 ) {
 
   @Inject
   constructor(
       currentFacility: Provider<Facility>,
       appDatabase: AppDatabase,
-      @TypedPreference(FacilitySyncGroupSwitchedAt) facilitySyncGroupSwitchedAt: Preference<Optional<Instant>>
+      @TypedPreference(FacilitySyncGroupSwitchedAt) facilitySyncGroupSwitchedAt: Preference<Optional<Instant>>,
+      clock: UtcClock
   ) : this(
       currentFacility = currentFacility,
       appDatabase = appDatabase,
       facilitySyncGroupSwitchedAt = facilitySyncGroupSwitchedAt,
-      delayPurgeAfterSwitchFor = Duration.ofHours(24)
+      delayPurgeAfterSwitchFor = Duration.ofHours(24),
+      clock = clock
   )
 
   @WorkerThread

--- a/app/src/main/java/org/simple/clinic/sync/PurgeOnSync.kt
+++ b/app/src/main/java/org/simple/clinic/sync/PurgeOnSync.kt
@@ -37,6 +37,18 @@ class PurgeOnSync(
 
   @WorkerThread
   fun purgeUnusedData() {
-    appDatabase.deletePatientsNotInFacilitySyncGroup(currentFacility.get())
+    val facilitySyncSwitchedAtInstant = facilitySyncGroupSwitchedAt.get()
+
+    val shouldPurgeData = !facilitySyncSwitchedAtInstant.isPresent() || isSafeToPurgeData(facilitySyncSwitchedAtInstant.get())
+
+    if(shouldPurgeData) appDatabase.deletePatientsNotInFacilitySyncGroup(currentFacility.get())
+  }
+
+  private fun isSafeToPurgeData(
+      switchedAt: Instant
+  ): Boolean {
+    val now = Instant.now(clock)
+
+    return Duration.between(switchedAt, now) > delayPurgeAfterSwitchFor
   }
 }

--- a/app/src/main/java/org/simple/clinic/sync/PurgeOnSync.kt
+++ b/app/src/main/java/org/simple/clinic/sync/PurgeOnSync.kt
@@ -1,14 +1,20 @@
 package org.simple.clinic.sync
 
 import androidx.annotation.WorkerThread
+import com.f2prateek.rx.preferences2.Preference
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.facility.Facility
+import org.simple.clinic.main.TypedPreference
+import org.simple.clinic.main.TypedPreference.Type.FacilitySyncGroupSwitchedAt
+import org.simple.clinic.util.Optional
+import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Provider
 
 class PurgeOnSync @Inject constructor(
     private val currentFacility: Provider<Facility>,
-    private val appDatabase: AppDatabase
+    private val appDatabase: AppDatabase,
+    @TypedPreference(FacilitySyncGroupSwitchedAt) private val facilitySyncGroupSwitchedAt: Preference<Optional<Instant>>
 ) {
 
   @WorkerThread

--- a/app/src/main/java/org/simple/clinic/sync/PurgeOnSync.kt
+++ b/app/src/main/java/org/simple/clinic/sync/PurgeOnSync.kt
@@ -6,6 +6,7 @@ import org.simple.clinic.AppDatabase
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.main.TypedPreference
 import org.simple.clinic.main.TypedPreference.Type.FacilitySyncGroupSwitchedAt
+import org.simple.clinic.remoteconfig.ConfigReader
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.UtcClock
 import java.time.Duration
@@ -26,12 +27,13 @@ class PurgeOnSync(
       currentFacility: Provider<Facility>,
       appDatabase: AppDatabase,
       @TypedPreference(FacilitySyncGroupSwitchedAt) facilitySyncGroupSwitchedAt: Preference<Optional<Instant>>,
-      clock: UtcClock
+      clock: UtcClock,
+      remoteConfig: ConfigReader
   ) : this(
       currentFacility = currentFacility,
       appDatabase = appDatabase,
       facilitySyncGroupSwitchedAt = facilitySyncGroupSwitchedAt,
-      delayPurgeAfterSwitchFor = Duration.ofHours(24),
+      delayPurgeAfterSwitchFor = Duration.parse(remoteConfig.string("delay_purge_after_facility_sync_group_switch_duration", "P1D")),
       clock = clock
   )
 

--- a/app/src/main/java/org/simple/clinic/sync/PurgeOnSync.kt
+++ b/app/src/main/java/org/simple/clinic/sync/PurgeOnSync.kt
@@ -7,15 +7,29 @@ import org.simple.clinic.facility.Facility
 import org.simple.clinic.main.TypedPreference
 import org.simple.clinic.main.TypedPreference.Type.FacilitySyncGroupSwitchedAt
 import org.simple.clinic.util.Optional
+import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Provider
 
-class PurgeOnSync @Inject constructor(
+class PurgeOnSync(
     private val currentFacility: Provider<Facility>,
     private val appDatabase: AppDatabase,
-    @TypedPreference(FacilitySyncGroupSwitchedAt) private val facilitySyncGroupSwitchedAt: Preference<Optional<Instant>>
+    private val facilitySyncGroupSwitchedAt: Preference<Optional<Instant>>,
+    private val delayPurgeAfterSwitchFor: Duration
 ) {
+
+  @Inject
+  constructor(
+      currentFacility: Provider<Facility>,
+      appDatabase: AppDatabase,
+      @TypedPreference(FacilitySyncGroupSwitchedAt) facilitySyncGroupSwitchedAt: Preference<Optional<Instant>>
+  ) : this(
+      currentFacility = currentFacility,
+      appDatabase = appDatabase,
+      facilitySyncGroupSwitchedAt = facilitySyncGroupSwitchedAt,
+      delayPurgeAfterSwitchFor = Duration.ofHours(24)
+  )
 
   @WorkerThread
   fun purgeUnusedData() {

--- a/app/src/main/java/org/simple/clinic/sync/SyncModule.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncModule.kt
@@ -1,5 +1,7 @@
 package org.simple.clinic.sync
 
+import com.f2prateek.rx.preferences2.Preference
+import com.f2prateek.rx.preferences2.RxSharedPreferences
 import dagger.Module
 import dagger.Provides
 import org.simple.clinic.bloodsugar.BloodSugarRepository
@@ -15,6 +17,8 @@ import org.simple.clinic.facility.FacilityModule
 import org.simple.clinic.facility.FacilitySync
 import org.simple.clinic.help.HelpModule
 import org.simple.clinic.help.HelpSync
+import org.simple.clinic.main.TypedPreference
+import org.simple.clinic.main.TypedPreference.Type.FacilitySyncGroupSwitchedAt
 import org.simple.clinic.medicalhistory.MedicalHistoryModule
 import org.simple.clinic.medicalhistory.MedicalHistoryRepository
 import org.simple.clinic.medicalhistory.sync.MedicalHistorySync
@@ -32,6 +36,10 @@ import org.simple.clinic.reports.ReportsSync
 import org.simple.clinic.summary.teleconsultation.sync.TeleconsultationSync
 import org.simple.clinic.teleconsultlog.teleconsultrecord.TeleconsultRecordRepository
 import org.simple.clinic.teleconsultlog.teleconsultrecord.TeleconsultRecordSync
+import org.simple.clinic.util.Optional
+import org.simple.clinic.util.preference.InstantRxPreferencesConverter
+import org.simple.clinic.util.preference.getOptional
+import java.time.Instant
 import javax.inject.Named
 
 @Module(includes = [
@@ -61,7 +69,7 @@ class SyncModule {
       helpSync: HelpSync,
       bloodSugarSync: BloodSugarSync,
       teleconsultationMedicalOfficersSync: TeleconsultationSync,
-      teleconsultRecordSync : TeleconsultRecordSync
+      teleconsultRecordSync: TeleconsultRecordSync
   ): List<ModelSync> {
     return listOf(
         facilitySync, protocolSync, patientSync,
@@ -81,7 +89,7 @@ class SyncModule {
       appointmentSyncRepository: AppointmentRepository,
       prescriptionSyncRepository: PrescriptionRepository,
       bloodSugarRepository: BloodSugarRepository,
-      teleconsultRecordRepository : TeleconsultRecordRepository
+      teleconsultRecordRepository: TeleconsultRecordRepository
   ): List<SynceableRepository<*, *>> {
     return listOf(
         patientSyncRepository,
@@ -92,5 +100,13 @@ class SyncModule {
         bloodSugarRepository,
         teleconsultRecordRepository
     )
+  }
+
+  @Provides
+  @TypedPreference(FacilitySyncGroupSwitchedAt)
+  fun provideFacilitySyncGroupSwitchedAtPreferences(
+      rxSharedPreferences: RxSharedPreferences
+  ): Preference<Optional<Instant>> {
+    return rxSharedPreferences.getOptional("facility_sync_group_switched_at", InstantRxPreferencesConverter())
   }
 }

--- a/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandlerTest.kt
@@ -52,7 +52,7 @@ class ConfirmFacilityChangeEffectHandlerTest {
     testCase.dispatch(ChangeFacilityEffect(facility))
 
     //then
-    testCase.assertOutgoingEvents(FacilityChanged)
+    testCase.assertOutgoingEvents(FacilityChanged(facility))
     verify(reportsRepository).deleteReports()
     verify(reportsSync).sync()
     verify(isFacilitySwitchedPreference).set(true)

--- a/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandlerTest.kt
@@ -8,16 +8,21 @@ import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.Completable
+import org.junit.Rule
 import org.junit.Test
 import org.simple.clinic.TestData
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.mobius.EffectHandlerTestCase
 import org.simple.clinic.reports.ReportsRepository
 import org.simple.clinic.reports.ReportsSync
+import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.scheduler.TestSchedulersProvider
 import java.util.UUID
 
 class ConfirmFacilityChangeEffectHandlerTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
 
   private val facilityRepository = mock<FacilityRepository>()
   private val reportsRepository = mock<ReportsRepository>()
@@ -64,5 +69,19 @@ class ConfirmFacilityChangeEffectHandlerTest {
     testCase.assertNoOutgoingEvents()
     verify(uiActions).closeSheet()
     verifyNoMoreInteractions(uiActions)
+  }
+
+  @Test
+  fun `when the load current facility effect is received, load the current facility`() {
+    // given
+    val facility = TestData.facility(UUID.fromString("98a260cb-45b1-46f7-a7ca-d217a27c43c0"))
+    whenever(facilityRepository.currentFacilityImmediate()) doReturn facility
+
+    // when
+    testCase.dispatch(LoadCurrentFacility)
+
+    // then
+    testCase.assertOutgoingEvents(CurrentFacilityLoaded(facility))
+    verifyZeroInteractions(uiActions)
   }
 }

--- a/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandlerTest.kt
@@ -40,7 +40,6 @@ class ConfirmFacilityChangeEffectHandlerTest {
     //given
     val facility = TestData.facility(UUID.fromString("98a260cb-45b1-46f7-a7ca-d217a27c43c0"))
 
-    whenever(facilityRepository.setCurrentFacility(facility)) doReturn Completable.complete()
     whenever(reportsRepository.deleteReports()) doReturn Completable.complete()
     whenever(reportsSync.sync()) doReturn Completable.complete()
 
@@ -52,6 +51,7 @@ class ConfirmFacilityChangeEffectHandlerTest {
     verify(reportsRepository).deleteReports()
     verify(reportsSync).sync()
     verify(isFacilitySwitchedPreference).set(true)
+    verify(facilityRepository).setCurrentFacilityImmediate(facility)
     verifyZeroInteractions(uiActions)
   }
 

--- a/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandlerTest.kt
@@ -14,7 +14,7 @@ import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.mobius.EffectHandlerTestCase
 import org.simple.clinic.reports.ReportsRepository
 import org.simple.clinic.reports.ReportsSync
-import org.simple.clinic.util.scheduler.TrampolineSchedulersProvider
+import org.simple.clinic.util.scheduler.TestSchedulersProvider
 import java.util.UUID
 
 class ConfirmFacilityChangeEffectHandlerTest {
@@ -29,7 +29,7 @@ class ConfirmFacilityChangeEffectHandlerTest {
       facilityRepository,
       reportsRepository,
       reportsSync,
-      TrampolineSchedulersProvider(),
+      TestSchedulersProvider.trampoline(),
       uiActions,
       isFacilitySwitchedPreference
   )

--- a/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeEffectHandlerTest.kt
@@ -15,8 +15,10 @@ import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.mobius.EffectHandlerTestCase
 import org.simple.clinic.reports.ReportsRepository
 import org.simple.clinic.reports.ReportsSync
+import org.simple.clinic.util.Optional
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.scheduler.TestSchedulersProvider
+import java.time.Instant
 import java.util.UUID
 
 class ConfirmFacilityChangeEffectHandlerTest {
@@ -29,14 +31,16 @@ class ConfirmFacilityChangeEffectHandlerTest {
   private val reportsSync = mock<ReportsSync>()
   private val uiActions = mock<ConfirmFacilityChangeUiActions>()
   private val isFacilitySwitchedPreference = mock<Preference<Boolean>>()
+  private val facilitySyncGroupSwitchedAtPreference = mock<Preference<Optional<Instant>>>()
 
   private val effectHandler = ConfirmFacilityChangeEffectHandler(
-      facilityRepository,
-      reportsRepository,
-      reportsSync,
-      TestSchedulersProvider.trampoline(),
-      uiActions,
-      isFacilitySwitchedPreference
+      facilityRepository = facilityRepository,
+      reportsRepository = reportsRepository,
+      reportsSync = reportsSync,
+      schedulersProvider = TestSchedulersProvider.trampoline(),
+      uiActions = uiActions,
+      isFacilitySwitchedPreference = isFacilitySwitchedPreference,
+      facilitySyncGroupSwitchAtPreference = facilitySyncGroupSwitchedAtPreference
   )
   private val testCase = EffectHandlerTestCase(effectHandler.build())
 

--- a/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeInitTest.kt
@@ -1,0 +1,41 @@
+package org.simple.clinic.facility.change.confirm
+
+import com.spotify.mobius.test.FirstMatchers.hasEffects
+import com.spotify.mobius.test.FirstMatchers.hasModel
+import com.spotify.mobius.test.FirstMatchers.hasNoEffects
+import com.spotify.mobius.test.InitSpec
+import com.spotify.mobius.test.InitSpec.assertThatFirst
+import org.junit.Test
+import org.simple.clinic.TestData
+import java.util.UUID
+
+class ConfirmFacilityChangeInitTest {
+
+  private val spec = InitSpec(ConfirmFacilityChangeInit())
+
+  private val defaultModel = ConfirmFacilityChangeModel.create()
+
+  @Test
+  fun `when the screen is created, load the required information`() {
+    spec
+        .whenInit(defaultModel)
+        .then(assertThatFirst(
+            hasModel(defaultModel),
+            hasEffects(LoadCurrentFacility)
+        ))
+  }
+
+  @Test
+  fun `when the screen is restored, dont load the required information`() {
+    val facility = TestData.facility(uuid = UUID.fromString("3d362e26-c8ca-4bd6-8910-4fbcbcb98678"))
+
+    val model = defaultModel.currentFacilityLoaded(facility)
+
+    spec
+        .whenInit(model)
+        .then(assertThatFirst(
+            hasModel(model),
+            hasNoEffects()
+        ))
+  }
+}

--- a/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdateTest.kt
@@ -1,6 +1,8 @@
 package org.simple.clinic.facility.change.confirm
 
 import com.spotify.mobius.test.NextMatchers.hasEffects
+import com.spotify.mobius.test.NextMatchers.hasModel
+import com.spotify.mobius.test.NextMatchers.hasNoEffects
 import com.spotify.mobius.test.NextMatchers.hasNoModel
 import com.spotify.mobius.test.UpdateSpec
 import com.spotify.mobius.test.UpdateSpec.assertThatNext
@@ -12,11 +14,16 @@ class ConfirmFacilityChangeUpdateTest {
 
   private val updateSpec = UpdateSpec(ConfirmFacilityChangeUpdate())
 
+  private val currentFacility = TestData.facility(UUID.fromString("3d362e26-c8ca-4bd6-8910-4fbcbcb98678"))
+
+  private val defaultModel = ConfirmFacilityChangeModel.create()
+
   @Test
   fun `when facility change is confirmed then user's facility should be changed`() {
     val selectedFacility = TestData.facility(UUID.fromString("ef47531f-9b8c-4045-8578-eda31f0952c4"))
+
     updateSpec
-        .given(ConfirmFacilityChangeModel.create())
+        .given(defaultModel)
         .whenEvent(FacilityChangeConfirmed(selectedFacility))
         .then(
             assertThatNext(
@@ -29,12 +36,25 @@ class ConfirmFacilityChangeUpdateTest {
   @Test
   fun `when user's facility is changed then the sheet should be closed`() {
     updateSpec
-        .given(ConfirmFacilityChangeModel.create())
+        .given(defaultModel)
         .whenEvent(FacilityChanged)
         .then(
             assertThatNext(
                 hasNoModel(),
                 hasEffects(CloseSheet as ConfirmFacilityChangeEffect)
+            )
+        )
+  }
+
+  @Test
+  fun `when the current facility is loaded, then update the ui`() {
+    updateSpec
+        .given(defaultModel)
+        .whenEvent(CurrentFacilityLoaded(currentFacility))
+        .then(
+            assertThatNext(
+                hasModel(defaultModel.currentFacilityLoaded(currentFacility)),
+                hasNoEffects()
             )
         )
   }

--- a/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdateTest.kt
@@ -10,13 +10,13 @@ import java.util.UUID
 
 class ConfirmFacilityChangeUpdateTest {
 
-  private val updateSpec = UpdateSpec<ConfirmFacilityChangeModel, ConfirmFacilityChangeEvent, ConfirmFacilityChangeEffect>(ConfirmFacilityChangeUpdate())
+  private val updateSpec = UpdateSpec(ConfirmFacilityChangeUpdate())
 
   @Test
   fun `when facility change is confirmed then user's facility should be changed`() {
     val selectedFacility = TestData.facility(UUID.fromString("ef47531f-9b8c-4045-8578-eda31f0952c4"))
     updateSpec
-        .given(ConfirmFacilityChangeModel())
+        .given(ConfirmFacilityChangeModel.create())
         .whenEvent(FacilityChangeConfirmed(selectedFacility))
         .then(
             assertThatNext(
@@ -29,7 +29,7 @@ class ConfirmFacilityChangeUpdateTest {
   @Test
   fun `when user's facility is changed then the sheet should be closed`() {
     updateSpec
-        .given(ConfirmFacilityChangeModel())
+        .given(ConfirmFacilityChangeModel.create())
         .whenEvent(FacilityChanged)
         .then(
             assertThatNext(

--- a/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/facility/change/confirm/ConfirmFacilityChangeUpdateTest.kt
@@ -35,9 +35,11 @@ class ConfirmFacilityChangeUpdateTest {
 
   @Test
   fun `when user's facility is changed then the sheet should be closed`() {
+    val facility = TestData.facility(uuid = UUID.fromString("21707c61-12d4-4bae-bedb-d26367d4afcb"))
+
     updateSpec
         .given(defaultModel)
-        .whenEvent(FacilityChanged)
+        .whenEvent(FacilityChanged(facility))
         .then(
             assertThatNext(
                 hasNoModel(),

--- a/app/src/test/java/org/simple/clinic/sync/PurgeOnSyncTest.kt
+++ b/app/src/test/java/org/simple/clinic/sync/PurgeOnSyncTest.kt
@@ -1,0 +1,80 @@
+package org.simple.clinic.sync
+
+import com.f2prateek.rx.preferences2.Preference
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Test
+import org.simple.clinic.AppDatabase
+import org.simple.clinic.TestData
+import org.simple.clinic.util.Optional
+import org.simple.clinic.util.TestUtcClock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+class PurgeOnSyncTest {
+
+  private val clock = TestUtcClock(LocalDate.parse("2020-01-01"))
+  private val now = Instant.now(clock)
+  private val facility = TestData.facility(uuid = UUID.fromString("d12d4595-8adb-41ed-9492-c74f12d85ab6"))
+  private val appDatabase = mock<AppDatabase>()
+  private val delayPurgeAfterSwitchFor = Duration.ofHours(1)
+  private val facilitySyncGroupSwitchedAt = mock<Preference<Optional<Instant>>>()
+
+  private val purgeOnSync = PurgeOnSync(
+      currentFacility = { facility },
+      appDatabase = appDatabase,
+      facilitySyncGroupSwitchedAt = facilitySyncGroupSwitchedAt,
+      delayPurgeAfterSwitchFor = delayPurgeAfterSwitchFor,
+      clock = clock
+  )
+
+  @Test
+  fun `when the facility sync group has not been switched before, purging the data should happen`() {
+    // given
+    whenever(facilitySyncGroupSwitchedAt.get()).thenReturn(Optional.empty())
+
+    // when
+    purgeOnSync.purgeUnusedData()
+
+    // then
+    verify(appDatabase).deletePatientsNotInFacilitySyncGroup(facility)
+    verifyNoMoreInteractions(appDatabase)
+  }
+
+  @Test
+  fun `when the facility sync group has been switched, purging the data should not be done if the specified delay duration has not yet passed`() {
+    // given
+    val facilityGroupSwitchedAtInstant = now.minus(delayPurgeAfterSwitchFor)
+    whenever(facilitySyncGroupSwitchedAt.get()).thenReturn(Optional.of(facilityGroupSwitchedAtInstant))
+
+    // when
+    purgeOnSync.purgeUnusedData()
+
+    // then
+    verify(appDatabase, never()).deletePatientsNotInFacilitySyncGroup(any())
+    verifyNoMoreInteractions(appDatabase)
+  }
+
+  @Test
+  fun `when the facility sync group has been switched, purging the data should be done if the specified delay duration has passed`() {
+    // given
+    val facilityGroupSwitchedAtInstant = now
+        .minus(delayPurgeAfterSwitchFor)
+        .minusSeconds(1)
+    whenever(facilitySyncGroupSwitchedAt.get()).thenReturn(Optional.of(facilityGroupSwitchedAtInstant))
+
+    // when
+    purgeOnSync.purgeUnusedData()
+
+    // then
+    verify(appDatabase).deletePatientsNotInFacilitySyncGroup(facility)
+    verifyNoMoreInteractions(appDatabase)
+  }
+
+}


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/1491/delay-purging-of-data-from-an-older-sync-group-if-the-blocks-have-been-switched-within-a-certain-time-window