### PR TITLE
Extract authentication flows to a separate activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     - Change reactive calls for registering a patient to synchronous ones
     - Accept the ongoing patient entry as a parameter to the register patient method
     - Remove deprecated `Optional` class usages
+- Move registration and login flows to a separate activity
 
 ### Changes
 - Update translations: `kn-IN`, `ta-IN`, `bn-IN`, `ti`, `bn-BD`, `pa-IN`, `mr-IN`, `te-IN`, `hi-IN`

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -165,6 +165,11 @@
       android:theme="@style/Clinic.V2.Theme.BottomSheetActivity"
       android:windowSoftInputMode="adjustResize" />
 
+    <activity
+      android:name=".registerorlogin.AuthenticationActivity"
+      android:screenOrientation="portrait"
+      android:windowSoftInputMode="adjustResize" />
+
     <receiver
       android:name=".login.OtpSmsReceiver"
       android:exported="true"

--- a/app/src/main/java/org/simple/clinic/di/AppComponent.kt
+++ b/app/src/main/java/org/simple/clinic/di/AppComponent.kt
@@ -14,6 +14,7 @@ import org.simple.clinic.facility.change.confirm.FacilityChangeComponent
 import org.simple.clinic.facility.change.confirm.di.ConfirmFacilityChangeComponent
 import org.simple.clinic.login.OtpSmsReceiver
 import org.simple.clinic.main.TheActivityComponent
+import org.simple.clinic.registerorlogin.AuthenticationActivityComponent
 import org.simple.clinic.scheduleappointment.di.ScheduleAppointmentSheetComponent
 import org.simple.clinic.scheduleappointment.facilityselection.FacilitySelectionActivityComponent
 import org.simple.clinic.setup.SetupActivityComponent
@@ -54,6 +55,7 @@ interface AppComponent {
   fun medicineFrequencyComponent(): MedicineFrequencyComponent.Builder
   fun contactDoctorComponent(): ContactDoctorComponent.Builder
   fun teleconsultStatusComponent(): TeleconsultStatusComponent.Builder
+  fun authenticationActivityComponent(): AuthenticationActivityComponent.Builder
 }
 
 @Scope

--- a/app/src/main/java/org/simple/clinic/empty/EmptyScreenKey.kt
+++ b/app/src/main/java/org/simple/clinic/empty/EmptyScreenKey.kt
@@ -1,0 +1,17 @@
+package org.simple.clinic.empty
+
+import kotlinx.android.parcel.IgnoredOnParcel
+import kotlinx.android.parcel.Parcelize
+import org.simple.clinic.R
+import org.simple.clinic.router.screen.FullScreenKey
+
+@Parcelize
+class EmptyScreenKey : FullScreenKey {
+
+  @IgnoredOnParcel
+  override val analyticsName: String = "Empty Screen"
+
+  override fun layoutRes(): Int {
+    return R.layout.screen_empty
+  }
+}

