### PR TITLE
Clean up patient repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Bump AGP to 4.1.0
 - Add `PrescribedDrug#refill` method
 - Remove unnecessary sealed class types for different Business ID metadata versions
+- Clean up `PatientRepository`
+    - Change reactive calls for registering a patient to synchronous ones
+    - Accept the ongoing patient entry as a parameter to the register patient method
+    - Remove deprecated `Optional` class usages
 
 ### Changes
 - Update translations: `kn-IN`, `ta-IN`, `bn-IN`, `ti`, `bn-BD`, `pa-IN`, `mr-IN`, `te-IN`, `hi-IN`

--- a/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
@@ -3,7 +3,6 @@ package org.simple.clinic.patient
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonAdapter
-import io.reactivex.Single
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -162,12 +161,17 @@ class PatientRepositoryAndroidTest {
 
     val personalDetailsOnlyEntry = OngoingNewPatientEntry(personalDetails = ongoingPersonalDetails)
 
-    val savedPatient = patientRepository.saveOngoingEntry(personalDetailsOnlyEntry)
-        .andThen(Single.fromCallable { patientRepository.ongoingEntry() })
-        .map { ongoingEntry -> ongoingEntry.copy(address = ongoingAddress) }
-        .map { updatedEntry -> updatedEntry.copy(phoneNumber = ongoingPhoneNumber) }
-        .flatMapCompletable { withAddressAndPhoneNumbers -> patientRepository.saveOngoingEntry(withAddressAndPhoneNumbers) }
-        .andThen(patientRepository.saveOngoingEntryAsPatient(
+    patientRepository.saveOngoingEntry(personalDetailsOnlyEntry)
+
+    val ongoingEntryWithAddressAndPhoneNumbers = patientRepository
+        .ongoingEntry()
+        .copy(address = ongoingAddress)
+        .copy(phoneNumber = ongoingPhoneNumber)
+
+    patientRepository.saveOngoingEntry(ongoingEntryWithAddressAndPhoneNumbers)
+
+    val savedPatient = patientRepository
+        .saveOngoingEntryAsPatient(
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
@@ -175,7 +179,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        ))
+        )
         .blockingGet()
 
     val patient = database.patientDao().getOne(savedPatient.uuid)!!
@@ -192,8 +196,10 @@ class PatientRepositoryAndroidTest {
   fun when_a_patient_without_phone_numbers_is_saved_then_it_should_be_correctly_stored_in_the_database() {
     val patientEntry = testData.ongoingPatientEntry(fullName = "Jeevan Bima", phone = null)
 
-    val savedPatient = patientRepository.saveOngoingEntry(patientEntry)
-        .andThen(patientRepository.saveOngoingEntryAsPatient(
+    patientRepository.saveOngoingEntry(patientEntry)
+
+    val savedPatient = patientRepository
+        .saveOngoingEntryAsPatient(
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
@@ -201,7 +207,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        ))
+        )
         .blockingGet()
 
     val patient = database.patientDao().patient(savedPatient.uuid)
@@ -216,8 +222,10 @@ class PatientRepositoryAndroidTest {
   fun when_a_patient_with_null_dateofbirth_and_nonnull_age_is_saved_then_it_should_be_correctly_stored_in_the_database() {
     val patientEntry = testData.ongoingPatientEntry(fullName = "Ashok Kumar")
 
-    val savedPatient = patientRepository.saveOngoingEntry(patientEntry)
-        .andThen(patientRepository.saveOngoingEntryAsPatient(
+    patientRepository.saveOngoingEntry(patientEntry)
+
+    val savedPatient = patientRepository
+        .saveOngoingEntryAsPatient(
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
@@ -225,7 +233,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        ))
+        )
         .blockingGet()
 
     val patient = database.patientDao().getOne(savedPatient.uuid)!!
@@ -249,8 +257,10 @@ class PatientRepositoryAndroidTest {
     val advanceClockBy = Duration.ofDays(7L)
     clock.advanceBy(advanceClockBy)
 
-    val savedPatientUuid = patientRepository.saveOngoingEntry(patientEntry)
-        .andThen(patientRepository.saveOngoingEntryAsPatient(
+    patientRepository.saveOngoingEntry(patientEntry)
+
+    val savedPatientUuid = patientRepository
+        .saveOngoingEntryAsPatient(
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
@@ -258,7 +268,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        ))
+        )
         .blockingGet()
         .uuid
 
@@ -278,7 +288,9 @@ class PatientRepositoryAndroidTest {
     val patientEntry = testData.ongoingPatientEntry(fullName = "Asha Kumar", dateOfBirth = "15/08/1947", age = null)
 
     patientRepository.saveOngoingEntry(patientEntry)
-        .andThen(patientRepository.saveOngoingEntryAsPatient(
+
+    patientRepository
+        .saveOngoingEntryAsPatient(
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
@@ -286,8 +298,9 @@ class PatientRepositoryAndroidTest {
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        ))
-        .subscribe()
+        )
+        .ignoreElement()
+        .blockingAwait()
 
     val combinedPatient = patientRepository.search(Name(patientName = "kumar"))
         .blockingFirst()
@@ -317,8 +330,10 @@ class PatientRepositoryAndroidTest {
     )
     val ongoingPhoneNumber = OngoingNewPatientEntry.PhoneNumber("3914159", PatientPhoneNumberType.Mobile, active = true)
     val ongoingPatientEntry = OngoingNewPatientEntry(ongoingPersonalDetails, ongoingAddress, ongoingPhoneNumber)
-    val abhayKumar = patientRepository.saveOngoingEntry(ongoingPatientEntry)
-        .andThen(patientRepository.saveOngoingEntryAsPatient(
+    patientRepository.saveOngoingEntry(ongoingPatientEntry)
+
+    val abhayKumar = patientRepository
+        .saveOngoingEntryAsPatient(
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("a9c26fec-204a-47ae-9eb4-9be15047e93e"),
@@ -326,7 +341,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForBpPassport = { UUID.fromString("7d705a05-adf5-4dfc-b1c0-6ca7e5f9f81b") },
             supplyUuidForAlternativeId = { UUID.fromString("1a3326ea-0be6-4265-ad17-57a89ed7ee1a") },
             supplyUuidForPhoneNumber = { UUID.fromString("b1c47a77-06ba-48af-8db7-8ec4ded3e906") }
-        ))
+        )
         .blockingGet()
 
     val opd2 = OngoingNewPatientEntry.PersonalDetails("Alok Kumar", "15/08/1940", null, Gender.Transgender)
@@ -340,7 +355,8 @@ class PatientRepositoryAndroidTest {
     val opn2 = OngoingNewPatientEntry.PhoneNumber("3418959", PatientPhoneNumberType.Mobile, active = true)
     val ope2 = OngoingNewPatientEntry(opd2, opa2, opn2)
     patientRepository.saveOngoingEntry(ope2)
-        .andThen(patientRepository.saveOngoingEntryAsPatient(
+    patientRepository
+        .saveOngoingEntryAsPatient(
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("df7afc76-9664-49c7-8d9f-44b9cc8cef19"),
@@ -348,7 +364,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForBpPassport = { UUID.fromString("a16d3578-9390-412c-b353-b7d0a50ef6d3") },
             supplyUuidForAlternativeId = { UUID.fromString("2e07d591-f79d-4c9a-8209-54b86e23ac9f") },
             supplyUuidForPhoneNumber = { UUID.fromString("9b51bc94-418b-45a0-9c83-f28dc36147fd") }
-        ))
+        )
         .blockingGet()
 
     val opd3 = OngoingNewPatientEntry.PersonalDetails("Abhishek Kumar", null, "68", Gender.Transgender)
@@ -361,8 +377,9 @@ class PatientRepositoryAndroidTest {
     )
     val opn3 = OngoingNewPatientEntry.PhoneNumber("9989159", PatientPhoneNumberType.Mobile, active = true)
     val ope3 = OngoingNewPatientEntry(opd3, opa3, opn3)
-    val abhishekKumar = patientRepository.saveOngoingEntry(ope3)
-        .andThen(patientRepository.saveOngoingEntryAsPatient(
+    patientRepository.saveOngoingEntry(ope3)
+    val abhishekKumar = patientRepository
+        .saveOngoingEntryAsPatient(
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("74b316df-22dc-4425-8e67-0202662467f4"),
@@ -370,7 +387,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForBpPassport = { UUID.fromString("dc4b038d-ad56-4a48-ba10-eea73abe75f8") },
             supplyUuidForAlternativeId = { UUID.fromString("7fe2b07e-2bc3-42a1-95f3-d171154c6cad") },
             supplyUuidForPhoneNumber = { UUID.fromString("05a0d327-09e2-4bb5-8e6f-dfd911337748") }
-        ))
+        )
         .blockingGet()
 
     val opd4 = OngoingNewPatientEntry.PersonalDetails("Abshot Kumar", null, "67", Gender.Transgender)
@@ -383,8 +400,9 @@ class PatientRepositoryAndroidTest {
     )
     val opn4 = OngoingNewPatientEntry.PhoneNumber("1991591", PatientPhoneNumberType.Mobile, active = true)
     val ope4 = OngoingNewPatientEntry(opd4, opa4, opn4)
-    val abshotKumar = patientRepository.saveOngoingEntry(ope4)
-        .andThen(patientRepository.saveOngoingEntryAsPatient(
+    patientRepository.saveOngoingEntry(ope4)
+    val abshotKumar = patientRepository
+        .saveOngoingEntryAsPatient(
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("18e327b6-b153-48ab-a863-b9950ba00f61"),
@@ -392,7 +410,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForBpPassport = { UUID.fromString("262b6c69-3130-4f37-b8e6-13606e005098") },
             supplyUuidForAlternativeId = { UUID.fromString("8b7a671c-f0fc-4c83-b9fb-19dce2515c57") },
             supplyUuidForPhoneNumber = { UUID.fromString("2a877a22-a9e6-40ab-b540-c0a49a6a15b4") }
-        ))
+        )
         .blockingGet()
 
     val search0 = patientRepository.search(Name("Vinod")).blockingFirst()
@@ -588,9 +606,9 @@ class PatientRepositoryAndroidTest {
 
   @Test
   fun when_patient_is_marked_dead_they_should_not_show_in_search_results() {
+    patientRepository.saveOngoingEntry(testData.ongoingPatientEntry(fullName = "Ashok Kumar"))
     val patient = patientRepository
-        .saveOngoingEntry(testData.ongoingPatientEntry(fullName = "Ashok Kumar"))
-        .andThen(patientRepository.saveOngoingEntryAsPatient(
+        .saveOngoingEntryAsPatient(
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
@@ -598,7 +616,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        ))
+        )
         .blockingGet()
 
     val searchResults = patientRepository.search(Name(patientName = "Ashok")).blockingFirst()
@@ -623,9 +641,9 @@ class PatientRepositoryAndroidTest {
   fun when_patient_is_marked_dead_they_should_marked_as_pending_sync() {
     val timeOfCreation = Instant.now(clock)
 
+    patientRepository.saveOngoingEntry(testData.ongoingPatientEntry(fullName = "Ashok Kumar"))
     val patient = patientRepository
-        .saveOngoingEntry(testData.ongoingPatientEntry(fullName = "Ashok Kumar"))
-        .andThen(patientRepository.saveOngoingEntryAsPatient(
+        .saveOngoingEntryAsPatient(
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
@@ -633,7 +651,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        ))
+        )
         .blockingGet()
 
     clock.advanceBy(Duration.ofDays(365))
@@ -1527,18 +1545,20 @@ class PatientRepositoryAndroidTest {
     val ongoingPatientEntry = testData.ongoingPatientEntry(
         bangladeshNationalId = Identifier(nationalId, BangladeshNationalId)
     )
-    patientRepository.saveOngoingEntry(ongoingPatientEntry).blockingAwait()
+    patientRepository.saveOngoingEntry(ongoingPatientEntry)
 
     // when
-    val savedPatient = patientRepository.saveOngoingEntryAsPatient(
-        loggedInUser = loggedInUser,
-        facility = facilityToSavePatientAt,
-        patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
-        addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
-        supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
-        supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
-        supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-    ).blockingGet()
+    val savedPatient = patientRepository
+        .saveOngoingEntryAsPatient(
+            loggedInUser = loggedInUser,
+            facility = facilityToSavePatientAt,
+            patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
+            addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
+            supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
+            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
+            supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
+        )
+        .blockingGet()
     val savedPatientNationalId = patientRepository.bangladeshNationalIdForPatient(savedPatient.uuid).blockingFirst().toNullable()!!
 
     // then
@@ -1558,18 +1578,20 @@ class PatientRepositoryAndroidTest {
     val ongoingPatientEntry = testData.ongoingPatientEntry(
         bangladeshNationalId = Identifier(nationalId, BangladeshNationalId)
     )
-    patientRepository.saveOngoingEntry(ongoingPatientEntry).blockingAwait()
+    patientRepository.saveOngoingEntry(ongoingPatientEntry)
 
     // when
-    val savedPatient = patientRepository.saveOngoingEntryAsPatient(
-        loggedInUser = loggedInUser,
-        facility = facilityToSavePatientAt,
-        patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
-        addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
-        supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
-        supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
-        supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-    ).blockingGet()
+    val savedPatient = patientRepository
+        .saveOngoingEntryAsPatient(
+            loggedInUser = loggedInUser,
+            facility = facilityToSavePatientAt,
+            patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
+            addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
+            supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
+            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
+            supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
+        )
+        .blockingGet()
     val savedPatientNationalId = patientRepository.bangladeshNationalIdForPatient(savedPatient.uuid).blockingFirst()
 
     // then
@@ -1723,9 +1745,9 @@ class PatientRepositoryAndroidTest {
         prescribedDrugUuid: UUID,
         appointmentUuid: UUID
     ): Pair<UUID, String> {
+      patientRepository.saveOngoingEntry(testData.ongoingPatientEntry(fullName = fullName))
       patientRepository
-          .saveOngoingEntry(testData.ongoingPatientEntry(fullName = fullName))
-          .andThen(patientRepository.saveOngoingEntryAsPatient(
+          .saveOngoingEntryAsPatient(
               loggedInUser = loggedInUser,
               facility = currentFacility,
               patientUuid = patientUuid,
@@ -1733,7 +1755,7 @@ class PatientRepositoryAndroidTest {
               supplyUuidForBpPassport = { bpPassportUuid },
               supplyUuidForAlternativeId = { alternativeIdUuid },
               supplyUuidForPhoneNumber = { phoneNumberUuid }
-          ))
+          )
           .blockingGet()
 
       bpMeasurement?.forEach {
@@ -3268,18 +3290,20 @@ class PatientRepositoryAndroidTest {
         streetAddress = userEnteredPatientStreetAddress,
         zone = userEnteredPatientZone
     )
-    patientRepository.saveOngoingEntry(ongoingPatientEntry).blockingAwait()
+    patientRepository.saveOngoingEntry(ongoingPatientEntry)
 
     // when
-    val savedPatient = patientRepository.saveOngoingEntryAsPatient(
-        loggedInUser = loggedInUser,
-        facility = facilityToSavePatientAt,
-        patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
-        addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
-        supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
-        supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
-        supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-    ).blockingGet()
+    val savedPatient = patientRepository
+        .saveOngoingEntryAsPatient(
+            loggedInUser = loggedInUser,
+            facility = facilityToSavePatientAt,
+            patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
+            addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
+            supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
+            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
+            supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
+        )
+        .blockingGet()
     val savedPatientAddress = patientRepository.address(savedPatient.addressUuid).blockingFirst().toNullable()!!
 
     // then

--- a/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
@@ -168,18 +168,16 @@ class PatientRepositoryAndroidTest {
         .copy(address = ongoingAddress)
         .copy(phoneNumber = ongoingPhoneNumber)
 
-    patientRepository.saveOngoingEntry(ongoingEntryWithAddressAndPhoneNumbers)
-
     val savedPatient = patientRepository
         .saveOngoingEntryAsPatient(
+            patientEntry = ongoingEntryWithAddressAndPhoneNumbers,
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
             addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
-            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
-            supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        )
+            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") }
+        ) { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
 
     val patient = database.patientDao().getOne(savedPatient.patientUuid)!!
 
@@ -195,18 +193,16 @@ class PatientRepositoryAndroidTest {
   fun when_a_patient_without_phone_numbers_is_saved_then_it_should_be_correctly_stored_in_the_database() {
     val patientEntry = testData.ongoingPatientEntry(fullName = "Jeevan Bima", phone = null)
 
-    patientRepository.saveOngoingEntry(patientEntry)
-
     val savedPatient = patientRepository
         .saveOngoingEntryAsPatient(
+            patientEntry = patientEntry,
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
             addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
-            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
-            supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        )
+            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") }
+        ) { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
 
     val patient = database.patientDao().patient(savedPatient.patientUuid)
 
@@ -220,18 +216,16 @@ class PatientRepositoryAndroidTest {
   fun when_a_patient_with_null_dateofbirth_and_nonnull_age_is_saved_then_it_should_be_correctly_stored_in_the_database() {
     val patientEntry = testData.ongoingPatientEntry(fullName = "Ashok Kumar")
 
-    patientRepository.saveOngoingEntry(patientEntry)
-
     val savedPatient = patientRepository
         .saveOngoingEntryAsPatient(
+            patientEntry = patientEntry,
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
             addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
-            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
-            supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        )
+            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") }
+        ) { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
 
     val patient = database.patientDao().getOne(savedPatient.patientUuid)!!
 
@@ -254,18 +248,16 @@ class PatientRepositoryAndroidTest {
     val advanceClockBy = Duration.ofDays(7L)
     clock.advanceBy(advanceClockBy)
 
-    patientRepository.saveOngoingEntry(patientEntry)
-
     val savedPatientUuid = patientRepository
         .saveOngoingEntryAsPatient(
+            patientEntry = patientEntry,
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
             addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
-            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
-            supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        )
+            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") }
+        ) { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         .patientUuid
 
     val patientProfile = database
@@ -283,18 +275,16 @@ class PatientRepositoryAndroidTest {
   fun when_a_patient_with_address_is_saved_then_search_should_correctly_return_combined_object() {
     val patientEntry = testData.ongoingPatientEntry(fullName = "Asha Kumar", dateOfBirth = "15/08/1947", age = null)
 
-    patientRepository.saveOngoingEntry(patientEntry)
-
     patientRepository
         .saveOngoingEntryAsPatient(
+            patientEntry = patientEntry,
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
             addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
-            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
-            supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        )
+            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") }
+        ) { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
 
     val combinedPatient = patientRepository.search(Name(patientName = "kumar"))
         .blockingFirst()
@@ -324,18 +314,17 @@ class PatientRepositoryAndroidTest {
     )
     val ongoingPhoneNumber = OngoingNewPatientEntry.PhoneNumber("3914159", PatientPhoneNumberType.Mobile, active = true)
     val ongoingPatientEntry = OngoingNewPatientEntry(ongoingPersonalDetails, ongoingAddress, ongoingPhoneNumber)
-    patientRepository.saveOngoingEntry(ongoingPatientEntry)
 
     val abhayKumar = patientRepository
         .saveOngoingEntryAsPatient(
+            patientEntry = ongoingPatientEntry,
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("a9c26fec-204a-47ae-9eb4-9be15047e93e"),
             addressUuid = UUID.fromString("41fa131c-6118-4e88-a978-3513bc39315c"),
             supplyUuidForBpPassport = { UUID.fromString("7d705a05-adf5-4dfc-b1c0-6ca7e5f9f81b") },
-            supplyUuidForAlternativeId = { UUID.fromString("1a3326ea-0be6-4265-ad17-57a89ed7ee1a") },
-            supplyUuidForPhoneNumber = { UUID.fromString("b1c47a77-06ba-48af-8db7-8ec4ded3e906") }
-        )
+            supplyUuidForAlternativeId = { UUID.fromString("1a3326ea-0be6-4265-ad17-57a89ed7ee1a") }
+        ) { UUID.fromString("b1c47a77-06ba-48af-8db7-8ec4ded3e906") }
 
     val opd2 = OngoingNewPatientEntry.PersonalDetails("Alok Kumar", "15/08/1940", null, Gender.Transgender)
     val opa2 = OngoingNewPatientEntry.Address(
@@ -347,17 +336,16 @@ class PatientRepositoryAndroidTest {
     )
     val opn2 = OngoingNewPatientEntry.PhoneNumber("3418959", PatientPhoneNumberType.Mobile, active = true)
     val ope2 = OngoingNewPatientEntry(opd2, opa2, opn2)
-    patientRepository.saveOngoingEntry(ope2)
     patientRepository
         .saveOngoingEntryAsPatient(
+            patientEntry = ope2,
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("df7afc76-9664-49c7-8d9f-44b9cc8cef19"),
             addressUuid = UUID.fromString("f76d0f5a-c63b-4862-be5a-d1d20b5e9852"),
             supplyUuidForBpPassport = { UUID.fromString("a16d3578-9390-412c-b353-b7d0a50ef6d3") },
-            supplyUuidForAlternativeId = { UUID.fromString("2e07d591-f79d-4c9a-8209-54b86e23ac9f") },
-            supplyUuidForPhoneNumber = { UUID.fromString("9b51bc94-418b-45a0-9c83-f28dc36147fd") }
-        )
+            supplyUuidForAlternativeId = { UUID.fromString("2e07d591-f79d-4c9a-8209-54b86e23ac9f") }
+        ) { UUID.fromString("9b51bc94-418b-45a0-9c83-f28dc36147fd") }
 
     val opd3 = OngoingNewPatientEntry.PersonalDetails("Abhishek Kumar", null, "68", Gender.Transgender)
     val opa3 = OngoingNewPatientEntry.Address(
@@ -369,17 +357,16 @@ class PatientRepositoryAndroidTest {
     )
     val opn3 = OngoingNewPatientEntry.PhoneNumber("9989159", PatientPhoneNumberType.Mobile, active = true)
     val ope3 = OngoingNewPatientEntry(opd3, opa3, opn3)
-    patientRepository.saveOngoingEntry(ope3)
     val abhishekKumar = patientRepository
         .saveOngoingEntryAsPatient(
+            patientEntry = ope3,
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("74b316df-22dc-4425-8e67-0202662467f4"),
             addressUuid = UUID.fromString("c4c5fe7e-b619-4dbf-84de-5e7333a9af22"),
             supplyUuidForBpPassport = { UUID.fromString("dc4b038d-ad56-4a48-ba10-eea73abe75f8") },
-            supplyUuidForAlternativeId = { UUID.fromString("7fe2b07e-2bc3-42a1-95f3-d171154c6cad") },
-            supplyUuidForPhoneNumber = { UUID.fromString("05a0d327-09e2-4bb5-8e6f-dfd911337748") }
-        )
+            supplyUuidForAlternativeId = { UUID.fromString("7fe2b07e-2bc3-42a1-95f3-d171154c6cad") }
+        ) { UUID.fromString("05a0d327-09e2-4bb5-8e6f-dfd911337748") }
 
     val opd4 = OngoingNewPatientEntry.PersonalDetails("Abshot Kumar", null, "67", Gender.Transgender)
     val opa4 = OngoingNewPatientEntry.Address(
@@ -391,17 +378,16 @@ class PatientRepositoryAndroidTest {
     )
     val opn4 = OngoingNewPatientEntry.PhoneNumber("1991591", PatientPhoneNumberType.Mobile, active = true)
     val ope4 = OngoingNewPatientEntry(opd4, opa4, opn4)
-    patientRepository.saveOngoingEntry(ope4)
     val abshotKumar = patientRepository
         .saveOngoingEntryAsPatient(
+            patientEntry = ope4,
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("18e327b6-b153-48ab-a863-b9950ba00f61"),
             addressUuid = UUID.fromString("f76b24ae-33eb-497c-ba57-05325ab43ac4"),
             supplyUuidForBpPassport = { UUID.fromString("262b6c69-3130-4f37-b8e6-13606e005098") },
-            supplyUuidForAlternativeId = { UUID.fromString("8b7a671c-f0fc-4c83-b9fb-19dce2515c57") },
-            supplyUuidForPhoneNumber = { UUID.fromString("2a877a22-a9e6-40ab-b540-c0a49a6a15b4") }
-        )
+            supplyUuidForAlternativeId = { UUID.fromString("8b7a671c-f0fc-4c83-b9fb-19dce2515c57") }
+        ) { UUID.fromString("2a877a22-a9e6-40ab-b540-c0a49a6a15b4") }
 
     val search0 = patientRepository.search(Name("Vinod")).blockingFirst()
     assertThat(search0).hasSize(0)
@@ -596,17 +582,16 @@ class PatientRepositoryAndroidTest {
 
   @Test
   fun when_patient_is_marked_dead_they_should_not_show_in_search_results() {
-    patientRepository.saveOngoingEntry(testData.ongoingPatientEntry(fullName = "Ashok Kumar"))
     val patient = patientRepository
         .saveOngoingEntryAsPatient(
+            patientEntry = testData.ongoingPatientEntry(fullName = "Ashok Kumar"),
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
             addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
-            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
-            supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        )
+            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") }
+        ) { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
 
     val searchResults = patientRepository.search(Name(patientName = "Ashok")).blockingFirst()
     assertThat(searchResults).isNotEmpty()
@@ -630,17 +615,16 @@ class PatientRepositoryAndroidTest {
   fun when_patient_is_marked_dead_they_should_marked_as_pending_sync() {
     val timeOfCreation = Instant.now(clock)
 
-    patientRepository.saveOngoingEntry(testData.ongoingPatientEntry(fullName = "Ashok Kumar"))
     val patient = patientRepository
         .saveOngoingEntryAsPatient(
+            patientEntry = testData.ongoingPatientEntry(fullName = "Ashok Kumar"),
             loggedInUser = loggedInUser,
             facility = currentFacility,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
             addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
-            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
-            supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        )
+            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") }
+        ) { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
 
     clock.advanceBy(Duration.ofDays(365))
     val timeOfDeath = Instant.now(clock)
@@ -1533,19 +1517,18 @@ class PatientRepositoryAndroidTest {
     val ongoingPatientEntry = testData.ongoingPatientEntry(
         bangladeshNationalId = Identifier(nationalId, BangladeshNationalId)
     )
-    patientRepository.saveOngoingEntry(ongoingPatientEntry)
 
     // when
     val savedPatient = patientRepository
         .saveOngoingEntryAsPatient(
+            patientEntry = ongoingPatientEntry,
             loggedInUser = loggedInUser,
             facility = facilityToSavePatientAt,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
             addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
-            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
-            supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        )
+            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") }
+        ) { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
     val savedPatientNationalId = patientRepository.bangladeshNationalIdForPatient(savedPatient.patientUuid).blockingFirst().toNullable()!!
 
     // then
@@ -1565,19 +1548,18 @@ class PatientRepositoryAndroidTest {
     val ongoingPatientEntry = testData.ongoingPatientEntry(
         bangladeshNationalId = Identifier(nationalId, BangladeshNationalId)
     )
-    patientRepository.saveOngoingEntry(ongoingPatientEntry)
 
     // when
     val savedPatient = patientRepository
         .saveOngoingEntryAsPatient(
+            patientEntry = ongoingPatientEntry,
             loggedInUser = loggedInUser,
             facility = facilityToSavePatientAt,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
             addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
-            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
-            supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        )
+            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") }
+        ) { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
     val savedPatientNationalId = patientRepository.bangladeshNationalIdForPatient(savedPatient.patientUuid).blockingFirst()
 
     // then
@@ -1731,17 +1713,16 @@ class PatientRepositoryAndroidTest {
         prescribedDrugUuid: UUID,
         appointmentUuid: UUID
     ): Pair<UUID, String> {
-      patientRepository.saveOngoingEntry(testData.ongoingPatientEntry(fullName = fullName))
       patientRepository
           .saveOngoingEntryAsPatient(
+              patientEntry = testData.ongoingPatientEntry(fullName = fullName),
               loggedInUser = loggedInUser,
               facility = currentFacility,
               patientUuid = patientUuid,
               addressUuid = addressUuid,
               supplyUuidForBpPassport = { bpPassportUuid },
-              supplyUuidForAlternativeId = { alternativeIdUuid },
-              supplyUuidForPhoneNumber = { phoneNumberUuid }
-          )
+              supplyUuidForAlternativeId = { alternativeIdUuid }
+          ) { phoneNumberUuid }
 
       bpMeasurement?.forEach {
         bloodPressureRepository.save(listOf(testData.bloodPressureMeasurement(
@@ -3275,19 +3256,18 @@ class PatientRepositoryAndroidTest {
         streetAddress = userEnteredPatientStreetAddress,
         zone = userEnteredPatientZone
     )
-    patientRepository.saveOngoingEntry(ongoingPatientEntry)
 
     // when
     val savedPatient = patientRepository
         .saveOngoingEntryAsPatient(
+            patientEntry = ongoingPatientEntry,
             loggedInUser = loggedInUser,
             facility = facilityToSavePatientAt,
             patientUuid = UUID.fromString("0d8b5e31-2695-49b3-ba23-d4f198012870"),
             addressUuid = UUID.fromString("05dfcc13-b855-4e06-be91-7c09c79d98ca"),
             supplyUuidForBpPassport = { UUID.fromString("b6915d20-d396-4c5d-b25c-4b2d9b81fd2b") },
-            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
-            supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
-        )
+            supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") }
+        ) { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
     val savedPatientAddress = patientRepository.address(savedPatient.address.uuid).blockingFirst().toNullable()!!
 
     // then

--- a/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
@@ -180,7 +180,6 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
-        .blockingGet()
 
     val patient = database.patientDao().getOne(savedPatient.uuid)!!
 
@@ -208,7 +207,6 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
-        .blockingGet()
 
     val patient = database.patientDao().patient(savedPatient.uuid)
 
@@ -234,7 +232,6 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
-        .blockingGet()
 
     val patient = database.patientDao().getOne(savedPatient.uuid)!!
 
@@ -269,7 +266,6 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
-        .blockingGet()
         .uuid
 
     val patientProfile = database
@@ -299,8 +295,6 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
-        .ignoreElement()
-        .blockingAwait()
 
     val combinedPatient = patientRepository.search(Name(patientName = "kumar"))
         .blockingFirst()
@@ -342,7 +336,6 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("1a3326ea-0be6-4265-ad17-57a89ed7ee1a") },
             supplyUuidForPhoneNumber = { UUID.fromString("b1c47a77-06ba-48af-8db7-8ec4ded3e906") }
         )
-        .blockingGet()
 
     val opd2 = OngoingNewPatientEntry.PersonalDetails("Alok Kumar", "15/08/1940", null, Gender.Transgender)
     val opa2 = OngoingNewPatientEntry.Address(
@@ -365,7 +358,6 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("2e07d591-f79d-4c9a-8209-54b86e23ac9f") },
             supplyUuidForPhoneNumber = { UUID.fromString("9b51bc94-418b-45a0-9c83-f28dc36147fd") }
         )
-        .blockingGet()
 
     val opd3 = OngoingNewPatientEntry.PersonalDetails("Abhishek Kumar", null, "68", Gender.Transgender)
     val opa3 = OngoingNewPatientEntry.Address(
@@ -388,7 +380,6 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("7fe2b07e-2bc3-42a1-95f3-d171154c6cad") },
             supplyUuidForPhoneNumber = { UUID.fromString("05a0d327-09e2-4bb5-8e6f-dfd911337748") }
         )
-        .blockingGet()
 
     val opd4 = OngoingNewPatientEntry.PersonalDetails("Abshot Kumar", null, "67", Gender.Transgender)
     val opa4 = OngoingNewPatientEntry.Address(
@@ -411,7 +402,6 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("8b7a671c-f0fc-4c83-b9fb-19dce2515c57") },
             supplyUuidForPhoneNumber = { UUID.fromString("2a877a22-a9e6-40ab-b540-c0a49a6a15b4") }
         )
-        .blockingGet()
 
     val search0 = patientRepository.search(Name("Vinod")).blockingFirst()
     assertThat(search0).hasSize(0)
@@ -617,7 +607,6 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
-        .blockingGet()
 
     val searchResults = patientRepository.search(Name(patientName = "Ashok")).blockingFirst()
     assertThat(searchResults).isNotEmpty()
@@ -652,7 +641,6 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
-        .blockingGet()
 
     clock.advanceBy(Duration.ofDays(365))
     val timeOfDeath = Instant.now(clock)
@@ -1558,7 +1546,6 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
-        .blockingGet()
     val savedPatientNationalId = patientRepository.bangladeshNationalIdForPatient(savedPatient.uuid).blockingFirst().toNullable()!!
 
     // then
@@ -1591,7 +1578,6 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
-        .blockingGet()
     val savedPatientNationalId = patientRepository.bangladeshNationalIdForPatient(savedPatient.uuid).blockingFirst()
 
     // then
@@ -1756,7 +1742,6 @@ class PatientRepositoryAndroidTest {
               supplyUuidForAlternativeId = { alternativeIdUuid },
               supplyUuidForPhoneNumber = { phoneNumberUuid }
           )
-          .blockingGet()
 
       bpMeasurement?.forEach {
         bloodPressureRepository.save(listOf(testData.bloodPressureMeasurement(
@@ -3303,7 +3288,6 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
-        .blockingGet()
     val savedPatientAddress = patientRepository.address(savedPatient.addressUuid).blockingFirst().toNullable()!!
 
     // then

--- a/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.patient
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.JsonAdapter
+import io.reactivex.Single
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -162,7 +163,7 @@ class PatientRepositoryAndroidTest {
     val personalDetailsOnlyEntry = OngoingNewPatientEntry(personalDetails = ongoingPersonalDetails)
 
     val savedPatient = patientRepository.saveOngoingEntry(personalDetailsOnlyEntry)
-        .andThen(patientRepository.ongoingEntry())
+        .andThen(Single.fromCallable { patientRepository.ongoingEntry() })
         .map { ongoingEntry -> ongoingEntry.copy(address = ongoingAddress) }
         .map { updatedEntry -> updatedEntry.copy(phoneNumber = ongoingPhoneNumber) }
         .flatMapCompletable { withAddressAndPhoneNumbers -> patientRepository.saveOngoingEntry(withAddressAndPhoneNumbers) }

--- a/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/patient/PatientRepositoryAndroidTest.kt
@@ -181,7 +181,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
 
-    val patient = database.patientDao().getOne(savedPatient.uuid)!!
+    val patient = database.patientDao().getOne(savedPatient.patientUuid)!!
 
     assertThat(patient.dateOfBirth).isEqualTo(LocalDate.parse("1985-04-08"))
     assertThat(patient.age).isNull()
@@ -208,11 +208,11 @@ class PatientRepositoryAndroidTest {
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
 
-    val patient = database.patientDao().patient(savedPatient.uuid)
+    val patient = database.patientDao().patient(savedPatient.patientUuid)
 
     assertThat(patient).isNotNull()
 
-    val savedPhoneNumbers = database.phoneNumberDao().phoneNumber(savedPatient.uuid).firstOrError().blockingGet()
+    val savedPhoneNumbers = database.phoneNumberDao().phoneNumber(savedPatient.patientUuid).firstOrError().blockingGet()
     assertThat(savedPhoneNumbers).isEmpty()
   }
 
@@ -233,7 +233,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
 
-    val patient = database.patientDao().getOne(savedPatient.uuid)!!
+    val patient = database.patientDao().getOne(savedPatient.patientUuid)!!
 
     assertThat(patient.fullName).isEqualTo(patientEntry.personalDetails!!.fullName)
     assertThat(patient.dateOfBirth).isNull()
@@ -266,7 +266,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
-        .uuid
+        .patientUuid
 
     val patientProfile = database
         .patientDao()
@@ -418,10 +418,10 @@ class PatientRepositoryAndroidTest {
 
     assertThat(search2).hasSize(expectedResultsInSearch2.size)
     search2.forEach { searchResult ->
-      val expectedPatient = expectedResultsInSearch2.find { it.fullName == searchResult.fullName }!!
+      val expectedPatient = expectedResultsInSearch2.find { it.patient.fullName == searchResult.fullName }!!
 
-      assertThat(searchResult.fullName).isEqualTo(expectedPatient.fullName)
-      assertThat(searchResult.dateOfBirth).isEqualTo(expectedPatient.dateOfBirth)
+      assertThat(searchResult.fullName).isEqualTo(expectedPatient.patient.fullName)
+      assertThat(searchResult.dateOfBirth).isEqualTo(expectedPatient.patient.dateOfBirth)
     }
   }
 
@@ -612,13 +612,13 @@ class PatientRepositoryAndroidTest {
     assertThat(searchResults).isNotEmpty()
     assertThat(searchResults.first().fullName).isEqualTo("Ashok Kumar")
 
-    patientRepository.updatePatientStatusToDead(patient.uuid)
+    patientRepository.updatePatientStatusToDead(patient.patientUuid)
 
     val searchResultsAfterUpdate = patientRepository.search(Name(patientName = "Ashok")).blockingFirst()
     assertThat(patientRepository.recordCount().blockingFirst()).isEqualTo(1)
     assertThat(searchResultsAfterUpdate).isEmpty()
 
-    val deadPatient: Patient = patientRepository.patient(patient.uuid)
+    val deadPatient: Patient = patientRepository.patient(patient.patientUuid)
         .unwrapJust()
         .blockingFirst()
 
@@ -645,8 +645,8 @@ class PatientRepositoryAndroidTest {
     clock.advanceBy(Duration.ofDays(365))
     val timeOfDeath = Instant.now(clock)
 
-    patientRepository.updatePatientStatusToDead(patient.uuid)
-    val deadPatient: Patient = patientRepository.patient(patient.uuid)
+      patientRepository.updatePatientStatusToDead(patient.patientUuid)
+    val deadPatient: Patient = patientRepository.patient(patient.patientUuid)
         .unwrapJust()
         .blockingFirst()
 
@@ -1546,7 +1546,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
-    val savedPatientNationalId = patientRepository.bangladeshNationalIdForPatient(savedPatient.uuid).blockingFirst().toNullable()!!
+    val savedPatientNationalId = patientRepository.bangladeshNationalIdForPatient(savedPatient.patientUuid).blockingFirst().toNullable()!!
 
     // then
     assertThat(savedPatientNationalId.identifier.value).isEqualTo(nationalId)
@@ -1578,7 +1578,7 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
-    val savedPatientNationalId = patientRepository.bangladeshNationalIdForPatient(savedPatient.uuid).blockingFirst()
+    val savedPatientNationalId = patientRepository.bangladeshNationalIdForPatient(savedPatient.patientUuid).blockingFirst()
 
     // then
     assertThat(savedPatientNationalId).isEqualTo(None<BusinessId>())
@@ -3288,11 +3288,11 @@ class PatientRepositoryAndroidTest {
             supplyUuidForAlternativeId = { UUID.fromString("91539c5f-70a0-4e69-9740-fa8b37fa2f16") },
             supplyUuidForPhoneNumber = { UUID.fromString("b842da76-26f8-4d7d-814a-415209335ecb") }
         )
-    val savedPatientAddress = patientRepository.address(savedPatient.addressUuid).blockingFirst().toNullable()!!
+    val savedPatientAddress = patientRepository.address(savedPatient.address.uuid).blockingFirst().toNullable()!!
 
     // then
     val expectedPatientAddress = testData.patientAddress(
-        uuid = savedPatient.addressUuid,
+        uuid = savedPatient.address.uuid,
         streetAddress = userEnteredPatientStreetAddress,
         colonyOrVillage = userEnteredPatientColony,
         district = userEnteredPatientDistrict,

--- a/app/src/main/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryEffectHandler.kt
@@ -37,7 +37,7 @@ class NewMedicalHistoryEffectHandler @AssistedInject constructor(
         .subtypeEffectHandler<NewMedicalHistoryEffect, NewMedicalHistoryEvent>()
         .addConsumer(OpenPatientSummaryScreen::class.java, { effect -> uiActions.openPatientSummaryScreen(effect.patientUuid) }, schedulersProvider.ui())
         .addTransformer(RegisterPatient::class.java, registerPatient(schedulersProvider.io()))
-        .addTransformer(LoadOngoingPatientEntry::class.java, loadOngoingNewPatientEntry(schedulersProvider.io()))
+        .addTransformer(LoadOngoingPatientEntry::class.java, loadOngoingNewPatientEntry())
         .addTransformer(LoadCurrentFacility::class.java, loadCurrentFacility(schedulersProvider.io()))
         .addTransformer(TriggerSync::class.java, triggerSync())
         .build()
@@ -78,10 +78,10 @@ class NewMedicalHistoryEffectHandler @AssistedInject constructor(
     }
   }
 
-  private fun loadOngoingNewPatientEntry(scheduler: Scheduler): ObservableTransformer<LoadOngoingPatientEntry, NewMedicalHistoryEvent> {
+  private fun loadOngoingNewPatientEntry(): ObservableTransformer<LoadOngoingPatientEntry, NewMedicalHistoryEvent> {
     return ObservableTransformer { effects ->
       effects
-          .flatMapSingle { patientRepository.ongoingEntry().subscribeOn(scheduler) }
+          .map { patientRepository.ongoingEntry() }
           .map(::OngoingPatientEntryLoaded)
     }
   }

--- a/app/src/main/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryEffectHandler.kt
@@ -70,10 +70,10 @@ class NewMedicalHistoryEffectHandler @AssistedInject constructor(
             medicalHistoryRepository
                 .save(
                     uuid = uuidGenerator.v4(),
-                    patientUuid = registeredPatient.uuid,
+                    patientUuid = registeredPatient.patientUuid,
                     historyEntry = ongoingMedicalHistoryEntry
                 )
-                .toSingleDefault(PatientRegistered(registeredPatient.uuid))
+                .toSingleDefault(PatientRegistered(registeredPatient.patientUuid))
           }
     }
   }

--- a/app/src/main/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryEffectHandler.kt
@@ -57,6 +57,7 @@ class NewMedicalHistoryEffectHandler @AssistedInject constructor(
           .map { (user, facility, ongoingMedicalHistoryEntry) ->
             patientRepository
                 .saveOngoingEntryAsPatient(
+                    patientEntry = patientRepository.ongoingEntry(),
                     loggedInUser = user,
                     facility = facility,
                     patientUuid = uuidGenerator.v4(),

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffectHandler.kt
@@ -19,7 +19,6 @@ import org.simple.clinic.newentry.Field.PhoneNumber
 import org.simple.clinic.newentry.Field.State
 import org.simple.clinic.newentry.country.InputFields
 import org.simple.clinic.newentry.country.InputFieldsFactory
-import org.simple.clinic.patient.OngoingNewPatientEntry
 import org.simple.clinic.patient.OngoingNewPatientEntry.Address
 import org.simple.clinic.patient.PatientEntryValidationError
 import org.simple.clinic.patient.PatientEntryValidationError.AgeExceedsMaxLimit
@@ -138,16 +137,10 @@ class PatientEntryEffectHandler @AssistedInject constructor(
       savePatientEffects
           .map { it.entry }
           .subscribeOn(scheduler)
-          .flatMapSingle { savePatientEntry(it) }
+          .doOnNext(patientRepository::saveOngoingEntry)
           .doOnNext { patientRegisteredCount.set(patientRegisteredCount.get().plus(1)) }
           .map { PatientEntrySaved }
     }
-  }
-
-  private fun savePatientEntry(entry: OngoingNewPatientEntry): Single<Unit> {
-    return patientRepository
-        .saveOngoingEntry(entry)
-        .andThen(Single.just(Unit))
   }
 
   private fun showValidationErrors(errors: List<PatientEntryValidationError>) {

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryEffectHandler.kt
@@ -8,7 +8,6 @@ import io.reactivex.ObservableTransformer
 import io.reactivex.Scheduler
 import io.reactivex.Single
 import io.reactivex.rxkotlin.Singles
-import org.simple.clinic.appconfig.Country
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.newentry.Field.Age
 import org.simple.clinic.newentry.Field.ColonyOrVillage
@@ -43,7 +42,6 @@ import org.simple.clinic.patient.PatientEntryValidationError.PhoneNumberNonNullB
 import org.simple.clinic.patient.PatientEntryValidationError.StateEmpty
 import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.platform.analytics.Analytics
-import org.simple.clinic.user.UserSession
 import org.simple.clinic.util.ValueChangedCallback
 import org.simple.clinic.util.scheduler.SchedulersProvider
 import javax.inject.Named
@@ -90,7 +88,7 @@ class PatientEntryEffectHandler @AssistedInject constructor(
     return ObservableTransformer { fetchPatientEntries ->
       val getPatientEntryAndFacility = Singles
           .zip(
-              patientRepository.ongoingEntry(),
+              Single.just(patientRepository.ongoingEntry()),
               facilityRepository.currentFacility().firstOrError()
           )
 

--- a/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
@@ -236,10 +236,8 @@ class PatientRepository @Inject constructor(
     return ongoingNewPatientEntry
   }
 
-  fun saveOngoingEntry(ongoingEntry: OngoingNewPatientEntry): Completable {
-    return Completable.fromAction {
-      ongoingNewPatientEntry = ongoingEntry
-    }
+  fun saveOngoingEntry(ongoingEntry: OngoingNewPatientEntry) {
+    ongoingNewPatientEntry = ongoingEntry
   }
 
   fun saveOngoingEntryAsPatient(

--- a/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
@@ -241,6 +241,7 @@ class PatientRepository @Inject constructor(
   }
 
   fun saveOngoingEntryAsPatient(
+      patientEntry: OngoingNewPatientEntry,
       loggedInUser: User,
       facility: Facility,
       patientUuid: UUID,
@@ -250,6 +251,7 @@ class PatientRepository @Inject constructor(
       supplyUuidForPhoneNumber: () -> UUID
   ): PatientProfile {
     val patientProfile = convertOngoingPatientEntryToPatientProfile(
+        patientEntry = patientEntry,
         loggedInUser = loggedInUser,
         facility = facility,
         patientUuid = patientUuid,
@@ -265,6 +267,7 @@ class PatientRepository @Inject constructor(
   }
 
   private fun convertOngoingPatientEntryToPatientProfile(
+      patientEntry: OngoingNewPatientEntry,
       loggedInUser: User,
       facility: Facility,
       patientUuid: UUID,
@@ -273,7 +276,7 @@ class PatientRepository @Inject constructor(
       supplyUuidForAlternativeId: () -> UUID,
       supplyUuidForPhoneNumber: () -> UUID
   ): PatientProfile {
-    return with(ongoingNewPatientEntry) {
+    return with(patientEntry) {
       requireNotNull(personalDetails)
       requireNotNull(address)
 

--- a/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
@@ -232,8 +232,8 @@ class PatientRepository @Inject constructor(
     )
   }
 
-  fun ongoingEntry(): Single<OngoingNewPatientEntry> {
-    return Single.fromCallable { ongoingNewPatientEntry }
+  fun ongoingEntry(): OngoingNewPatientEntry {
+    return ongoingNewPatientEntry
   }
 
   fun saveOngoingEntry(ongoingEntry: OngoingNewPatientEntry): Completable {

--- a/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
@@ -248,7 +248,7 @@ class PatientRepository @Inject constructor(
       supplyUuidForBpPassport: () -> UUID,
       supplyUuidForAlternativeId: () -> UUID,
       supplyUuidForPhoneNumber: () -> UUID
-  ): Patient {
+  ): PatientProfile {
     val patientProfile = convertOngoingPatientEntryToPatientProfile(
         loggedInUser = loggedInUser,
         facility = facility,
@@ -261,7 +261,7 @@ class PatientRepository @Inject constructor(
 
     saveRecords(listOf(patientProfile))
 
-    return patientProfile.patient
+    return patientProfile
   }
 
   private fun convertOngoingPatientEntryToPatientProfile(

--- a/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
@@ -248,24 +248,20 @@ class PatientRepository @Inject constructor(
       supplyUuidForBpPassport: () -> UUID,
       supplyUuidForAlternativeId: () -> UUID,
       supplyUuidForPhoneNumber: () -> UUID
-  ): Single<Patient> {
-    return Single
-        .fromCallable {
-          convertOngoingPatientEntryToPatientProfile(
-              loggedInUser = loggedInUser,
-              facility = facility,
-              patientUuid = patientUuid,
-              addressUuid = addressUuid,
-              supplyUuidForBpPassport = supplyUuidForBpPassport,
-              supplyUuidForAlternativeId = supplyUuidForAlternativeId,
-              supplyUuidForPhoneNumber = supplyUuidForPhoneNumber
-          )
-        }
-        .flatMap { patientProfile ->
-          save(listOf(patientProfile))
-              .toSingleDefault(patientProfile)
-        }
-        .map(PatientProfile::patient)
+  ): Patient {
+    val patientProfile = convertOngoingPatientEntryToPatientProfile(
+        loggedInUser = loggedInUser,
+        facility = facility,
+        patientUuid = patientUuid,
+        addressUuid = addressUuid,
+        supplyUuidForBpPassport = supplyUuidForBpPassport,
+        supplyUuidForAlternativeId = supplyUuidForAlternativeId,
+        supplyUuidForPhoneNumber = supplyUuidForPhoneNumber
+    )
+
+    saveRecords(listOf(patientProfile))
+
+    return patientProfile.patient
   }
 
   private fun convertOngoingPatientEntryToPatientProfile(

--- a/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
@@ -568,24 +568,17 @@ class PatientRepository @Inject constructor(
         .toObservable()
   }
 
-
   fun addIdentifierToPatient(
       uuid: UUID,
       patientUuid: UUID,
       identifier: Identifier,
       assigningUser: User
   ): Single<BusinessId> {
-    val metaAndVersion = createBusinessIdMetaDataForIdentifier(identifier.type, assigningUser)
-    val now = Instant.now(utcClock)
-    val businessId = BusinessId(
-        uuid = uuid,
+    val businessId = createBusinessIdFromIdentifier(
+        id = uuid,
         patientUuid = patientUuid,
         identifier = identifier,
-        metaDataVersion = metaAndVersion.metaDataVersion,
-        metaData = metaAndVersion.metaData,
-        createdAt = now,
-        updatedAt = now,
-        deletedAt = null
+        user = assigningUser
     )
 
     return saveBusinessId(businessId)

--- a/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
@@ -41,7 +41,6 @@ import javax.inject.Inject
 import javax.inject.Named
 
 typealias PatientUuid = UUID
-typealias FacilityUuid = UUID
 
 @AppScope
 class PatientRepository @Inject constructor(
@@ -129,8 +128,6 @@ class PatientRepository @Inject constructor(
         .searchByPhoneNumber(phoneNumber, config.limitOfSearchResults)
         .toObservable()
   }
-
-  private fun savePatient(patient: Patient): Completable = Completable.fromAction { database.patientDao().save(patient) }
 
   fun patient(uuid: UUID): Observable<Optional<Patient>> {
     return database.patientDao()
@@ -480,16 +477,6 @@ class PatientRepository @Inject constructor(
         }
         .flatMapCompletable(this::savePhoneNumber)
         .andThen(Completable.fromAction { setSyncStatus(listOf(patientUuid), PENDING) })
-  }
-
-  private fun convertToDate(dateOfBirth: String?): LocalDate? {
-    return dateOfBirth?.let { dateOfBirthFormat.parse(dateOfBirth, LocalDate::from) }
-  }
-
-  private fun saveAddress(address: PatientAddress): Completable {
-    return Completable.fromAction {
-      database.addressDao().save(address)
-    }
   }
 
   fun address(addressUuid: UUID): Observable<Optional<PatientAddress>> {

--- a/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
@@ -27,8 +27,6 @@ import org.simple.clinic.patient.sync.PatientPayload
 import org.simple.clinic.reports.ReportsRepository
 import org.simple.clinic.sync.SynceableRepository
 import org.simple.clinic.user.User
-import org.simple.clinic.util.Just
-import org.simple.clinic.util.None
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.UtcClock
 import org.simple.clinic.util.scheduler.SchedulersProvider
@@ -133,12 +131,7 @@ class PatientRepository @Inject constructor(
     return database.patientDao()
         .patient(uuid)
         .toObservable()
-        .map { patients ->
-          when {
-            patients.isNotEmpty() -> Just(patients.first())
-            else -> None<Patient>()
-          }
-        }
+        .map { patients -> Optional.ofNullable(patients.firstOrNull()) }
   }
 
   fun patientImmediate(uuid: UUID): Patient? {
@@ -480,12 +473,7 @@ class PatientRepository @Inject constructor(
     return database.addressDao()
         .address(addressUuid)
         .toObservable()
-        .map { addresses ->
-          when {
-            addresses.isNotEmpty() -> Just(addresses.first())
-            else -> None<PatientAddress>()
-          }
-        }
+        .map { addresses -> Optional.ofNullable(addresses.firstOrNull()) }
   }
 
   private fun savePhoneNumber(number: PatientPhoneNumber): Completable {
@@ -498,12 +486,7 @@ class PatientRepository @Inject constructor(
     return database.phoneNumberDao()
         .phoneNumber(patientUuid)
         .toObservable()
-        .map { numbers ->
-          when {
-            numbers.isNotEmpty() -> Just(numbers.first())
-            else -> None<PatientPhoneNumber>()
-          }
-        }
+        .map { numbers -> Optional.ofNullable(numbers.firstOrNull()) }
   }
 
   fun latestPhoneNumberForPatient(patientUuid: UUID): Optional<PatientPhoneNumber> {
@@ -600,13 +583,7 @@ class PatientRepository @Inject constructor(
     return database
         .patientDao()
         .findPatientsWithBusinessId(identifier)
-        .map { patients ->
-          if (patients.isEmpty()) {
-            None()
-          } else {
-            patients.first().toOptional()
-          }
-        }
+        .map { patients -> Optional.ofNullable(patients.firstOrNull()) }
         .toObservable()
 
   }
@@ -623,13 +600,7 @@ class PatientRepository @Inject constructor(
     return database
         .businessIdDao()
         .latestForPatientByType(patientUuid, BangladeshNationalId)
-        .map { bangladeshNationalId ->
-          if (bangladeshNationalId.isEmpty()) {
-            None()
-          } else {
-            bangladeshNationalId.first().toOptional()
-          }
-        }
+        .map { bangladeshNationalId -> Optional.ofNullable(bangladeshNationalId.firstOrNull()) }
         .toObservable()
   }
 

--- a/app/src/main/java/org/simple/clinic/search/results/PatientSearchResultsEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/search/results/PatientSearchResultsEffectHandler.kt
@@ -39,12 +39,8 @@ class PatientSearchResultsEffectHandler @AssistedInject constructor(
   private fun saveNewPatientEntry(): ObservableTransformer<SaveNewOngoingPatientEntry, PatientSearchResultsEvent> {
     return ObservableTransformer { effects ->
       effects
-          .observeOn(schedulers.io())
-          .switchMap { effect ->
-            patientRepository
-                .saveOngoingEntry(effect.entry)
-                .andThen(Observable.just(NewOngoingPatientEntrySaved))
-          }
+          .doOnNext { effect -> patientRepository.saveOngoingEntry(effect.entry) }
+          .map { NewOngoingPatientEntrySaved }
     }
   }
 

--- a/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreenLogicTest.kt
@@ -9,7 +9,6 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import dagger.Lazy
 import io.reactivex.Completable
-import io.reactivex.Single
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
 import org.junit.After
@@ -97,7 +96,7 @@ class NewMedicalHistoryScreenLogicTest {
         supplyUuidForBpPassport = any(),
         supplyUuidForAlternativeId = any(),
         supplyUuidForPhoneNumber = any()
-    )).thenReturn(Single.just(savedPatient))
+    )).thenReturn(savedPatient)
 
     // when
     startMobiusLoop(uuidGenerator = uuidGenerator)
@@ -111,7 +110,15 @@ class NewMedicalHistoryScreenLogicTest {
 
     // then
     with(inOrder(medicalHistoryRepository, patientRepository, uiActions)) {
-      verify(patientRepository).saveOngoingEntryAsPatient(eq(user), eq(facility), eq(patientUuid), eq(addressUuid), any(), any(), any())
+      verify(patientRepository).saveOngoingEntryAsPatient(
+          loggedInUser = eq(user),
+          facility = eq(facility),
+          patientUuid = eq(patientUuid),
+          addressUuid = eq(addressUuid),
+          supplyUuidForBpPassport = any(),
+          supplyUuidForAlternativeId = any(),
+          supplyUuidForPhoneNumber = any()
+      )
       verify(medicalHistoryRepository).save(
           uuid = medicalHistoryUuid,
           patientUuid = savedPatient.uuid,
@@ -144,7 +151,7 @@ class NewMedicalHistoryScreenLogicTest {
         supplyUuidForBpPassport = any(),
         supplyUuidForAlternativeId = any(),
         supplyUuidForPhoneNumber = any()
-    )).thenReturn(Single.just(savedPatient))
+    )).thenReturn(savedPatient)
 
     // when
     startMobiusLoop(uuidGenerator = uuidGenerator)
@@ -153,7 +160,15 @@ class NewMedicalHistoryScreenLogicTest {
 
     // then
     with(inOrder(medicalHistoryRepository, patientRepository, uiActions)) {
-      verify(patientRepository).saveOngoingEntryAsPatient(eq(user), eq(facility), eq(patientUuid), eq(addressUuid), any(), any(), any())
+      verify(patientRepository).saveOngoingEntryAsPatient(
+          loggedInUser = eq(user),
+          facility = eq(facility),
+          patientUuid = eq(patientUuid),
+          addressUuid = eq(addressUuid),
+          supplyUuidForBpPassport = any(),
+          supplyUuidForAlternativeId = any(),
+          supplyUuidForPhoneNumber = any()
+      )
       verify(medicalHistoryRepository).save(
           uuid = medicalHistoryUuid,
           patientUuid = savedPatient.uuid,
@@ -187,7 +202,7 @@ class NewMedicalHistoryScreenLogicTest {
         supplyUuidForBpPassport = any(),
         supplyUuidForAlternativeId = any(),
         supplyUuidForPhoneNumber = any()
-    )).thenReturn(Single.just(savedPatient))
+    )).thenReturn(savedPatient)
 
     // when
     startMobiusLoop(uuidGenerator = uuidGenerator)
@@ -210,7 +225,15 @@ class NewMedicalHistoryScreenLogicTest {
 
     // then
     with(inOrder(medicalHistoryRepository, patientRepository, uiActions)) {
-      verify(patientRepository).saveOngoingEntryAsPatient(eq(user), eq(facility), eq(patientUuid), eq(addressUuid), any(), any(), any())
+      verify(patientRepository).saveOngoingEntryAsPatient(
+          loggedInUser = eq(user),
+          facility = eq(facility),
+          patientUuid = eq(patientUuid),
+          addressUuid = eq(addressUuid),
+          supplyUuidForBpPassport = any(),
+          supplyUuidForAlternativeId = any(),
+          supplyUuidForPhoneNumber = any()
+      )
       verify(medicalHistoryRepository).save(
           uuid = medicalHistoryUuid,
           patientUuid = savedPatient.uuid,

--- a/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreenLogicTest.kt
@@ -70,7 +70,7 @@ class NewMedicalHistoryScreenLogicTest {
         dateOfBirth = null,
         age = "20",
         gender = Gender.Transgender))
-    whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(patientEntry))
+    whenever(patientRepository.ongoingEntry()).thenReturn(patientEntry)
 
     startMobiusLoop(ongoingPatientEntry = patientEntry)
 
@@ -231,7 +231,7 @@ class NewMedicalHistoryScreenLogicTest {
       uuidGenerator: UuidGenerator = FakeUuidGenerator.fixed(medicalHistoryUuid)
   ) {
     whenever(medicalHistoryRepository.save(eq(medicalHistoryUuid), eq(patientUuid), any())).thenReturn(Completable.complete())
-    whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(ongoingPatientEntry))
+    whenever(patientRepository.ongoingEntry()).thenReturn(ongoingPatientEntry)
 
     val effectHandler = NewMedicalHistoryEffectHandler(
         uiActions = uiActions,

--- a/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreenLogicTest.kt
@@ -28,6 +28,7 @@ import org.simple.clinic.medicalhistory.OngoingMedicalHistoryEntry
 import org.simple.clinic.patient.Gender
 import org.simple.clinic.patient.OngoingNewPatientEntry
 import org.simple.clinic.patient.OngoingNewPatientEntry.PersonalDetails
+import org.simple.clinic.patient.PatientProfile
 import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.util.RxErrorsRule
 import org.simple.clinic.util.scheduler.TrampolineSchedulersProvider
@@ -87,11 +88,13 @@ class NewMedicalHistoryScreenLogicTest {
         patientUuid = patientUuid,
         patientAddressUuid = addressUuid
     )
+    val patientEntry = savedPatient.toOngoingEntry()
 
     val uuidGenerator = mock<UuidGenerator>()
     whenever(uuidGenerator.v4()).thenReturn(patientUuid, addressUuid, medicalHistoryUuid)
 
     whenever(patientRepository.saveOngoingEntryAsPatient(
+        patientEntry = eq(patientEntry),
         loggedInUser = eq(user),
         facility = eq(facility),
         patientUuid = eq(patientUuid),
@@ -102,7 +105,7 @@ class NewMedicalHistoryScreenLogicTest {
     )).thenReturn(savedPatient)
 
     // when
-    startMobiusLoop(uuidGenerator = uuidGenerator)
+    startMobiusLoop(uuidGenerator = uuidGenerator, ongoingPatientEntry = patientEntry)
 
     uiEvents.onNext(NewMedicalHistoryAnswerToggled(DIAGNOSED_WITH_HYPERTENSION, No))
     uiEvents.onNext(NewMedicalHistoryAnswerToggled(HAS_HAD_A_HEART_ATTACK, No))
@@ -114,6 +117,7 @@ class NewMedicalHistoryScreenLogicTest {
     // then
     with(inOrder(medicalHistoryRepository, patientRepository, uiActions)) {
       verify(patientRepository).saveOngoingEntryAsPatient(
+          patientEntry = eq(patientEntry),
           loggedInUser = eq(user),
           facility = eq(facility),
           patientUuid = eq(patientUuid),
@@ -145,11 +149,13 @@ class NewMedicalHistoryScreenLogicTest {
         patientUuid = patientUuid,
         patientAddressUuid = addressUuid
     )
+    val patientEntry = savedPatient.toOngoingEntry()
 
     val uuidGenerator = mock<UuidGenerator>()
     whenever(uuidGenerator.v4()).thenReturn(patientUuid, addressUuid, medicalHistoryUuid)
 
     whenever(patientRepository.saveOngoingEntryAsPatient(
+        patientEntry = eq(patientEntry),
         loggedInUser = eq(user),
         facility = eq(facility),
         patientUuid = eq(patientUuid),
@@ -160,13 +166,14 @@ class NewMedicalHistoryScreenLogicTest {
     )).thenReturn(savedPatient)
 
     // when
-    startMobiusLoop(uuidGenerator = uuidGenerator)
+    startMobiusLoop(uuidGenerator = uuidGenerator, ongoingPatientEntry = patientEntry)
 
     uiEvents.onNext(SaveMedicalHistoryClicked())
 
     // then
     with(inOrder(medicalHistoryRepository, patientRepository, uiActions)) {
       verify(patientRepository).saveOngoingEntryAsPatient(
+          patientEntry = eq(patientEntry),
           loggedInUser = eq(user),
           facility = eq(facility),
           patientUuid = eq(patientUuid),
@@ -199,11 +206,13 @@ class NewMedicalHistoryScreenLogicTest {
         patientUuid = patientUuid,
         patientAddressUuid = addressUuid
     )
+    val patientEntry = savedPatient.toOngoingEntry()
 
     val uuidGenerator = mock<UuidGenerator>()
     whenever(uuidGenerator.v4()).thenReturn(patientUuid, addressUuid, medicalHistoryUuid)
 
     whenever(patientRepository.saveOngoingEntryAsPatient(
+        patientEntry = eq(patientEntry),
         loggedInUser = eq(user),
         facility = eq(facility),
         patientUuid = eq(patientUuid),
@@ -214,7 +223,7 @@ class NewMedicalHistoryScreenLogicTest {
     )).thenReturn(savedPatient)
 
     // when
-    startMobiusLoop(uuidGenerator = uuidGenerator)
+    startMobiusLoop(uuidGenerator = uuidGenerator, ongoingPatientEntry = patientEntry)
 
     // Initial answers
     uiEvents.onNext(NewMedicalHistoryAnswerToggled(DIAGNOSED_WITH_HYPERTENSION, No))
@@ -235,6 +244,7 @@ class NewMedicalHistoryScreenLogicTest {
     // then
     with(inOrder(medicalHistoryRepository, patientRepository, uiActions)) {
       verify(patientRepository).saveOngoingEntryAsPatient(
+          patientEntry = eq(patientEntry),
           loggedInUser = eq(user),
           facility = eq(facility),
           patientUuid = eq(patientUuid),
@@ -287,4 +297,8 @@ class NewMedicalHistoryScreenLogicTest {
 
     testFixture.start()
   }
+}
+
+private fun PatientProfile.toOngoingEntry(): OngoingNewPatientEntry {
+  return OngoingNewPatientEntry.fromFullName(patient.fullName)
 }

--- a/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreenLogicTest.kt
@@ -82,8 +82,11 @@ class NewMedicalHistoryScreenLogicTest {
   @Test
   fun `when save is clicked with selected answers then patient with the answers should be saved and summary screen should be opened`() {
     // given
-    val savedPatient = TestData.patient(uuid = patientUuid)
     val addressUuid = UUID.fromString("79f6d1bc-0e10-480b-9cce-43c628d827b7")
+    val savedPatient = TestData.patientProfile(
+        patientUuid = patientUuid,
+        patientAddressUuid = addressUuid
+    )
 
     val uuidGenerator = mock<UuidGenerator>()
     whenever(uuidGenerator.v4()).thenReturn(patientUuid, addressUuid, medicalHistoryUuid)
@@ -121,7 +124,7 @@ class NewMedicalHistoryScreenLogicTest {
       )
       verify(medicalHistoryRepository).save(
           uuid = medicalHistoryUuid,
-          patientUuid = savedPatient.uuid,
+          patientUuid = savedPatient.patientUuid,
           historyEntry = OngoingMedicalHistoryEntry(
               hasHadHeartAttack = No,
               hasHadStroke = No,
@@ -130,15 +133,18 @@ class NewMedicalHistoryScreenLogicTest {
               hasDiabetes = Yes
           )
       )
-      verify(uiActions).openPatientSummaryScreen(savedPatient.uuid)
+      verify(uiActions).openPatientSummaryScreen(savedPatient.patientUuid)
     }
   }
 
   @Test
   fun `when save is clicked with no answers then patient with an empty medical history should be saved and summary screen should be opened`() {
     // given
-    val savedPatient = TestData.patient(uuid = patientUuid)
     val addressUuid = UUID.fromString("79f6d1bc-0e10-480b-9cce-43c628d827b7")
+    val savedPatient = TestData.patientProfile(
+        patientUuid = patientUuid,
+        patientAddressUuid = addressUuid
+    )
 
     val uuidGenerator = mock<UuidGenerator>()
     whenever(uuidGenerator.v4()).thenReturn(patientUuid, addressUuid, medicalHistoryUuid)
@@ -171,7 +177,7 @@ class NewMedicalHistoryScreenLogicTest {
       )
       verify(medicalHistoryRepository).save(
           uuid = medicalHistoryUuid,
-          patientUuid = savedPatient.uuid,
+          patientUuid = savedPatient.patientUuid,
           historyEntry = OngoingMedicalHistoryEntry(
               // We currently default the hypertension diagnosis answer to 'Yes' if the facility
               // does not support diabetes management. The mock facility we use in tests has DM
@@ -181,15 +187,18 @@ class NewMedicalHistoryScreenLogicTest {
               hasHadKidneyDisease = Unanswered,
               diagnosedWithHypertension = Yes,
               hasDiabetes = Unanswered))
-      verify(uiActions).openPatientSummaryScreen(savedPatient.uuid)
+      verify(uiActions).openPatientSummaryScreen(savedPatient.patientUuid)
     }
   }
 
   @Test
   fun `when an already selected answer for a question is changed, the new answer should be used when saving the medical history`() {
     // given
-    val savedPatient = TestData.patient(uuid = patientUuid)
     val addressUuid = UUID.fromString("79f6d1bc-0e10-480b-9cce-43c628d827b7")
+    val savedPatient = TestData.patientProfile(
+        patientUuid = patientUuid,
+        patientAddressUuid = addressUuid
+    )
 
     val uuidGenerator = mock<UuidGenerator>()
     whenever(uuidGenerator.v4()).thenReturn(patientUuid, addressUuid, medicalHistoryUuid)
@@ -236,7 +245,7 @@ class NewMedicalHistoryScreenLogicTest {
       )
       verify(medicalHistoryRepository).save(
           uuid = medicalHistoryUuid,
-          patientUuid = savedPatient.uuid,
+          patientUuid = savedPatient.patientUuid,
           historyEntry = OngoingMedicalHistoryEntry(
               hasHadHeartAttack = Unanswered,
               hasHadStroke = Unanswered,
@@ -245,7 +254,7 @@ class NewMedicalHistoryScreenLogicTest {
               hasDiabetes = No
           )
       )
-      verify(uiActions).openPatientSummaryScreen(savedPatient.uuid)
+      verify(uiActions).openPatientSummaryScreen(savedPatient.patientUuid)
     }
   }
 

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryEffectHandlerTest.kt
@@ -6,7 +6,6 @@ import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.Observable
-import io.reactivex.Single
 import org.junit.After
 import org.junit.Test
 import org.simple.clinic.TestData
@@ -103,7 +102,7 @@ class PatientEntryEffectHandlerTest {
 
   private fun setupTestCase() {
     whenever(facilityRepository.currentFacility()).thenReturn(Observable.just(facility))
-    whenever(patientRepository.ongoingEntry()).thenReturn(Single.just(entry))
+    whenever(patientRepository.ongoingEntry()).thenReturn(entry)
 
     testCase = EffectHandlerTestCase(effectHandler.build())
   }

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenLogicTest.kt
@@ -12,7 +12,6 @@ import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
-import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
@@ -167,7 +166,6 @@ class PatientEntryScreenLogicTest {
   @Test
   fun `when save button is clicked then a patient record should be created from the form input`() {
     whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
-    whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     whenever(patientRegisteredCount.get()).doReturn(0)
     screenCreated()
 
@@ -209,7 +207,6 @@ class PatientEntryScreenLogicTest {
     val bangladeshNationalId = Identifier("123456789012", BangladeshNationalId)
 
     whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
-    whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     whenever(patientRegisteredCount.get()).doReturn(0)
     screenCreated()
 
@@ -264,7 +261,6 @@ class PatientEntryScreenLogicTest {
     )
 
     whenever(patientRepository.ongoingEntry()).doReturn(ongoingEntry)
-    whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     whenever(patientRegisteredCount.get()).doReturn(existingPatientRegisteredCount)
     screenCreated()
 
@@ -462,7 +458,6 @@ class PatientEntryScreenLogicTest {
   @Test
   fun `regression test for validations 1`() {
     whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
-    whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     screenCreated()
 
     with(uiEvents) {
@@ -485,7 +480,6 @@ class PatientEntryScreenLogicTest {
   @Test
   fun `regression test for validations 2`() {
     whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
-    whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     screenCreated()
 
     with(uiEvents) {
@@ -508,7 +502,6 @@ class PatientEntryScreenLogicTest {
   @Test
   fun `regression test for validations 3`() {
     whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
-    whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     screenCreated()
 
     with(uiEvents) {
@@ -528,10 +521,10 @@ class PatientEntryScreenLogicTest {
     verify(patientRepository, never()).saveOngoingEntry(any())
   }
 
+  // TODO (vs) 27/10/20: Tighten assertions in this test`
   @Test
   fun `regression test for validations 4`() {
     whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
-    whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     whenever(patientRegisteredCount.get()).doReturn(0)
     screenCreated()
 
@@ -576,7 +569,6 @@ class PatientEntryScreenLogicTest {
   @Test
   fun `when validation errors are shown then the form should be scrolled to the first field with error`() {
     whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
-    whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     screenCreated()
 
     with(uiEvents) {
@@ -603,7 +595,6 @@ class PatientEntryScreenLogicTest {
   fun `when the ongoing entry has an identifier it must be retained when accepting input`() {
     val identifier = Identifier(value = "id", type = BpPassport)
     whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry(identifier = identifier))
-    whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     whenever(patientRegisteredCount.get()).doReturn(0)
     screenCreated()
 

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryScreenLogicTest.kt
@@ -14,7 +14,6 @@ import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.Completable
 import io.reactivex.Observable
-import io.reactivex.Single
 import io.reactivex.subjects.PublishSubject
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
@@ -103,7 +102,6 @@ class PatientEntryScreenLogicTest {
             state = "state",
             streetAddress = "street"
         )))
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.never())
 
     val effectHandler = PatientEntryEffectHandler(
         facilityRepository = facilityRepository,
@@ -135,7 +133,7 @@ class PatientEntryScreenLogicTest {
 
   @Test
   fun `when screen is created then existing data should be pre-filled`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
 
     screenCreated()
 
@@ -159,7 +157,7 @@ class PatientEntryScreenLogicTest {
         streetAddress = "streetAddress",
         zone = "zone"
     )
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry(address = address)))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry(address = address))
 
     screenCreated()
 
@@ -168,7 +166,7 @@ class PatientEntryScreenLogicTest {
 
   @Test
   fun `when save button is clicked then a patient record should be created from the form input`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
     whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     whenever(patientRegisteredCount.get()).doReturn(0)
     screenCreated()
@@ -210,7 +208,7 @@ class PatientEntryScreenLogicTest {
   fun `when bangladesh national id is entered and save is clicked then patient should get registered`() {
     val bangladeshNationalId = Identifier("123456789012", BangladeshNationalId)
 
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
     whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     whenever(patientRegisteredCount.get()).doReturn(0)
     screenCreated()
@@ -265,7 +263,7 @@ class PatientEntryScreenLogicTest {
         phoneNumber = OngoingNewPatientEntry.PhoneNumber("1234567890")
     )
 
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(ongoingEntry))
+    whenever(patientRepository.ongoingEntry()).doReturn(ongoingEntry)
     whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     whenever(patientRegisteredCount.get()).doReturn(existingPatientRegisteredCount)
     screenCreated()
@@ -280,7 +278,7 @@ class PatientEntryScreenLogicTest {
 
   @Test
   fun `date-of-birth and age fields should only be visible while one of them is empty`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
     screenCreated()
 
     with(uiEvents) {
@@ -305,7 +303,7 @@ class PatientEntryScreenLogicTest {
   //                      pivotal story - https://www.pivotaltracker.com/story/show/168946268
   @Test
   fun `when both date-of-birth and age fields have text then an assertion error should be thrown`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
     screenCreated()
     errorConsumer = { assertThat(it).isInstanceOf(AssertionError::class.java) }
 
@@ -317,7 +315,7 @@ class PatientEntryScreenLogicTest {
 
   @Test
   fun `while date-of-birth has focus or has some input then date format should be shown in the label`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
     screenCreated()
 
     with(uiEvents) {
@@ -334,7 +332,7 @@ class PatientEntryScreenLogicTest {
 
   @Test
   fun `when save is clicked then user input should be validated`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
     screenCreated()
 
     with(uiEvents) {
@@ -392,7 +390,7 @@ class PatientEntryScreenLogicTest {
 
   @Test
   fun `when input validation fails, the errors must be sent to analytics`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
     screenCreated()
 
     with(uiEvents) {
@@ -431,7 +429,7 @@ class PatientEntryScreenLogicTest {
 
   @Test
   fun `validation errors should be cleared on every input change`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
     screenCreated()
 
     with(uiEvents) {
@@ -463,7 +461,7 @@ class PatientEntryScreenLogicTest {
 
   @Test
   fun `regression test for validations 1`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
     whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     screenCreated()
 
@@ -486,7 +484,7 @@ class PatientEntryScreenLogicTest {
 
   @Test
   fun `regression test for validations 2`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
     whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     screenCreated()
 
@@ -509,7 +507,7 @@ class PatientEntryScreenLogicTest {
 
   @Test
   fun `regression test for validations 3`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
     whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     screenCreated()
 
@@ -532,7 +530,7 @@ class PatientEntryScreenLogicTest {
 
   @Test
   fun `regression test for validations 4`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
     whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     whenever(patientRegisteredCount.get()).doReturn(0)
     screenCreated()
@@ -558,7 +556,7 @@ class PatientEntryScreenLogicTest {
   @Test
   @Parameters(method = "params for gender values")
   fun `when gender is selected for the first time then the form should be scrolled to bottom`(gender: Gender) {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
     screenCreated()
 
     with(uiEvents) {
@@ -577,7 +575,7 @@ class PatientEntryScreenLogicTest {
 
   @Test
   fun `when validation errors are shown then the form should be scrolled to the first field with error`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry()))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry())
     whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     screenCreated()
 
@@ -604,7 +602,7 @@ class PatientEntryScreenLogicTest {
   @Test
   fun `when the ongoing entry has an identifier it must be retained when accepting input`() {
     val identifier = Identifier(value = "id", type = BpPassport)
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry(identifier = identifier)))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry(identifier = identifier))
     whenever(patientRepository.saveOngoingEntry(any())).doReturn(Completable.complete())
     whenever(patientRegisteredCount.get()).doReturn(0)
     screenCreated()
@@ -645,7 +643,7 @@ class PatientEntryScreenLogicTest {
 
   @Test
   fun `when the ongoing patient entry has an identifier, the identifier section must be shown`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry(identifier = Identifier("id", BpPassport))))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry(identifier = Identifier("id", BpPassport)))
 
     screenCreated()
 
@@ -654,7 +652,7 @@ class PatientEntryScreenLogicTest {
 
   @Test
   fun `when the ongoing patient entry does not have an identifier, the identifier section must be hidden`() {
-    whenever(patientRepository.ongoingEntry()).doReturn(Single.just(OngoingNewPatientEntry(identifier = null)))
+    whenever(patientRepository.ongoingEntry()).doReturn(OngoingNewPatientEntry(identifier = null))
 
     screenCreated()
 

--- a/app/src/test/java/org/simple/clinic/search/results/PatientSearchResultsLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/search/results/PatientSearchResultsLogicTest.kt
@@ -1,11 +1,8 @@
 package org.simple.clinic.search.results
 
-import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
-import com.nhaarman.mockitokotlin2.whenever
-import io.reactivex.Completable
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
 import org.junit.After
@@ -81,8 +78,6 @@ class PatientSearchResultsLogicTest {
     val ongoingEntry = OngoingNewPatientEntry.fromFullName(fullName)
     val searchCriteria = PatientSearchCriteria.Name(fullName)
 
-    whenever(patientRepository.saveOngoingEntry(ongoingEntry)) doReturn (Completable.complete())
-
     // when
     setupController(searchCriteria)
     uiEvents.onNext(PatientSearchResultRegisterNewPatient(searchCriteria))
@@ -103,8 +98,6 @@ class PatientSearchResultsLogicTest {
         .withIdentifier(identifier)
     val searchCriteria = PatientSearchCriteria.Name(fullName, identifier)
 
-    whenever(patientRepository.saveOngoingEntry(ongoingEntry)) doReturn (Completable.complete())
-
     // when
     setupController(searchCriteria)
     uiEvents.onNext(PatientSearchResultRegisterNewPatient(searchCriteria))
@@ -121,8 +114,6 @@ class PatientSearchResultsLogicTest {
     val phoneNumber = "123456"
     val ongoingEntry = OngoingNewPatientEntry.fromPhoneNumber(phoneNumber)
     val searchCriteria = PatientSearchCriteria.PhoneNumber(phoneNumber)
-
-    whenever(patientRepository.saveOngoingEntry(ongoingEntry)) doReturn (Completable.complete())
 
     // when
     setupController(searchCriteria)
@@ -144,8 +135,6 @@ class PatientSearchResultsLogicTest {
         .withIdentifier(identifier)
     val searchCriteria = PatientSearchCriteria.PhoneNumber(phoneNumber, identifier)
 
-    whenever(patientRepository.saveOngoingEntry(ongoingEntry)) doReturn (Completable.complete())
-
     // when
     setupController(searchCriteria)
     uiEvents.onNext(PatientSearchResultRegisterNewPatient(searchCriteria))
@@ -162,8 +151,6 @@ class PatientSearchResultsLogicTest {
     val fullName = "name"
     val ongoingEntry = OngoingNewPatientEntry.fromFullName(fullName)
     val searchCriteria = PatientSearchCriteria.Name(fullName)
-
-    whenever(patientRepository.saveOngoingEntry(ongoingEntry)) doReturn (Completable.complete())
 
     // when
     setupController(searchCriteria)


### PR DESCRIPTION
This is being done in preparation for some future refactoring work before we get to the "Faster patient registration" feature.

- Extract patient registration to a use case outside the `PatientRepository` scoped to the patient entry screens
- Unify the patient entry and edit forms in some fashion so we don't need to duplicate most of the code