### PR TITLE
Migration app screens to use ViewBinding #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Update `appupdatedialog_body` string
 - Enable ViewBinding
 - Migrate `SplashScreen` to use ViewBinding
+- [In Progress: 4 Nov 2020] Migrate app screens to use ViewBinding
 
 ### Changes
 - Update translations: `kn-IN`, `ta-IN`, `bn-IN`, `ti`, `bn-BD`, `pa-IN`, `mr-IN`, `te-IN`, `hi-IN`

--- a/app/src/main/java/org/simple/clinic/introvideoscreen/IntroVideoScreen.kt
+++ b/app/src/main/java/org/simple/clinic/introvideoscreen/IntroVideoScreen.kt
@@ -9,9 +9,9 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
-import kotlinx.android.synthetic.main.screen_intro_video.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenIntroVideoBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.platform.crash.CrashReporter
@@ -25,6 +25,20 @@ class IntroVideoScreen(
     context: Context,
     attrs: AttributeSet
 ) : ConstraintLayout(context, attrs), UiActions {
+
+  var binding: ScreenIntroVideoBinding? = null
+
+  private val introVideoSubtitle
+    get() = binding!!.introVideoSubtitle
+
+  private val introVideoImageView
+    get() = binding!!.introVideoImageView
+
+  private val watchVideoButton
+    get() = binding!!.watchVideoButton
+
+  private val skipButton
+    get() = binding!!.skipButton
 
   @Inject
   lateinit var screenRouter: ScreenRouter
@@ -60,6 +74,7 @@ class IntroVideoScreen(
 
   override fun onFinishInflate() {
     super.onFinishInflate()
+    binding = ScreenIntroVideoBinding.bind(this)
     if (isInEditMode) return
 
     context.injector<IntroVideoScreenInjector>().inject(this)
@@ -78,6 +93,7 @@ class IntroVideoScreen(
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
     mobiusDelegate.stop()
+    binding = null
   }
 
   override fun openVideo() {

--- a/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/simple/clinic/onboarding/OnboardingScreen.kt
@@ -8,9 +8,9 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
-import kotlinx.android.synthetic.main.screen_onboarding.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenOnboardingBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.registerorlogin.AuthenticationActivity
@@ -27,6 +27,20 @@ class OnboardingScreen(context: Context, attributeSet: AttributeSet) : Constrain
 
   @Inject
   lateinit var activity: AppCompatActivity
+
+  private var binding: ScreenOnboardingBinding? = null
+
+  private val getStartedButton
+    get() = binding!!.getStartedButton
+
+  private val introOneTextView
+    get() = binding!!.introOneTextView
+
+  private val introTwoTextView
+    get() = binding!!.introTwoTextView
+
+  private val introThreeTextView
+    get() = binding!!.introThreeTextView
 
   private val events: Observable<OnboardingEvent> by unsafeLazy {
     getStartedClicks()
@@ -45,6 +59,7 @@ class OnboardingScreen(context: Context, attributeSet: AttributeSet) : Constrain
 
   override fun onFinishInflate() {
     super.onFinishInflate()
+    binding = ScreenOnboardingBinding.bind(this)
     if (isInEditMode) {
       return
     }
@@ -63,6 +78,7 @@ class OnboardingScreen(context: Context, attributeSet: AttributeSet) : Constrain
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinScreen.kt
+++ b/app/src/main/java/org/simple/clinic/registration/confirmpin/RegistrationConfirmPinScreen.kt
@@ -10,9 +10,9 @@ import com.jakewharton.rxbinding3.view.clicks
 import com.jakewharton.rxbinding3.widget.editorActions
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_registration_confirm_pin.view.*
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.SECURITY_PIN_LENGTH
+import org.simple.clinic.databinding.ScreenRegistrationConfirmPinBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.registration.location.RegistrationLocationPermissionScreenKey
@@ -28,6 +28,23 @@ class RegistrationConfirmPinScreen(
     context: Context,
     attrs: AttributeSet
 ) : RelativeLayout(context, attrs), RegistrationConfirmPinUi, RegistrationConfirmPinUiActions {
+
+  var binding: ScreenRegistrationConfirmPinBinding? = null
+
+  private val confirmPinEditText
+    get() = binding!!.confirmPinEditText
+
+  private val backButton
+    get() = binding!!.backButton
+
+  private val resetPinButton
+    get() = binding!!.resetPinButton
+
+  private val errorStateViewGroup
+    get() = binding!!.errorStateViewGroup
+
+  private val pinHintTextView
+    get() = binding!!.pinHintTextView
 
   @Inject
   lateinit var screenRouter: ScreenRouter
@@ -61,6 +78,7 @@ class RegistrationConfirmPinScreen(
 
   override fun onFinishInflate() {
     super.onFinishInflate()
+    binding = ScreenRegistrationConfirmPinBinding.bind(this)
     if (isInEditMode) {
       return
     }
@@ -82,6 +100,7 @@ class RegistrationConfirmPinScreen(
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
+    binding = null
     delegate.stop()
   }
 

--- a/app/src/main/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionScreen.kt
+++ b/app/src/main/java/org/simple/clinic/registration/facility/RegistrationFacilitySelectionScreen.kt
@@ -8,8 +8,8 @@ import android.widget.RelativeLayout
 import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_registration_facility_selection.view.*
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenRegistrationFacilitySelectionBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.introvideoscreen.IntroVideoScreenKey
 import org.simple.clinic.mobius.MobiusDelegate
@@ -26,6 +26,11 @@ class RegistrationFacilitySelectionScreen(
     context: Context,
     attrs: AttributeSet
 ) : RelativeLayout(context, attrs), RegistrationFacilitySelectionUiActions {
+
+  var binding: ScreenRegistrationFacilitySelectionBinding? = null
+
+  private val facilityPickerView
+    get() = binding!!.facilityPickerView
 
   @Inject
   lateinit var screenRouter: ScreenRouter
@@ -61,6 +66,7 @@ class RegistrationFacilitySelectionScreen(
   @SuppressLint("CheckResult")
   override fun onFinishInflate() {
     super.onFinishInflate()
+    binding = ScreenRegistrationFacilitySelectionBinding.bind(this)
     if (isInEditMode) {
       return
     }
@@ -78,6 +84,7 @@ class RegistrationFacilitySelectionScreen(
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
     delegate.stop()
+    binding = null
   }
 
   override fun onSaveInstanceState(): Parcelable? {

--- a/app/src/main/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreen.kt
+++ b/app/src/main/java/org/simple/clinic/registration/location/RegistrationLocationPermissionScreen.kt
@@ -7,8 +7,8 @@ import android.widget.RelativeLayout
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_registration_location_permission.view.*
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenRegistrationLocationPermissionBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.registration.facility.RegistrationFacilitySelectionScreenKey
@@ -26,6 +26,17 @@ class RegistrationLocationPermissionScreen(
     context: Context,
     attrs: AttributeSet
 ) : RelativeLayout(context, attrs), RegistrationLocationPermissionUi {
+
+  var binding: ScreenRegistrationLocationPermissionBinding? = null
+
+  private val allowAccessButton
+    get() = binding!!.allowAccessButton
+
+  private val skipButton
+    get() = binding!!.skipButton
+
+  private val toolbar
+    get() = binding!!.toolbar
 
   @Inject
   lateinit var screenRouter: ScreenRouter
@@ -68,6 +79,7 @@ class RegistrationLocationPermissionScreen(
 
   override fun onFinishInflate() {
     super.onFinishInflate()
+    binding = ScreenRegistrationLocationPermissionBinding.bind(this)
     if (isInEditMode) {
       return
     }
@@ -89,6 +101,7 @@ class RegistrationLocationPermissionScreen(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/registration/name/RegistrationFullNameScreen.kt
+++ b/app/src/main/java/org/simple/clinic/registration/name/RegistrationFullNameScreen.kt
@@ -11,9 +11,9 @@ import com.jakewharton.rxbinding3.widget.editorActions
 import com.jakewharton.rxbinding3.widget.textChanges
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_registration_name.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenRegistrationNameBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.registration.pin.RegistrationPinScreenKey
@@ -27,6 +27,20 @@ class RegistrationFullNameScreen(
     context: Context,
     attrs: AttributeSet
 ) : RelativeLayout(context, attrs), RegistrationNameUi, RegistrationNameUiActions {
+
+  var binding: ScreenRegistrationNameBinding? = null
+
+  private val backButton
+    get() = binding!!.backButton
+
+  private val cardViewContentLayout
+    get() = binding!!.cardViewContentLayout
+
+  private val fullNameEditText
+    get() = binding!!.fullNameEditText
+
+  private val validationErrorTextView
+    get() = binding!!.validationErrorTextView
 
   @Inject
   lateinit var screenRouter: ScreenRouter
@@ -61,6 +75,7 @@ class RegistrationFullNameScreen(
 
   override fun onFinishInflate() {
     super.onFinishInflate()
+    binding = ScreenRegistrationNameBinding.bind(this)
     if (isInEditMode) {
       return
     }
@@ -85,6 +100,7 @@ class RegistrationFullNameScreen(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneScreen.kt
+++ b/app/src/main/java/org/simple/clinic/registration/phone/RegistrationPhoneScreen.kt
@@ -12,10 +12,10 @@ import com.jakewharton.rxbinding3.widget.editorActions
 import com.jakewharton.rxbinding3.widget.textChanges
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_registration_phone.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.appconfig.Country
+import org.simple.clinic.databinding.ScreenRegistrationPhoneBinding
 import org.simple.clinic.deniedaccess.AccessDeniedScreenKey
 import org.simple.clinic.di.injector
 import org.simple.clinic.login.pin.LoginPinScreenKey
@@ -48,6 +48,20 @@ class RegistrationPhoneScreen(
   @Inject
   lateinit var effectHandlerFactory: RegistrationPhoneEffectHandler.Factory
 
+  var binding: ScreenRegistrationPhoneBinding? = null
+
+  private val isdCodeEditText
+    get() = binding!!.isdCodeEditText
+
+  private val phoneNumberEditText
+    get() = binding!!.phoneNumberEditText
+
+  private val validationErrorTextView
+    get() = binding!!.validationErrorTextView
+
+  private val progressView
+    get() = binding!!.progressView
+
   @Inject
   lateinit var uuidGenerator: UuidGenerator
 
@@ -76,6 +90,7 @@ class RegistrationPhoneScreen(
 
   override fun onFinishInflate() {
     super.onFinishInflate()
+    binding = ScreenRegistrationPhoneBinding.bind(this)
     if (isInEditMode) {
       return
     }
@@ -92,6 +107,7 @@ class RegistrationPhoneScreen(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/registration/pin/RegistrationPinScreen.kt
+++ b/app/src/main/java/org/simple/clinic/registration/pin/RegistrationPinScreen.kt
@@ -9,10 +9,10 @@ import android.widget.RelativeLayout
 import com.jakewharton.rxbinding3.widget.editorActions
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_registration_pin.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.SECURITY_PIN_LENGTH
+import org.simple.clinic.databinding.ScreenRegistrationPinBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.registration.confirmpin.RegistrationConfirmPinScreenKey
@@ -25,6 +25,20 @@ class RegistrationPinScreen(
     context: Context,
     attrs: AttributeSet
 ) : RelativeLayout(context, attrs), RegistrationPinUi, RegistrationPinUiActions {
+
+  var binding: ScreenRegistrationPinBinding? = null
+
+  private val pinEditText
+    get() = binding!!.pinEditText
+
+  private val backButton
+    get() = binding!!.backButton
+
+  private val pinHintTextView
+    get() = binding!!.pinHintTextView
+
+  private val errorTextView
+    get() = binding!!.errorTextView
 
   @Inject
   lateinit var screenRouter: ScreenRouter
@@ -47,7 +61,7 @@ class RegistrationPinScreen(
     val screenKey = screenRouter.key<RegistrationPinScreenKey>(this)
 
     MobiusDelegate.forView(
-      events = events.ofType(),
+        events = events.ofType(),
         defaultModel = RegistrationPinModel.create(screenKey.registrationEntry),
         update = RegistrationPinUpdate(requiredPinLength = SECURITY_PIN_LENGTH),
         init = RegistrationPinInit(),
@@ -58,6 +72,7 @@ class RegistrationPinScreen(
 
   override fun onFinishInflate() {
     super.onFinishInflate()
+    binding = ScreenRegistrationPinBinding.bind(this)
     if (isInEditMode) {
       return
     }
@@ -79,6 +94,7 @@ class RegistrationPinScreen(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingScreen.kt
+++ b/app/src/main/java/org/simple/clinic/registration/register/RegistrationLoadingScreen.kt
@@ -8,9 +8,9 @@ import android.widget.LinearLayout
 import androidx.appcompat.app.AppCompatActivity
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_registration_loading.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenRegistrationLoadingBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.main.TheActivity
 import org.simple.clinic.mobius.MobiusDelegate
@@ -24,6 +24,23 @@ class RegistrationLoadingScreen(
     context: Context,
     attrs: AttributeSet
 ) : LinearLayout(context, attrs), RegistrationLoadingUi, RegistrationLoadingUiActions {
+
+  var binding: ScreenRegistrationLoadingBinding? = null
+
+  private val loaderBack
+    get() = binding!!.loaderBack
+
+  private val errorRetryButton
+    get() = binding!!.errorRetryButton
+
+  private val errorTitle
+    get() = binding!!.errorTitle
+
+  private val errorMessage
+    get() = binding!!.errorMessage
+
+  private val viewSwitcher
+    get() = binding!!.viewSwitcher
 
   @Inject
   lateinit var screenRouter: ScreenRouter
@@ -56,6 +73,7 @@ class RegistrationLoadingScreen(
   override fun onFinishInflate() {
     super.onFinishInflate()
 
+    binding = ScreenRegistrationLoadingBinding.bind(this)
     context.injector<Injector>().inject(this)
 
     loaderBack.setOnClickListener {
@@ -70,6 +88,7 @@ class RegistrationLoadingScreen(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/selectcountry/SelectCountryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/selectcountry/SelectCountryScreen.kt
@@ -10,12 +10,12 @@ import com.jakewharton.rxbinding2.view.RxView
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_selectcountry.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.appconfig.AppConfigRepository
 import org.simple.clinic.appconfig.Country
 import org.simple.clinic.appconfig.displayname.CountryDisplayNameFetcher
+import org.simple.clinic.databinding.ScreenSelectcountryBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.platform.crash.CrashReporter
@@ -34,6 +34,26 @@ class SelectCountryScreen(
     context: Context,
     attributeSet: AttributeSet
 ) : ConstraintLayout(context, attributeSet), SelectCountryUi, UiActions {
+
+  var binding: ScreenSelectcountryBinding? = null
+
+  private val countrySelectionViewFlipper
+    get() = binding!!.countrySelectionViewFlipper
+
+  private val supportedCountriesList
+    get() = binding!!.supportedCountriesList
+
+  private val tryAgain
+    get() = binding!!.tryAgain
+
+  private val nextButton
+    get() = binding!!.nextButton
+
+  private val errorMessageTextView
+    get() = binding!!.errorMessageTextView
+
+  private val nextButtonFrame
+    get() = binding!!.nextButtonFrame
 
   @Inject
   lateinit var appConfigRepository: AppConfigRepository
@@ -95,6 +115,7 @@ class SelectCountryScreen(
   override fun onFinishInflate() {
     super.onFinishInflate()
 
+    binding = ScreenSelectcountryBinding.bind(this)
     if (isInEditMode) {
       return
     }
@@ -140,6 +161,7 @@ class SelectCountryScreen(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/1828/migrate-app-to-use-view-binding-instead-of-kotlin-synthetic-view-accessors