--- a/app/src/main/java/org/simple/clinic/login/pin/LoginPinScreen.kt
+++ b/app/src/main/java/org/simple/clinic/login/pin/LoginPinScreen.kt
@@ -134,7 +134,7 @@ class LoginPinScreen(context: Context, attrs: AttributeSet) : RelativeLayout(con
 
   override fun openHomeScreen() {
     val intent = TheActivity
-        .newIntent(activity)
+        .newIntent(activity, isFreshAuthentication = true)
         .disableAnimations()
 
     activity.startActivity(intent)

--- a/app/src/main/java/org/simple/clinic/login/pin/LoginPinScreen.kt
+++ b/app/src/main/java/org/simple/clinic/login/pin/LoginPinScreen.kt
@@ -4,21 +4,22 @@ import android.content.Context
 import android.os.Parcelable
 import android.util.AttributeSet
 import android.widget.RelativeLayout
+import androidx.appcompat.app.AppCompatActivity
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
 import kotlinx.android.synthetic.main.screen_login_pin.view.*
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.di.injector
-import org.simple.clinic.home.HomeScreenKey
+import org.simple.clinic.main.TheActivity
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.router.screen.BackPressInterceptCallback
 import org.simple.clinic.router.screen.BackPressInterceptor
-import org.simple.clinic.router.screen.RouterDirection
 import org.simple.clinic.router.screen.ScreenRouter
 import org.simple.clinic.security.pin.PinAuthenticated
 import org.simple.clinic.security.pin.verification.LoginPinServerVerificationMethod.UserData
 import org.simple.clinic.user.OngoingLoginEntry
+import org.simple.clinic.util.disableAnimations
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.widgets.UiEvent
 import javax.inject.Inject
@@ -30,6 +31,9 @@ class LoginPinScreen(context: Context, attrs: AttributeSet) : RelativeLayout(con
 
   @Inject
   lateinit var effectHandler: LoginPinEffectHandler.Factory
+
+  @Inject
+  lateinit var activity: AppCompatActivity
 
   private val events by unsafeLazy {
     Observable
@@ -129,7 +133,13 @@ class LoginPinScreen(context: Context, attrs: AttributeSet) : RelativeLayout(con
   }
 
   override fun openHomeScreen() {
-    screenRouter.clearHistoryAndPush(HomeScreenKey, RouterDirection.REPLACE)
+    val intent = TheActivity
+        .newIntent(activity)
+        .disableAnimations()
+
+    activity.startActivity(intent)
+    activity.overridePendingTransition(0, 0)
+    activity.finish()
   }
 
   override fun goBackToRegistrationScreen() {

--- a/app/src/main/java/org/simple/clinic/login/pin/LoginPinScreen.kt
+++ b/app/src/main/java/org/simple/clinic/login/pin/LoginPinScreen.kt
@@ -20,6 +20,7 @@ import org.simple.clinic.security.pin.PinAuthenticated
 import org.simple.clinic.security.pin.verification.LoginPinServerVerificationMethod.UserData
 import org.simple.clinic.user.OngoingLoginEntry
 import org.simple.clinic.util.disableAnimations
+import org.simple.clinic.util.finishWithoutAnimations
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.widgets.UiEvent
 import javax.inject.Inject
@@ -138,8 +139,7 @@ class LoginPinScreen(context: Context, attrs: AttributeSet) : RelativeLayout(con
         .disableAnimations()
 
     activity.startActivity(intent)
-    activity.overridePendingTransition(0, 0)
-    activity.finish()
+    activity.finishWithoutAnimations()
   }
 
   override fun goBackToRegistrationScreen() {

--- a/app/src/main/java/org/simple/clinic/main/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivity.kt
@@ -59,6 +59,7 @@ import org.simple.clinic.util.LocaleOverrideContextWrapper
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.UtcClock
 import org.simple.clinic.util.disableAnimations
+import org.simple.clinic.util.finishWithoutAnimations
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.util.wrap
 import java.time.Instant
@@ -340,8 +341,7 @@ class TheActivity : AppCompatActivity(), TheActivityUi {
         .disableAnimations()
 
     startActivity(intent)
-    overridePendingTransition(0, 0)
-    finish()
+    finishWithoutAnimations()
   }
 
   override fun showAccessDeniedScreen(fullName: String) {

--- a/app/src/main/java/org/simple/clinic/main/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivity.kt
@@ -175,7 +175,7 @@ class TheActivity : AppCompatActivity(), TheActivityUi {
 
     MobiusDelegate.forActivity(
         events = Observable.never(),
-        defaultModel = TheActivityModel.create(),
+        defaultModel = TheActivityModel.createForAlreadyLoggedInUser(),
         update = TheActivityUpdate(),
         effectHandler = effectHandlerFactory.create(this).build(),
         init = TheActivityInit(),

--- a/app/src/main/java/org/simple/clinic/main/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivity.kt
@@ -59,7 +59,6 @@ import org.simple.clinic.util.LocaleOverrideContextWrapper
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.UtcClock
 import org.simple.clinic.util.disableAnimations
-import org.simple.clinic.util.toNullable
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.util.wrap
 import java.time.Instant
@@ -69,21 +68,20 @@ import javax.inject.Inject
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 fun initialScreenKey(
-    user: User?
+    user: User
 ): FullScreenKey {
-  val userDisapproved = user?.status == UserStatus.DisapprovedForSyncing
+  val userDisapproved = user.status == UserStatus.DisapprovedForSyncing
 
-  val canMoveToHomeScreen = when (user?.loggedInStatus) {
+  val canMoveToHomeScreen = when (user.loggedInStatus) {
     NOT_LOGGED_IN, RESETTING_PIN -> false
     LOGGED_IN, OTP_REQUESTED, RESET_PIN_REQUESTED, UNAUTHORIZED -> true
-    null -> false
   }
 
   return when {
     canMoveToHomeScreen && !userDisapproved -> HomeScreenKey
-    userDisapproved -> AccessDeniedScreenKey(user?.fullName!!)
-    user?.loggedInStatus == RESETTING_PIN -> ForgotPinCreateNewPinScreenKey()
-    else -> throw IllegalStateException("Unknown user status combinations: [${user?.loggedInStatus}, ${user?.status}]")
+    userDisapproved -> AccessDeniedScreenKey(user.fullName)
+    user.loggedInStatus == RESETTING_PIN -> ForgotPinCreateNewPinScreenKey()
+    else -> throw IllegalStateException("Unknown user status combinations: [${user.loggedInStatus}, ${user.status}]")
   }
 }
 
@@ -257,7 +255,7 @@ class TheActivity : AppCompatActivity(), TheActivityUi {
         onKeyChange = this::onScreenChanged
     ))
 
-    val currentUser: User? = userSession.loggedInUser().blockingFirst().toNullable()
+    val currentUser: User = userSession.loggedInUser().blockingFirst().get()
     return screenRouter.installInContext(baseContext, initialScreenKey(currentUser))
   }
 

--- a/app/src/main/java/org/simple/clinic/main/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivity.kt
@@ -31,6 +31,7 @@ import org.simple.clinic.login.applock.AppLockConfig
 import org.simple.clinic.login.applock.AppLockScreenKey
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.platform.analytics.Analytics
+import org.simple.clinic.registerorlogin.AuthenticationActivity
 import org.simple.clinic.registration.phone.RegistrationPhoneScreenKey
 import org.simple.clinic.router.ScreenResultBus
 import org.simple.clinic.router.screen.ActivityPermissionResult
@@ -52,6 +53,7 @@ import org.simple.clinic.user.UserStatus
 import org.simple.clinic.util.LocaleOverrideContextWrapper
 import org.simple.clinic.util.Optional
 import org.simple.clinic.util.UtcClock
+import org.simple.clinic.util.disableAnimations
 import org.simple.clinic.util.toNullable
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.util.wrap
@@ -315,7 +317,13 @@ class TheActivity : AppCompatActivity(), TheActivityUi {
   }
 
   override fun redirectToLogin() {
-    screenRouter.clearHistoryAndPush(RegistrationPhoneScreenKey(), RouterDirection.REPLACE)
+    val intent = AuthenticationActivity
+        .forReauthentication(this)
+        .disableAnimations()
+
+    startActivity(intent)
+    overridePendingTransition(0, 0)
+    finish()
   }
 
   override fun showAccessDeniedScreen(fullName: String) {

--- a/app/src/main/java/org/simple/clinic/main/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivity.kt
@@ -32,7 +32,6 @@ import org.simple.clinic.login.applock.AppLockScreenKey
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.platform.analytics.Analytics
 import org.simple.clinic.registerorlogin.AuthenticationActivity
-import org.simple.clinic.registration.phone.RegistrationPhoneScreenKey
 import org.simple.clinic.router.ScreenResultBus
 import org.simple.clinic.router.screen.ActivityPermissionResult
 import org.simple.clinic.router.screen.ActivityResult
@@ -48,6 +47,12 @@ import org.simple.clinic.sync.DataSync
 import org.simple.clinic.sync.SyncSetup
 import org.simple.clinic.user.UnauthorizeUser
 import org.simple.clinic.user.User
+import org.simple.clinic.user.User.LoggedInStatus.LOGGED_IN
+import org.simple.clinic.user.User.LoggedInStatus.NOT_LOGGED_IN
+import org.simple.clinic.user.User.LoggedInStatus.OTP_REQUESTED
+import org.simple.clinic.user.User.LoggedInStatus.RESETTING_PIN
+import org.simple.clinic.user.User.LoggedInStatus.RESET_PIN_REQUESTED
+import org.simple.clinic.user.User.LoggedInStatus.UNAUTHORIZED
 import org.simple.clinic.user.UserSession
 import org.simple.clinic.user.UserStatus
 import org.simple.clinic.util.LocaleOverrideContextWrapper
@@ -69,16 +74,16 @@ fun initialScreenKey(
   val userDisapproved = user?.status == UserStatus.DisapprovedForSyncing
 
   val canMoveToHomeScreen = when (user?.loggedInStatus) {
-    User.LoggedInStatus.NOT_LOGGED_IN, User.LoggedInStatus.RESETTING_PIN, User.LoggedInStatus.UNAUTHORIZED -> false
-    User.LoggedInStatus.LOGGED_IN, User.LoggedInStatus.OTP_REQUESTED, User.LoggedInStatus.RESET_PIN_REQUESTED -> true
+    NOT_LOGGED_IN, RESETTING_PIN -> false
+    LOGGED_IN, OTP_REQUESTED, RESET_PIN_REQUESTED, UNAUTHORIZED -> true
     null -> false
   }
 
   return when {
     canMoveToHomeScreen && !userDisapproved -> HomeScreenKey
     userDisapproved -> AccessDeniedScreenKey(user?.fullName!!)
-    user?.loggedInStatus == User.LoggedInStatus.RESETTING_PIN -> ForgotPinCreateNewPinScreenKey()
-    else -> RegistrationPhoneScreenKey()
+    user?.loggedInStatus == RESETTING_PIN -> ForgotPinCreateNewPinScreenKey()
+    else -> throw IllegalStateException("Unknown user status combinations: [${user?.loggedInStatus}, ${user?.status}]")
   }
 }
 

--- a/app/src/main/java/org/simple/clinic/main/TheActivityComponent.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityComponent.kt
@@ -30,24 +30,14 @@ import org.simple.clinic.home.overdue.OverdueScreen
 import org.simple.clinic.home.patients.PatientsModule
 import org.simple.clinic.home.patients.PatientsTabScreen
 import org.simple.clinic.home.report.ReportsScreen
-import org.simple.clinic.introvideoscreen.IntroVideoScreenInjector
 import org.simple.clinic.login.applock.AppLockScreen
 import org.simple.clinic.login.applock.ConfirmResetPinDialog
-import org.simple.clinic.login.pin.LoginPinScreen
 import org.simple.clinic.medicalhistory.newentry.NewMedicalHistoryScreen
 import org.simple.clinic.newentry.PatientEntryScreen
 import org.simple.clinic.newentry.country.di.InputFieldsFactoryModule
 import org.simple.clinic.onboarding.OnboardingScreenInjector
 import org.simple.clinic.recentpatient.RecentPatientsScreen
 import org.simple.clinic.recentpatientsview.RecentPatientsView
-import org.simple.clinic.registration.confirmpin.RegistrationConfirmPinScreen
-import org.simple.clinic.registration.facility.RegistrationFacilitySelectionScreen
-import org.simple.clinic.registration.location.RegistrationLocationPermissionScreen
-import org.simple.clinic.registration.name.RegistrationFullNameScreen
-import org.simple.clinic.registration.phone.RegistrationPhoneScreen
-import org.simple.clinic.registration.phone.loggedout.LoggedOutOfDeviceDialog
-import org.simple.clinic.registration.pin.RegistrationPinScreen
-import org.simple.clinic.registration.register.RegistrationLoadingScreen
 import org.simple.clinic.scanid.ScanSimpleIdScreen
 import org.simple.clinic.search.PatientSearchScreen
 import org.simple.clinic.search.results.PatientSearchResultsScreen
@@ -88,23 +78,14 @@ interface TheActivityComponent :
     BloodSugarHistoryScreenInjector,
     AccessDeniedScreenInjector,
     PinEntryCardView.Injector,
-    RegistrationPhoneScreen.Injector,
-    LoginPinScreen.Injector,
     EnterOtpScreen.Injector,
     DeletePatientScreenInjector,
     PatientsTabScreen.Injector,
     HelpScreen.Injector,
     ReportsScreen.Injector,
-    IntroVideoScreenInjector,
-    RegistrationFullNameScreen.Injector,
-    RegistrationPinScreen.Injector,
-    RegistrationConfirmPinScreen.Injector,
-    RegistrationLocationPermissionScreen.Injector,
-    RegistrationFacilitySelectionScreen.Injector,
     AddPhoneNumberDialog.Injector,
     RecentPatientsView.Injector,
     AssignedFacilityView.Injector,
-    RegistrationLoadingScreen.Injector,
     RecentPatientsScreen.Injector,
     FacilityPickerView.Injector,
     ForgotPinCreateNewPinScreen.Injector,
@@ -114,7 +95,6 @@ interface TheActivityComponent :
     ForgotPinConfirmPinScreen.Injector,
     ScanSimpleIdScreen.Injector,
     HomeScreen.Injector,
-    LoggedOutOfDeviceDialog.Injector,
     PatientEntryScreen.Injector,
     UpdatePhoneNumberDialog.Injector,
     EditPatientScreen.Injector,

--- a/app/src/main/java/org/simple/clinic/main/TheActivityInit.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityInit.kt
@@ -1,12 +1,22 @@
 package org.simple.clinic.main
 
 import com.spotify.mobius.First
+import com.spotify.mobius.First.first
 import com.spotify.mobius.Init
-import org.simple.clinic.mobius.first
 
-class TheActivityInit: Init<TheActivityModel, TheActivityEffect> {
+class TheActivityInit : Init<TheActivityModel, TheActivityEffect> {
 
   override fun init(model: TheActivityModel): First<TheActivityModel, TheActivityEffect> {
-    return first(model, LoadAppLockInfo, ListenForUserVerifications, ListenForUserUnauthorizations, ListenForUserDisapprovals)
+    val effects = mutableSetOf(
+        ListenForUserVerifications,
+        ListenForUserUnauthorizations,
+        ListenForUserDisapprovals
+    )
+
+    if (!model.isFreshLogin) {
+      effects.add(LoadAppLockInfo)
+    }
+
+    return first(model, effects)
   }
 }

--- a/app/src/main/java/org/simple/clinic/main/TheActivityModel.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityModel.kt
@@ -4,9 +4,11 @@ import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
-class TheActivityModel : Parcelable {
+data class TheActivityModel(val isFreshLogin: Boolean) : Parcelable {
 
   companion object {
-    fun create(): TheActivityModel = TheActivityModel()
+    fun createForAlreadyLoggedInUser(): TheActivityModel = TheActivityModel(isFreshLogin = false)
+
+    fun createForNewlyLoggedInUser(): TheActivityModel = TheActivityModel(isFreshLogin = true)
   }
 }

--- a/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreen.kt
@@ -75,7 +75,7 @@ class OnboardingScreen(context: Context, attributeSet: AttributeSet) : Constrain
     // event bus?) and handle the navigation there.
     // TODO(vs): 2019-11-07 Move this to an event that is subscribed in the parent activity
     val intent = AuthenticationActivity
-        .newIntent(activity)
+        .forNewLogin(activity)
         .disableAnimations()
 
     activity.startActivity(intent)

--- a/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreen.kt
@@ -3,8 +3,8 @@ package org.simple.clinic.onboarding
 import android.content.Context
 import android.text.style.TextAppearanceSpan
 import android.util.AttributeSet
+import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.navigation.findNavController
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
@@ -13,7 +13,9 @@ import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
+import org.simple.clinic.registerorlogin.AuthenticationActivity
 import org.simple.clinic.util.Truss
+import org.simple.clinic.util.disableAnimations
 import org.simple.clinic.util.unsafeLazy
 import javax.inject.Inject
 
@@ -21,6 +23,9 @@ class OnboardingScreen(context: Context, attributeSet: AttributeSet) : Constrain
 
   @Inject
   lateinit var onboardingEffectHandler: OnboardingEffectHandler.Factory
+
+  @Inject
+  lateinit var activity: AppCompatActivity
 
   private val events: Observable<OnboardingEvent> by unsafeLazy {
     getStartedClicks()
@@ -65,7 +70,17 @@ class OnboardingScreen(context: Context, attributeSet: AttributeSet) : Constrain
   }
 
   override fun moveToRegistrationScreen() {
-    findNavController().navigate(R.id.action_onboardingScreen_to_selectCountryScreen)
+    // This navigation should not be done here, we need a way to publish
+    // an event to the parent activity (maybe via the screen router's
+    // event bus?) and handle the navigation there.
+    // TODO(vs): 2019-11-07 Move this to an event that is subscribed in the parent activity
+    val intent = AuthenticationActivity
+        .newIntent(activity)
+        .disableAnimations()
+
+    activity.startActivity(intent)
+    activity.overridePendingTransition(0, 0)
+    activity.finish()
   }
 
   private fun setIntroOneTextView() {

--- a/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreen.kt
@@ -16,6 +16,7 @@ import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.registerorlogin.AuthenticationActivity
 import org.simple.clinic.util.Truss
 import org.simple.clinic.util.disableAnimations
+import org.simple.clinic.util.finishWithoutAnimations
 import org.simple.clinic.util.unsafeLazy
 import javax.inject.Inject
 
@@ -79,8 +80,7 @@ class OnboardingScreen(context: Context, attributeSet: AttributeSet) : Constrain
         .disableAnimations()
 
     activity.startActivity(intent)
-    activity.overridePendingTransition(0, 0)
-    activity.finish()
+    activity.finishWithoutAnimations()
   }
 
   private fun setIntroOneTextView() {

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActiivtyComponent.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActiivtyComponent.kt
@@ -1,0 +1,17 @@
+package org.simple.clinic.registerorlogin
+
+import dagger.Subcomponent
+import org.simple.clinic.activity.BindsActivity
+import org.simple.clinic.activity.BindsScreenRouter
+
+@Subcomponent
+interface AuthenticationActivityComponent {
+
+  fun inject(target: AuthenticationActivity)
+
+  @Subcomponent.Builder
+  interface Builder : BindsActivity<Builder>, BindsScreenRouter<Builder> {
+    fun build(): AuthenticationActivityComponent
+  }
+}
+

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActiivtyComponent.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActiivtyComponent.kt
@@ -3,10 +3,38 @@ package org.simple.clinic.registerorlogin
 import dagger.Subcomponent
 import org.simple.clinic.activity.BindsActivity
 import org.simple.clinic.activity.BindsScreenRouter
+import org.simple.clinic.deniedaccess.AccessDeniedScreenInjector
+import org.simple.clinic.di.AssistedInjectModule
+import org.simple.clinic.facilitypicker.FacilityPickerView
+import org.simple.clinic.introvideoscreen.IntroVideoScreenInjector
+import org.simple.clinic.login.pin.LoginPinScreen
+import org.simple.clinic.registration.confirmpin.RegistrationConfirmPinScreen
+import org.simple.clinic.registration.facility.RegistrationFacilitySelectionScreen
+import org.simple.clinic.registration.location.RegistrationLocationPermissionScreen
+import org.simple.clinic.registration.name.RegistrationFullNameScreen
+import org.simple.clinic.registration.phone.RegistrationPhoneScreen
+import org.simple.clinic.registration.phone.loggedout.LoggedOutOfDeviceDialog
+import org.simple.clinic.registration.pin.RegistrationPinScreen
+import org.simple.clinic.registration.register.RegistrationLoadingScreen
+import org.simple.clinic.security.pin.PinEntryCardView
+import org.simple.clinic.selectcountry.SelectCountryScreenInjector
 
-@Subcomponent
-interface AuthenticationActivityComponent {
-
+@Subcomponent(modules = [AssistedInjectModule::class])
+interface AuthenticationActivityComponent :
+    RegistrationPhoneScreen.Injector,
+    AccessDeniedScreenInjector,
+    LoginPinScreen.Injector,
+    RegistrationFullNameScreen.Injector,
+    RegistrationPinScreen.Injector,
+    RegistrationConfirmPinScreen.Injector,
+    RegistrationLocationPermissionScreen.Injector,
+    RegistrationFacilitySelectionScreen.Injector,
+    IntroVideoScreenInjector,
+    RegistrationLoadingScreen.Injector,
+    PinEntryCardView.Injector,
+    LoggedOutOfDeviceDialog.Injector,
+    SelectCountryScreenInjector,
+    FacilityPickerView.Injector {
   fun inject(target: AuthenticationActivity)
 
   @Subcomponent.Builder
@@ -14,4 +42,3 @@ interface AuthenticationActivityComponent {
     fun build(): AuthenticationActivityComponent
   }
 }
-

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActivity.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActivity.kt
@@ -11,6 +11,7 @@ import org.simple.clinic.di.InjectorProviderContextWrapper
 import org.simple.clinic.feature.Feature
 import org.simple.clinic.feature.Features
 import org.simple.clinic.platform.analytics.Analytics
+import org.simple.clinic.registration.phone.RegistrationPhoneScreenKey
 import org.simple.clinic.router.ScreenResultBus
 import org.simple.clinic.router.screen.ActivityPermissionResult
 import org.simple.clinic.router.screen.ActivityResult
@@ -25,11 +26,21 @@ import org.simple.clinic.util.wrap
 import java.util.Locale
 import javax.inject.Inject
 
-class AuthenticationActivity: AppCompatActivity() {
+class AuthenticationActivity : AppCompatActivity() {
 
   companion object {
-    fun newIntent(context: Context): Intent {
-      return Intent(context, AuthenticationActivity::class.java)
+    private const val EXTRA_INITIAL_SCREEN_KEY = "AuthenticationActivity.EXTRA_INITIAL_SCREEN_KEY"
+
+    fun forNewLogin(context: Context): Intent {
+      return Intent(context, AuthenticationActivity::class.java).apply {
+        putExtra(EXTRA_INITIAL_SCREEN_KEY, SelectCountryScreenKey())
+      }
+    }
+
+    fun forReauthentication(context: Context): Intent {
+      return Intent(context, AuthenticationActivity::class.java).apply {
+        putExtra(EXTRA_INITIAL_SCREEN_KEY, RegistrationPhoneScreenKey())
+      }
     }
   }
 
@@ -44,6 +55,10 @@ class AuthenticationActivity: AppCompatActivity() {
   }
 
   private val screenResults: ScreenResultBus = ScreenResultBus()
+
+  private val initialScreenKey: FullScreenKey by unsafeLazy {
+    intent.extras!!.getParcelable(EXTRA_INITIAL_SCREEN_KEY)!!
+  }
 
   private lateinit var component: AuthenticationActivityComponent
 
@@ -76,7 +91,7 @@ class AuthenticationActivity: AppCompatActivity() {
         onKeyChange = ::onScreenChanged
     ))
 
-    return screenRouter.installInContext(baseContext, SelectCountryScreenKey())
+    return screenRouter.installInContext(baseContext, initialScreenKey)
   }
 
   private fun onScreenChanged(outgoing: FullScreenKey?, incoming: FullScreenKey) {

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActivity.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActivity.kt
@@ -12,7 +12,6 @@ import org.simple.clinic.empty.EmptyScreenKey
 import org.simple.clinic.feature.Feature
 import org.simple.clinic.feature.Features
 import org.simple.clinic.platform.analytics.Analytics
-import org.simple.clinic.registration.phone.RegistrationPhoneScreenKey
 import org.simple.clinic.router.ScreenResultBus
 import org.simple.clinic.router.screen.ActivityPermissionResult
 import org.simple.clinic.router.screen.ActivityResult
@@ -20,7 +19,6 @@ import org.simple.clinic.router.screen.FullScreenKey
 import org.simple.clinic.router.screen.FullScreenKeyChanger
 import org.simple.clinic.router.screen.NestedKeyChanger
 import org.simple.clinic.router.screen.ScreenRouter
-import org.simple.clinic.selectcountry.SelectCountryScreenKey
 import org.simple.clinic.util.LocaleOverrideContextWrapper
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.util.wrap
@@ -30,17 +28,17 @@ import javax.inject.Inject
 class AuthenticationActivity : AppCompatActivity() {
 
   companion object {
-    private const val EXTRA_INITIAL_SCREEN_KEY = "AuthenticationActivity.EXTRA_INITIAL_SCREEN_KEY"
+    private const val EXTRA_OPEN_FOR = "AuthenticationActivity.EXTRA_OPEN_FOR"
 
     fun forNewLogin(context: Context): Intent {
       return Intent(context, AuthenticationActivity::class.java).apply {
-        putExtra(EXTRA_INITIAL_SCREEN_KEY, SelectCountryScreenKey())
+        putExtra(EXTRA_OPEN_FOR, OpenFor.NewLogin)
       }
     }
 
     fun forReauthentication(context: Context): Intent {
       return Intent(context, AuthenticationActivity::class.java).apply {
-        putExtra(EXTRA_INITIAL_SCREEN_KEY, RegistrationPhoneScreenKey())
+        putExtra(EXTRA_OPEN_FOR, OpenFor.Reauthentication)
       }
     }
   }
@@ -57,8 +55,8 @@ class AuthenticationActivity : AppCompatActivity() {
 
   private val screenResults: ScreenResultBus = ScreenResultBus()
 
-  private val initialScreenKey: FullScreenKey by unsafeLazy {
-    intent.extras!!.getParcelable(EXTRA_INITIAL_SCREEN_KEY)!!
+  private val openFor: OpenFor by unsafeLazy {
+    intent.extras!!.getSerializable(EXTRA_OPEN_FOR)!! as OpenFor
   }
 
   private lateinit var component: AuthenticationActivityComponent

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActivity.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActivity.kt
@@ -11,7 +11,6 @@ import org.simple.clinic.di.InjectorProviderContextWrapper
 import org.simple.clinic.feature.Feature
 import org.simple.clinic.feature.Features
 import org.simple.clinic.platform.analytics.Analytics
-import org.simple.clinic.registration.phone.RegistrationPhoneScreenKey
 import org.simple.clinic.router.ScreenResultBus
 import org.simple.clinic.router.screen.ActivityPermissionResult
 import org.simple.clinic.router.screen.ActivityResult
@@ -19,6 +18,7 @@ import org.simple.clinic.router.screen.FullScreenKey
 import org.simple.clinic.router.screen.FullScreenKeyChanger
 import org.simple.clinic.router.screen.NestedKeyChanger
 import org.simple.clinic.router.screen.ScreenRouter
+import org.simple.clinic.selectcountry.SelectCountryScreenKey
 import org.simple.clinic.util.LocaleOverrideContextWrapper
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.util.wrap
@@ -26,6 +26,12 @@ import java.util.Locale
 import javax.inject.Inject
 
 class AuthenticationActivity: AppCompatActivity() {
+
+  companion object {
+    fun newIntent(context: Context): Intent {
+      return Intent(context, AuthenticationActivity::class.java)
+    }
+  }
 
   @Inject
   lateinit var locale: Locale
@@ -70,7 +76,7 @@ class AuthenticationActivity: AppCompatActivity() {
         onKeyChange = ::onScreenChanged
     ))
 
-    return screenRouter.installInContext(baseContext, RegistrationPhoneScreenKey())
+    return screenRouter.installInContext(baseContext, SelectCountryScreenKey())
   }
 
   private fun onScreenChanged(outgoing: FullScreenKey?, incoming: FullScreenKey) {

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActivity.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActivity.kt
@@ -8,6 +8,7 @@ import io.github.inflationx.viewpump.ViewPumpContextWrapper
 import org.simple.clinic.ClinicApp
 import org.simple.clinic.R
 import org.simple.clinic.di.InjectorProviderContextWrapper
+import org.simple.clinic.empty.EmptyScreenKey
 import org.simple.clinic.feature.Feature
 import org.simple.clinic.feature.Features
 import org.simple.clinic.platform.analytics.Analytics
@@ -91,7 +92,7 @@ class AuthenticationActivity : AppCompatActivity() {
         onKeyChange = ::onScreenChanged
     ))
 
-    return screenRouter.installInContext(baseContext, initialScreenKey)
+    return screenRouter.installInContext(baseContext, EmptyScreenKey())
   }
 
   private fun onScreenChanged(outgoing: FullScreenKey?, incoming: FullScreenKey) {

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActivity.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActivity.kt
@@ -1,0 +1,110 @@
+package org.simple.clinic.registerorlogin
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import io.github.inflationx.viewpump.ViewPumpContextWrapper
+import org.simple.clinic.ClinicApp
+import org.simple.clinic.R
+import org.simple.clinic.di.InjectorProviderContextWrapper
+import org.simple.clinic.feature.Feature
+import org.simple.clinic.feature.Features
+import org.simple.clinic.platform.analytics.Analytics
+import org.simple.clinic.registration.phone.RegistrationPhoneScreenKey
+import org.simple.clinic.router.ScreenResultBus
+import org.simple.clinic.router.screen.ActivityPermissionResult
+import org.simple.clinic.router.screen.ActivityResult
+import org.simple.clinic.router.screen.FullScreenKey
+import org.simple.clinic.router.screen.FullScreenKeyChanger
+import org.simple.clinic.router.screen.NestedKeyChanger
+import org.simple.clinic.router.screen.ScreenRouter
+import org.simple.clinic.util.LocaleOverrideContextWrapper
+import org.simple.clinic.util.unsafeLazy
+import org.simple.clinic.util.wrap
+import java.util.Locale
+import javax.inject.Inject
+
+class AuthenticationActivity: AppCompatActivity() {
+
+  @Inject
+  lateinit var locale: Locale
+
+  @Inject
+  lateinit var features: Features
+
+  private val screenRouter: ScreenRouter by unsafeLazy {
+    ScreenRouter.create(this, NestedKeyChanger(), screenResults)
+  }
+
+  private val screenResults: ScreenResultBus = ScreenResultBus()
+
+  private lateinit var component: AuthenticationActivityComponent
+
+  override fun attachBaseContext(baseContext: Context) {
+    setupDiGraph()
+
+    val wrappedContext = baseContext
+        .wrap { LocaleOverrideContextWrapper.wrap(it, locale) }
+        .wrap { wrapContextWithRouter(it) }
+        .wrap { InjectorProviderContextWrapper.wrap(it, component) }
+        .wrap { ViewPumpContextWrapper.wrap(it) }
+
+    super.attachBaseContext(wrappedContext)
+  }
+
+  private fun setupDiGraph() {
+    component = ClinicApp.appComponent
+        .authenticationActivityComponent()
+        .activity(this)
+        .screenRouter(screenRouter)
+        .build()
+    component.inject(this)
+  }
+
+  private fun wrapContextWithRouter(baseContext: Context): Context {
+    screenRouter.registerKeyChanger(FullScreenKeyChanger(
+        activity = this,
+        screenLayoutContainerRes = android.R.id.content,
+        screenBackgroundRes = R.color.window_background,
+        onKeyChange = ::onScreenChanged
+    ))
+
+    return screenRouter.installInContext(baseContext, RegistrationPhoneScreenKey())
+  }
+
+  private fun onScreenChanged(outgoing: FullScreenKey?, incoming: FullScreenKey) {
+    val outgoingScreenName = outgoing?.analyticsName ?: ""
+    val incomingScreenName = incoming.analyticsName
+    Analytics.reportScreenChange(outgoingScreenName, incomingScreenName)
+  }
+
+  override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    super.onActivityResult(requestCode, resultCode, data)
+    screenResults.send(ActivityResult(requestCode, resultCode, data))
+  }
+
+  override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {
+    super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+    screenResults.send(ActivityPermissionResult(requestCode))
+  }
+
+  override fun onBackPressed() {
+    val interceptCallback = screenRouter.offerBackPressToInterceptors()
+    if (interceptCallback.intercepted) {
+      return
+    }
+    val popCallback = screenRouter.pop()
+    if (popCallback.popped) {
+      return
+    }
+    super.onBackPressed()
+  }
+
+  override fun onSaveInstanceState(outState: Bundle) {
+    if (features.isEnabled(Feature.LogSavedStateSizes)) {
+      screenRouter.logSizesOfSavedStates()
+    }
+    super.onSaveInstanceState(outState)
+  }
+}

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationEffect.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationEffect.kt
@@ -1,0 +1,3 @@
+package org.simple.clinic.registerorlogin
+
+sealed class AuthenticationEffect

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationEffect.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationEffect.kt
@@ -1,3 +1,5 @@
 package org.simple.clinic.registerorlogin
 
 sealed class AuthenticationEffect
+
+object OpenCountrySelectionScreen: AuthenticationEffect()

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationEffect.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationEffect.kt
@@ -3,3 +3,5 @@ package org.simple.clinic.registerorlogin
 sealed class AuthenticationEffect
 
 object OpenCountrySelectionScreen: AuthenticationEffect()
+
+object OpenRegistrationPhoneScreen: AuthenticationEffect()

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationEffectHandler.kt
@@ -20,6 +20,7 @@ class AuthenticationEffectHandler @AssistedInject constructor(
     return RxMobius
         .subtypeEffectHandler<AuthenticationEffect, AuthenticationEvent>()
         .addAction(OpenCountrySelectionScreen::class.java, uiActions::openCountrySelectionScreen, schedulers.ui())
+        .addAction(OpenRegistrationPhoneScreen::class.java, uiActions::openRegistrationPhoneScreen, schedulers.ui())
         .build()
   }
 }

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationEffectHandler.kt
@@ -1,0 +1,24 @@
+package org.simple.clinic.registerorlogin
+
+import com.spotify.mobius.rx2.RxMobius
+import com.squareup.inject.assisted.Assisted
+import com.squareup.inject.assisted.AssistedInject
+import io.reactivex.ObservableTransformer
+import org.simple.clinic.util.scheduler.SchedulersProvider
+
+class AuthenticationEffectHandler @AssistedInject constructor(
+    private val schedulers: SchedulersProvider,
+    @Assisted private val uiActions: AuthenticationUiActions
+) {
+
+  @AssistedInject.Factory
+  interface Factory {
+    fun create(uiActions: AuthenticationUiActions): AuthenticationEffectHandler
+  }
+
+  fun build(): ObservableTransformer<AuthenticationEffect, AuthenticationEvent> {
+    return RxMobius
+        .subtypeEffectHandler<AuthenticationEffect, AuthenticationEvent>()
+        .build()
+  }
+}

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationEffectHandler.kt
@@ -19,6 +19,7 @@ class AuthenticationEffectHandler @AssistedInject constructor(
   fun build(): ObservableTransformer<AuthenticationEffect, AuthenticationEvent> {
     return RxMobius
         .subtypeEffectHandler<AuthenticationEffect, AuthenticationEvent>()
+        .addAction(OpenCountrySelectionScreen::class.java, uiActions::openCountrySelectionScreen, schedulers.ui())
         .build()
   }
 }

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationEvent.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationEvent.kt
@@ -1,0 +1,5 @@
+package org.simple.clinic.registerorlogin
+
+import org.simple.clinic.widgets.UiEvent
+
+sealed class AuthenticationEvent: UiEvent

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationInit.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationInit.kt
@@ -9,6 +9,6 @@ class AuthenticationInit : Init<AuthenticationModel, AuthenticationEffect> {
   override fun init(
       model: AuthenticationModel
   ): First<AuthenticationModel, AuthenticationEffect> {
-    return first(model)
+    return first(model, OpenCountrySelectionScreen)
   }
 }

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationInit.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationInit.kt
@@ -1,14 +1,21 @@
 package org.simple.clinic.registerorlogin
 
 import com.spotify.mobius.First
+import com.spotify.mobius.First.first
 import com.spotify.mobius.Init
-import org.simple.clinic.mobius.first
 
 class AuthenticationInit : Init<AuthenticationModel, AuthenticationEffect> {
 
   override fun init(
       model: AuthenticationModel
   ): First<AuthenticationModel, AuthenticationEffect> {
-    return first(model, OpenCountrySelectionScreen)
+    val effects = mutableSetOf<AuthenticationEffect>()
+
+    when(model.openFor) {
+      OpenFor.NewLogin -> effects.add(OpenCountrySelectionScreen)
+      OpenFor.Reauthentication -> effects.add(OpenRegistrationPhoneScreen)
+    }
+
+    return first(model, effects)
   }
 }

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationInit.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationInit.kt
@@ -1,0 +1,14 @@
+package org.simple.clinic.registerorlogin
+
+import com.spotify.mobius.First
+import com.spotify.mobius.Init
+import org.simple.clinic.mobius.first
+
+class AuthenticationInit : Init<AuthenticationModel, AuthenticationEffect> {
+
+  override fun init(
+      model: AuthenticationModel
+  ): First<AuthenticationModel, AuthenticationEffect> {
+    return first(model)
+  }
+}

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationInit.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationInit.kt
@@ -1,21 +1,28 @@
 package org.simple.clinic.registerorlogin
 
 import com.spotify.mobius.First
-import com.spotify.mobius.First.first
 import com.spotify.mobius.Init
+import org.simple.clinic.mobius.first
+import org.simple.clinic.registerorlogin.OpenFor.NewLogin
+import org.simple.clinic.registerorlogin.OpenFor.Reauthentication
 
 class AuthenticationInit : Init<AuthenticationModel, AuthenticationEffect> {
 
   override fun init(
       model: AuthenticationModel
   ): First<AuthenticationModel, AuthenticationEffect> {
-    val effects = mutableSetOf<AuthenticationEffect>()
+    return if (!model.openedInitialScreen)
+      loadInitialScreen(model)
+    else
+      first(model)
+  }
 
-    when(model.openFor) {
-      OpenFor.NewLogin -> effects.add(OpenCountrySelectionScreen)
-      OpenFor.Reauthentication -> effects.add(OpenRegistrationPhoneScreen)
+  private fun loadInitialScreen(model: AuthenticationModel): First<AuthenticationModel, AuthenticationEffect> {
+    val effect = when (model.openFor) {
+      NewLogin -> OpenCountrySelectionScreen
+      Reauthentication -> OpenRegistrationPhoneScreen
     }
 
-    return first(model, effects)
+    return first(model.initialScreenOpened(), effect)
   }
 }

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationModel.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationModel.kt
@@ -4,4 +4,11 @@ import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
-data class AuthenticationModel(val openFor: OpenFor): Parcelable
+data class AuthenticationModel(val openFor: OpenFor) : Parcelable {
+
+  companion object {
+    fun create(openFor: OpenFor): AuthenticationModel {
+      return AuthenticationModel(openFor)
+    }
+  }
+}

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationModel.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationModel.kt
@@ -4,11 +4,21 @@ import android.os.Parcelable
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
-data class AuthenticationModel(val openFor: OpenFor) : Parcelable {
+data class AuthenticationModel(
+    val openFor: OpenFor,
+    val openedInitialScreen: Boolean
+) : Parcelable {
 
   companion object {
     fun create(openFor: OpenFor): AuthenticationModel {
-      return AuthenticationModel(openFor)
+      return AuthenticationModel(
+          openFor = openFor,
+          openedInitialScreen = false
+      )
     }
+  }
+
+  fun initialScreenOpened(): AuthenticationModel {
+    return copy(openedInitialScreen = true)
   }
 }

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationModel.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationModel.kt
@@ -1,0 +1,7 @@
+package org.simple.clinic.registerorlogin
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+data class AuthenticationModel(val openFor: OpenFor): Parcelable

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationUiActions.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationUiActions.kt
@@ -2,4 +2,5 @@ package org.simple.clinic.registerorlogin
 
 interface AuthenticationUiActions {
   fun openCountrySelectionScreen()
+  fun openRegistrationPhoneScreen()
 }

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationUiActions.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationUiActions.kt
@@ -1,0 +1,4 @@
+package org.simple.clinic.registerorlogin
+
+interface AuthenticationUiActions {
+}

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationUiActions.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationUiActions.kt
@@ -1,4 +1,5 @@
 package org.simple.clinic.registerorlogin
 
 interface AuthenticationUiActions {
+  fun openCountrySelectionScreen()
 }

--- a/app/src/main/java/org/simple/clinic/registerorlogin/OpenFor.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/OpenFor.kt
@@ -1,0 +1,6 @@
+package org.simple.clinic.registerorlogin
+
+enum class OpenFor {
+  NewLogin,
+  Reauthentication
+}

--- a/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingScreen.kt
+++ b/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingScreen.kt
@@ -87,7 +87,7 @@ class RegistrationLoadingScreen(
 
   override fun openHomeScreen() {
     val intent = TheActivity
-        .newIntent(activity)
+        .newIntent(activity, isFreshAuthentication = true)
         .disableAnimations()
 
     activity.startActivity(intent)

--- a/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingScreen.kt
+++ b/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingScreen.kt
@@ -16,6 +16,7 @@ import org.simple.clinic.main.TheActivity
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.router.screen.ScreenRouter
 import org.simple.clinic.util.disableAnimations
+import org.simple.clinic.util.finishWithoutAnimations
 import org.simple.clinic.util.unsafeLazy
 import javax.inject.Inject
 
@@ -91,8 +92,7 @@ class RegistrationLoadingScreen(
         .disableAnimations()
 
     activity.startActivity(intent)
-    activity.overridePendingTransition(0, 0)
-    activity.finish()
+    activity.finishWithoutAnimations()
   }
 
   override fun showNetworkError() {

--- a/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingScreen.kt
+++ b/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingScreen.kt
@@ -5,16 +5,17 @@ import android.os.Parcelable
 import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
+import androidx.appcompat.app.AppCompatActivity
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.rxkotlin.ofType
 import kotlinx.android.synthetic.main.screen_registration_loading.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.di.injector
-import org.simple.clinic.home.HomeScreenKey
+import org.simple.clinic.main.TheActivity
 import org.simple.clinic.mobius.MobiusDelegate
-import org.simple.clinic.router.screen.RouterDirection
 import org.simple.clinic.router.screen.ScreenRouter
+import org.simple.clinic.util.disableAnimations
 import org.simple.clinic.util.unsafeLazy
 import javax.inject.Inject
 
@@ -28,6 +29,9 @@ class RegistrationLoadingScreen(
 
   @Inject
   lateinit var effectHandlerFactory: RegistrationLoadingEffectHandler.Factory
+
+  @Inject
+  lateinit var activity: AppCompatActivity
 
   private val events by unsafeLazy {
     retryClicks()
@@ -82,7 +86,13 @@ class RegistrationLoadingScreen(
       .doAfterNext { showLoader() }
 
   override fun openHomeScreen() {
-    screenRouter.clearHistoryAndPush(HomeScreenKey, RouterDirection.FORWARD)
+    val intent = TheActivity
+        .newIntent(activity)
+        .disableAnimations()
+
+    activity.startActivity(intent)
+    activity.overridePendingTransition(0, 0)
+    activity.finish()
   }
 
   override fun showNetworkError() {

--- a/app/src/main/java/org/simple/clinic/selectcountry/SelectCountryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/selectcountry/SelectCountryScreen.kt
@@ -1,7 +1,6 @@
 package org.simple.clinic.selectcountry
 
 import android.content.Context
-import android.content.Intent
 import android.os.Parcelable
 import android.util.AttributeSet
 import androidx.appcompat.app.AppCompatActivity
@@ -18,9 +17,10 @@ import org.simple.clinic.appconfig.AppConfigRepository
 import org.simple.clinic.appconfig.Country
 import org.simple.clinic.appconfig.displayname.CountryDisplayNameFetcher
 import org.simple.clinic.di.injector
-import org.simple.clinic.main.TheActivity
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.platform.crash.CrashReporter
+import org.simple.clinic.registration.phone.RegistrationPhoneScreenKey
+import org.simple.clinic.router.screen.ScreenRouter
 import org.simple.clinic.selectcountry.adapter.Event
 import org.simple.clinic.selectcountry.adapter.SelectableCountryItem
 import org.simple.clinic.selectcountry.adapter.SelectableCountryItemDiffCallback
@@ -49,6 +49,9 @@ class SelectCountryScreen(
 
   @Inject
   lateinit var activity: AppCompatActivity
+
+  @Inject
+  lateinit var screenRouter: ScreenRouter
 
   private val uiRenderer = SelectCountryUiRenderer(this)
 
@@ -177,15 +180,6 @@ class SelectCountryScreen(
   }
 
   override fun goToNextScreen() {
-    // This navigation should not be done here, we need a way to publish
-    // an event to the parent activity (maybe via the screen router's
-    // event bus?) and handle the navigation there.
-    // TODO(vs): 2019-11-07 Move this to an event that is subscribed in the parent activity
-    val intent = TheActivity.newIntent(activity).apply {
-      flags = Intent.FLAG_ACTIVITY_NO_ANIMATION
-    }
-    activity.startActivity(intent)
-    activity.overridePendingTransition(0, 0)
-    activity.finish()
+    screenRouter.push(RegistrationPhoneScreenKey())
   }
 }

--- a/app/src/main/java/org/simple/clinic/setup/SetupActivity.kt
+++ b/app/src/main/java/org/simple/clinic/setup/SetupActivity.kt
@@ -107,9 +107,11 @@ class SetupActivity : AppCompatActivity(), UiActions {
   }
 
   override fun goToMainActivity() {
-    val intent = TheActivity.newIntent(this).apply {
-      flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_ANIMATION
-    }
+    val intent = TheActivity
+        .newIntent(this, isFreshAuthentication = false)
+        .apply {
+          flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_ANIMATION
+        }
     startActivity(intent)
     overridePendingTransition(0, 0)
   }

--- a/app/src/main/java/org/simple/clinic/setup/SetupActivity.kt
+++ b/app/src/main/java/org/simple/clinic/setup/SetupActivity.kt
@@ -22,6 +22,8 @@ import org.simple.clinic.router.screen.ActivityResult
 import org.simple.clinic.util.LocaleOverrideContextWrapper
 import org.simple.clinic.util.UtcClock
 import org.simple.clinic.util.disableAnimations
+import org.simple.clinic.util.disablePendingTransitions
+import org.simple.clinic.util.finishWithoutAnimations
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.util.wrap
 import java.util.Locale
@@ -113,7 +115,7 @@ class SetupActivity : AppCompatActivity(), UiActions {
           flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_ANIMATION
         }
     startActivity(intent)
-    overridePendingTransition(0, 0)
+    disablePendingTransitions()
   }
 
   override fun showSplashScreen() {
@@ -133,8 +135,7 @@ class SetupActivity : AppCompatActivity(), UiActions {
         .disableAnimations()
 
     startActivity(intent)
-    overridePendingTransition(0, 0)
-    finish()
+    finishWithoutAnimations()
   }
 
   private fun setupDiGraph() {

--- a/app/src/main/java/org/simple/clinic/setup/SetupActivity.kt
+++ b/app/src/main/java/org/simple/clinic/setup/SetupActivity.kt
@@ -15,11 +15,13 @@ import org.simple.clinic.R
 import org.simple.clinic.di.InjectorProviderContextWrapper
 import org.simple.clinic.main.TheActivity
 import org.simple.clinic.mobius.MobiusDelegate
+import org.simple.clinic.registerorlogin.AuthenticationActivity
 import org.simple.clinic.router.ScreenResultBus
 import org.simple.clinic.router.screen.ActivityPermissionResult
 import org.simple.clinic.router.screen.ActivityResult
 import org.simple.clinic.util.LocaleOverrideContextWrapper
 import org.simple.clinic.util.UtcClock
+import org.simple.clinic.util.disableAnimations
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.util.wrap
 import java.util.Locale
@@ -124,12 +126,13 @@ class SetupActivity : AppCompatActivity(), UiActions {
   }
 
   override fun showCountrySelectionScreen() {
-    // If select country screen is already being shown don't navigate again, it would cause
-    // duplicate destinations
-    if (navController.currentDestination?.id == R.id.placeholderScreen &&
-        navController.currentDestination?.id != R.id.selectCountryScreen) {
-      navController.navigate(R.id.action_placeholderScreen_to_selectCountryScreen)
-    }
+    val intent = AuthenticationActivity
+        .newIntent(this)
+        .disableAnimations()
+
+    startActivity(intent)
+    overridePendingTransition(0, 0)
+    finish()
   }
 
   private fun setupDiGraph() {

--- a/app/src/main/java/org/simple/clinic/setup/SetupActivity.kt
+++ b/app/src/main/java/org/simple/clinic/setup/SetupActivity.kt
@@ -127,7 +127,7 @@ class SetupActivity : AppCompatActivity(), UiActions {
 
   override fun showCountrySelectionScreen() {
     val intent = AuthenticationActivity
-        .newIntent(this)
+        .forNewLogin(this)
         .disableAnimations()
 
     startActivity(intent)

--- a/app/src/main/java/org/simple/clinic/setup/SetupActivityComponent.kt
+++ b/app/src/main/java/org/simple/clinic/setup/SetupActivityComponent.kt
@@ -3,10 +3,9 @@ package org.simple.clinic.setup
 import dagger.Subcomponent
 import org.simple.clinic.activity.BindsActivity
 import org.simple.clinic.onboarding.OnboardingScreenInjector
-import org.simple.clinic.selectcountry.SelectCountryScreenInjector
 
 @Subcomponent(modules = [SetupActivityModule::class])
-interface SetupActivityComponent : OnboardingScreenInjector, SelectCountryScreenInjector {
+interface SetupActivityComponent : OnboardingScreenInjector {
 
   fun inject(target: SetupActivity)
 

--- a/app/src/main/java/org/simple/clinic/util/AndroidExtensions.kt
+++ b/app/src/main/java/org/simple/clinic/util/AndroidExtensions.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.util
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import io.reactivex.Observable
@@ -25,4 +26,13 @@ fun Intent.disableAnimations(): Intent {
   flags = flags or Intent.FLAG_ACTIVITY_NO_ANIMATION
 
   return this
+}
+
+fun Activity.disablePendingTransitions() {
+  overridePendingTransition(0, 0)
+}
+
+fun Activity.finishWithoutAnimations() {
+  overridePendingTransition(0, 0)
+  finish()
 }

--- a/app/src/main/java/org/simple/clinic/util/AndroidExtensions.kt
+++ b/app/src/main/java/org/simple/clinic/util/AndroidExtensions.kt
@@ -20,3 +20,9 @@ fun Observable<ActivityResult>.filterIfSuccessful(
 ): Observable<ActivityResult> {
   return filter { it.requestCode == requestCode && it.succeeded() && it.data != null }
 }
+
+fun Intent.disableAnimations(): Intent {
+  flags = flags or Intent.FLAG_ACTIVITY_NO_ANIMATION
+
+  return this
+}

--- a/app/src/main/java/org/simple/clinic/widgets/BottomSheetActivity.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/BottomSheetActivity.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity
 import kotterknife.bindView
 import org.simple.clinic.BuildConfig
 import org.simple.clinic.R
+import org.simple.clinic.util.disablePendingTransitions
 
 /**
  * We're using Activities as fake bottom sheets instead of BottomSheetDialog because we want
@@ -24,7 +25,7 @@ abstract class BottomSheetActivity : AppCompatActivity() {
   private val contentContainer by bindView<ViewGroup>(R.id.bottomsheet_content_container)
 
   override fun onCreate(savedInstanceState: Bundle?) {
-    overridePendingTransition(0, 0)
+    disablePendingTransitions()
     super.onCreate(savedInstanceState)
     @Suppress("ConstantConditionIf")
     if (BuildConfig.DISABLE_SCREENSHOT) {
@@ -52,7 +53,7 @@ abstract class BottomSheetActivity : AppCompatActivity() {
         contentContainer = contentContainer,
         endAction = {
           super.finish()
-          overridePendingTransition(0, 0)
+          disablePendingTransitions()
         }
     )
   }

--- a/app/src/main/res/layout/screen_empty.xml
+++ b/app/src/main/res/layout/screen_empty.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<View xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"/>

--- a/app/src/main/res/navigation/setup_activity_nav_graph.xml
+++ b/app/src/main/res/navigation/setup_activity_nav_graph.xml
@@ -12,23 +12,11 @@
     app:layout="@layout/screen_placeholder"
     tools:layout="@layout/screen_placeholder">
     <action
-      android:id="@+id/action_placeholderScreen_to_selectCountryScreen"
-      app:destination="@id/selectCountryScreen"
-      app:popUpTo="@id/placeholderScreen"
-      app:popUpToInclusive="true" />
-    <action
       android:id="@+id/action_placeholderScreen_to_splashScreen"
       app:destination="@id/splashScreen"
       app:popUpTo="@id/placeholderScreen"
       app:popUpToInclusive="true" />
   </screen>
-  <screen
-    android:id="@+id/selectCountryScreen"
-    android:name="org.simple.clinic.selectcountry.SelectCountryScreen"
-    android:label="SelectCountryScreen"
-    app:analyticsName="Select Country"
-    app:layout="@layout/screen_selectcountry"
-    tools:layout="@layout/screen_selectcountry" />
   <screen
     android:id="@+id/splashScreen"
     android:name="org.simple.clinic.splash.SplashScreen"
@@ -48,11 +36,5 @@
     android:label="OnboardingScreen"
     app:analyticsName="Onboarding Screen"
     app:layout="@layout/screen_onboarding"
-    tools:layout="@layout/screen_onboarding">
-    <action
-      android:id="@+id/action_onboardingScreen_to_selectCountryScreen"
-      app:destination="@id/selectCountryScreen"
-      app:popUpTo="@id/onboardingScreen"
-      app:popUpToInclusive="true" />
-  </screen>
+    tools:layout="@layout/screen_onboarding" />
 </navigation>

--- a/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
@@ -384,7 +384,7 @@ class TheActivityControllerTest {
 
     testFixture = MobiusTestFixture(
         events = uiEvents.ofType(),
-        defaultModel = TheActivityModel.create(),
+        defaultModel = TheActivityModel.createForAlreadyLoggedInUser(),
         update = TheActivityUpdate(),
         effectHandler = effectHandler.build(),
         init = TheActivityInit(),

--- a/app/src/test/java/org/simple/clinic/activity/TheActivityInitialScreenKeyTest.kt
+++ b/app/src/test/java/org/simple/clinic/activity/TheActivityInitialScreenKeyTest.kt
@@ -7,7 +7,6 @@ import org.simple.clinic.deniedaccess.AccessDeniedScreenKey
 import org.simple.clinic.forgotpin.createnewpin.ForgotPinCreateNewPinScreenKey
 import org.simple.clinic.home.HomeScreenKey
 import org.simple.clinic.main.initialScreenKey
-import org.simple.clinic.registration.phone.RegistrationPhoneScreenKey
 import org.simple.clinic.user.User
 import org.simple.clinic.user.UserStatus
 
@@ -56,31 +55,17 @@ class TheActivityInitialScreenKeyTest {
   }
 
   @Test
-  fun `when the local user is waiting for approval and has not logged in, the login screen must be shown`() {
-    val user = TestData.loggedInUser(loggedInStatus = User.LoggedInStatus.NOT_LOGGED_IN, status = UserStatus.WaitingForApproval)
-
-    assertThat(initialScreenKey(user)).isInstanceOf(RegistrationPhoneScreenKey::class.java)
-  }
-
-  @Test
-  fun `when the local user is approved for syncing and has not logged in, the login screen must be shown`() {
-    val user = TestData.loggedInUser(loggedInStatus = User.LoggedInStatus.NOT_LOGGED_IN, status = UserStatus.ApprovedForSyncing)
-
-    assertThat(initialScreenKey(user)).isInstanceOf(RegistrationPhoneScreenKey::class.java)
-  }
-
-  @Test
   fun `when the local user is waiting for approval and has been unauthorized, the login screen must be shown`() {
     val user = TestData.loggedInUser(loggedInStatus = User.LoggedInStatus.UNAUTHORIZED, status = UserStatus.WaitingForApproval)
 
-    assertThat(initialScreenKey(user)).isInstanceOf(RegistrationPhoneScreenKey::class.java)
+    assertThat(initialScreenKey(user)).isInstanceOf(HomeScreenKey::class.java)
   }
 
   @Test
   fun `when the local user is approved for syncing and has been unauthorized, the login screen must be shown`() {
     val user = TestData.loggedInUser(loggedInStatus = User.LoggedInStatus.UNAUTHORIZED, status = UserStatus.ApprovedForSyncing)
 
-    assertThat(initialScreenKey(user)).isInstanceOf(RegistrationPhoneScreenKey::class.java)
+    assertThat(initialScreenKey(user)).isInstanceOf(HomeScreenKey::class.java)
   }
 
   @Test
@@ -137,11 +122,5 @@ class TheActivityInitialScreenKeyTest {
     val user = TestData.loggedInUser(loggedInStatus = User.LoggedInStatus.UNAUTHORIZED, status = UserStatus.DisapprovedForSyncing)
 
     assertThat(initialScreenKey(user)).isInstanceOf(AccessDeniedScreenKey::class.java)
-  }
-
-  @Test
-  fun `when there is no local user, the login screen should be shown`() {
-
-    assertThat(initialScreenKey(null)).isInstanceOf(RegistrationPhoneScreenKey::class.java)
   }
 }

--- a/app/src/test/java/org/simple/clinic/main/TheActivityInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/main/TheActivityInitTest.kt
@@ -1,0 +1,37 @@
+package org.simple.clinic.main
+
+import com.spotify.mobius.test.FirstMatchers.hasEffects
+import com.spotify.mobius.test.FirstMatchers.hasModel
+import com.spotify.mobius.test.InitSpec
+import com.spotify.mobius.test.InitSpec.assertThatFirst
+import org.junit.Test
+import org.simple.clinic.mobius.CustomFirstMatchers.doesNotHaveEffectOfType
+
+class TheActivityInitTest {
+
+  private val spec = InitSpec(TheActivityInit())
+
+  @Test
+  fun `when the screen is created for an already logged in user, the screen lock must be verified`() {
+    val model = TheActivityModel.createForAlreadyLoggedInUser()
+
+    spec
+        .whenInit(model)
+        .then(assertThatFirst(
+            hasModel(model),
+            hasEffects(LoadAppLockInfo)
+        ))
+  }
+
+  @Test
+  fun `when the screen is created for an freshly logged in user, the screen lock must not be verified`() {
+    val model = TheActivityModel.createForNewlyLoggedInUser()
+
+    spec
+        .whenInit(model)
+        .then(assertThatFirst(
+            hasModel(model),
+            doesNotHaveEffectOfType(LoadAppLockInfo::class.java)
+        ))
+  }
+}

--- a/app/src/test/java/org/simple/clinic/mobius/CustomFirstMatchers.kt
+++ b/app/src/test/java/org/simple/clinic/mobius/CustomFirstMatchers.kt
@@ -1,0 +1,43 @@
+package org.simple.clinic.mobius
+
+import com.spotify.mobius.First
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeDiagnosingMatcher
+import org.hamcrest.core.Is
+
+object CustomFirstMatchers {
+  fun <M, F> doesNotHaveEffectOfType(type: Class<*>): Matcher<First<M, F>> {
+
+    return object : TypeSafeDiagnosingMatcher<First<M, F>>() {
+
+      private val typeMatcher = Is.isA(type)
+
+      override fun describeTo(
+          description: Description
+      ) {
+        description
+            .appendText("should not have effect matching: ")
+            .appendDescriptionOf(typeMatcher)
+      }
+
+      override fun matchesSafely(
+          item: First<M, F>,
+          mismatchDescription: Description
+      ): Boolean {
+        val itemsMatching = item
+            .effects()
+            .filter(typeMatcher::matches)
+
+        return if (itemsMatching.isNotEmpty()) {
+          mismatchDescription
+              .appendText("found effects: ")
+              .appendValueList("[", ", ", "]", itemsMatching)
+          false
+        } else {
+          true
+        }
+      }
+    }
+  }
+}

--- a/app/src/test/java/org/simple/clinic/registerorlogin/AuthenticationEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registerorlogin/AuthenticationEffectHandlerTest.kt
@@ -1,0 +1,31 @@
+package org.simple.clinic.registerorlogin
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import org.junit.Test
+import org.simple.clinic.mobius.EffectHandlerTestCase
+import org.simple.clinic.util.scheduler.TestSchedulersProvider
+
+class AuthenticationEffectHandlerTest {
+
+  @Test
+  fun `when receiving the open country selection screen effect, open the country selection screen`() {
+    // given
+    val uiActions = mock<AuthenticationUiActions>()
+    val effectHandler = AuthenticationEffectHandler(
+        schedulers = TestSchedulersProvider.trampoline(),
+        uiActions = uiActions
+    ).build()
+    val testCase = EffectHandlerTestCase(effectHandler)
+
+    // when
+    testCase.dispatch(OpenCountrySelectionScreen)
+
+    // then
+    testCase.assertNoOutgoingEvents()
+    verify(uiActions).openCountrySelectionScreen()
+    verifyNoMoreInteractions(uiActions)
+    testCase.dispose()
+  }
+}

--- a/app/src/test/java/org/simple/clinic/registerorlogin/AuthenticationEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/registerorlogin/AuthenticationEffectHandlerTest.kt
@@ -3,22 +3,29 @@ package org.simple.clinic.registerorlogin
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import org.junit.After
 import org.junit.Test
 import org.simple.clinic.mobius.EffectHandlerTestCase
 import org.simple.clinic.util.scheduler.TestSchedulersProvider
 
 class AuthenticationEffectHandlerTest {
 
+  private val uiActions = mock<AuthenticationUiActions>()
+
+  private val effectHandler = AuthenticationEffectHandler(
+      schedulers = TestSchedulersProvider.trampoline(),
+      uiActions = uiActions
+  ).build()
+
+  private val testCase = EffectHandlerTestCase(effectHandler)
+
+  @After
+  fun tearDown() {
+    testCase.dispose()
+  }
+
   @Test
   fun `when receiving the open country selection screen effect, open the country selection screen`() {
-    // given
-    val uiActions = mock<AuthenticationUiActions>()
-    val effectHandler = AuthenticationEffectHandler(
-        schedulers = TestSchedulersProvider.trampoline(),
-        uiActions = uiActions
-    ).build()
-    val testCase = EffectHandlerTestCase(effectHandler)
-
     // when
     testCase.dispatch(OpenCountrySelectionScreen)
 
@@ -26,6 +33,16 @@ class AuthenticationEffectHandlerTest {
     testCase.assertNoOutgoingEvents()
     verify(uiActions).openCountrySelectionScreen()
     verifyNoMoreInteractions(uiActions)
-    testCase.dispose()
+  }
+
+  @Test
+  fun `when receiving the open registration phone screen effect, open the registration phone screen`() {
+    // when
+    testCase.dispatch(OpenRegistrationPhoneScreen)
+
+    // then
+    testCase.assertNoOutgoingEvents()
+    verify(uiActions).openRegistrationPhoneScreen()
+    verifyNoMoreInteractions(uiActions)
   }
 }

--- a/app/src/test/java/org/simple/clinic/registerorlogin/AuthenticationInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/registerorlogin/AuthenticationInitTest.kt
@@ -1,0 +1,23 @@
+package org.simple.clinic.registerorlogin
+
+import com.spotify.mobius.test.FirstMatchers.hasEffects
+import com.spotify.mobius.test.FirstMatchers.hasModel
+import com.spotify.mobius.test.InitSpec
+import com.spotify.mobius.test.InitSpec.assertThatFirst
+import org.junit.Test
+
+class AuthenticationInitTest {
+
+  @Test
+  fun `when the screen is created for a new login, open the country selection screen`() {
+    val spec = InitSpec(AuthenticationInit())
+    val model = AuthenticationModel.create(OpenFor.NewLogin)
+
+    spec
+        .whenInit(model)
+        .then(assertThatFirst(
+            hasModel(model),
+            hasEffects(OpenCountrySelectionScreen)
+        ))
+  }
+}

--- a/app/src/test/java/org/simple/clinic/registerorlogin/AuthenticationInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/registerorlogin/AuthenticationInitTest.kt
@@ -17,7 +17,7 @@ class AuthenticationInitTest {
     spec
         .whenInit(model)
         .then(assertThatFirst(
-            hasModel(model),
+            hasModel(model.initialScreenOpened()),
             hasEffects(OpenCountrySelectionScreen)
         ))
   }
@@ -29,7 +29,7 @@ class AuthenticationInitTest {
     spec
         .whenInit(model)
         .then(assertThatFirst(
-            hasModel(model),
+            hasModel(model.initialScreenOpened()),
             hasEffects(OpenRegistrationPhoneScreen)
         ))
   }

--- a/app/src/test/java/org/simple/clinic/registerorlogin/AuthenticationInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/registerorlogin/AuthenticationInitTest.kt
@@ -8,9 +8,10 @@ import org.junit.Test
 
 class AuthenticationInitTest {
 
+  private val spec = InitSpec(AuthenticationInit())
+
   @Test
   fun `when the screen is created for a new login, open the country selection screen`() {
-    val spec = InitSpec(AuthenticationInit())
     val model = AuthenticationModel.create(OpenFor.NewLogin)
 
     spec
@@ -18,6 +19,18 @@ class AuthenticationInitTest {
         .then(assertThatFirst(
             hasModel(model),
             hasEffects(OpenCountrySelectionScreen)
+        ))
+  }
+
+  @Test
+  fun `when the screen is created for a reauthentication, open the phone number entry screen`() {
+    val model = AuthenticationModel.create(OpenFor.Reauthentication)
+
+    spec
+        .whenInit(model)
+        .then(assertThatFirst(
+            hasModel(model),
+            hasEffects(OpenRegistrationPhoneScreen)
         ))
   }
 }

--- a/mobius-base/src/main/java/org/simple/clinic/mobius/MobiusDelegate.kt
+++ b/mobius-base/src/main/java/org/simple/clinic/mobius/MobiusDelegate.kt
@@ -7,6 +7,7 @@ import com.spotify.mobius.EventSource
 import com.spotify.mobius.First.first
 import com.spotify.mobius.Init
 import com.spotify.mobius.MobiusLoop
+import com.spotify.mobius.Next.noChange
 import com.spotify.mobius.Update
 import com.spotify.mobius.android.MobiusAndroid
 import com.spotify.mobius.extras.Connectables
@@ -33,7 +34,7 @@ class MobiusDelegate<M : Parcelable, E, F> private constructor(
     fun <M : Parcelable, E, F> forView(
         events: Observable<E>,
         defaultModel: M,
-        update: Update<M, E, F>,
+        update: Update<M, E, F> = Update { _, _ -> noChange() },
         effectHandler: ObservableTransformer<F, E>,
         init: Init<M, F> = Init { first(defaultModel) },
         modelUpdateListener: (M) -> Unit = {},
@@ -54,7 +55,7 @@ class MobiusDelegate<M : Parcelable, E, F> private constructor(
     fun <M : Parcelable, E, F> forActivity(
         events: Observable<E>,
         defaultModel: M,
-        update: Update<M, E, F>,
+        update: Update<M, E, F> = Update { _, _ -> noChange() },
         effectHandler: ObservableTransformer<F, E>,
         init: Init<M, F> = Init { first(defaultModel) },
         modelUpdateListener: (M) -> Unit = {},


### PR DESCRIPTION
This is in preparation for a future change where we will replace the screen router usage in this screen with a different navigation framework. This also is a good thing to do anyway because it lets us make assumptions in `TheActivity` about the presence of a user locally which was not the case earlier.