### PR TITLE
Migrate app screens to use ViewBinding #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 ### Features
 - [In Progress: 29 Oct 2020] Refill prescriptions in edit medicine screen
+- [In Progress: 11 Nov 2020] Migrate app screens to use ViewBinding
 
 ### Internal
 - Add `recipes.md`

--- a/app/src/main/java/org/simple/clinic/activity/placeholder/PlaceholderScreen.kt
+++ b/app/src/main/java/org/simple/clinic/activity/placeholder/PlaceholderScreen.kt
@@ -5,21 +5,30 @@ import android.util.AttributeSet
 import android.widget.RelativeLayout
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
-import kotlinx.android.synthetic.main.screen_placeholder.view.*
 import org.simple.clinic.await.Await
 import org.simple.clinic.await.Checkpoint
+import org.simple.clinic.databinding.ScreenPlaceholderBinding
 import java.util.concurrent.TimeUnit.SECONDS
 
 class PlaceholderScreen(context: Context, attrs: AttributeSet) : RelativeLayout(context, attrs) {
   private val delayToShowMessage = SECONDS.toMillis(3).toInt()
   private val await = Await(listOf(Checkpoint.unit(delayToShowMessage)))
   private var awaitDisposable: Disposable? = null
+  private var binding: ScreenPlaceholderBinding? = null
+
+  private val loadingTextLayout
+    get() = binding!!.loadingTextLayout
+
+  private val loadingProgressBar
+    get() = binding!!.loadingProgressBar
 
   override fun onFinishInflate() {
     super.onFinishInflate()
     if (isInEditMode) {
       return
     }
+
+    binding = ScreenPlaceholderBinding.bind(this)
   }
 
   override fun onAttachedToWindow() {
@@ -31,6 +40,7 @@ class PlaceholderScreen(context: Context, attrs: AttributeSet) : RelativeLayout(
 
   override fun onDetachedFromWindow() {
     awaitDisposable?.dispose()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/bloodsugar/history/BloodSugarHistoryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/bloodsugar/history/BloodSugarHistoryScreen.kt
@@ -13,7 +13,6 @@ import com.jakewharton.rxbinding3.view.detaches
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_blood_sugar_history.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.bloodsugar.BloodSugarHistoryListItemDataSourceFactory
@@ -23,6 +22,7 @@ import org.simple.clinic.bloodsugar.history.adapter.BloodSugarHistoryItemClicked
 import org.simple.clinic.bloodsugar.history.adapter.BloodSugarHistoryListItemDiffCallback
 import org.simple.clinic.bloodsugar.history.adapter.NewBloodSugarClicked
 import org.simple.clinic.bloodsugar.selection.type.BloodSugarTypePickerSheet
+import org.simple.clinic.databinding.ScreenBloodSugarHistoryBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.patient.DateOfBirth
@@ -85,6 +85,14 @@ class BloodSugarHistoryScreen(
   @Named("for_measurement_history")
   lateinit var measurementHistoryPaginationConfig: PagedList.Config
 
+  private var binding: ScreenBloodSugarHistoryBinding? = null
+
+  private val toolbar
+    get() = binding!!.toolbar
+
+  private val bloodSugarHistoryList
+    get() = binding!!.bloodSugarHistoryList
+
   private val bloodSugarHistoryAdapter = PagingItemAdapter(BloodSugarHistoryListItemDiffCallback())
 
   private val events: Observable<BloodSugarHistoryScreenEvent> by unsafeLazy {
@@ -117,6 +125,9 @@ class BloodSugarHistoryScreen(
     if (isInEditMode) {
       return
     }
+
+    binding = ScreenBloodSugarHistoryBinding.bind(this)
+
     context.injector<BloodSugarHistoryScreenInjector>().inject(this)
 
     val screenDestroys: Observable<ScreenDestroyed> = detaches().map { ScreenDestroyed() }
@@ -135,6 +146,7 @@ class BloodSugarHistoryScreen(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/deniedaccess/AccessDeniedScreen.kt
+++ b/app/src/main/java/org/simple/clinic/deniedaccess/AccessDeniedScreen.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.widget.RelativeLayout
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.android.synthetic.main.screen_access_denied.view.*
+import org.simple.clinic.databinding.ScreenAccessDeniedBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.router.screen.BackPressInterceptCallback
 import org.simple.clinic.router.screen.BackPressInterceptor
@@ -24,11 +24,19 @@ class AccessDeniedScreen(context: Context, attrs: AttributeSet) : RelativeLayout
     screenRouter.key<AccessDeniedScreenKey>(this)
   }
 
+  private var binding: ScreenAccessDeniedBinding? = null
+
+  private val userFullNameText
+    get() = binding!!.userFullNameText
+
   override fun onFinishInflate() {
     super.onFinishInflate()
     if (isInEditMode) {
       return
     }
+
+    binding = ScreenAccessDeniedBinding.bind(this)
+
     context.injector<AccessDeniedScreenInjector>().inject(this)
 
     userFullNameText.text = screenKey.fullName
@@ -43,5 +51,10 @@ class AccessDeniedScreen(context: Context, attrs: AttributeSet) : RelativeLayout
       }
     }
     screenRouter.registerBackPressInterceptor(interceptor)
+  }
+
+  override fun onDetachedFromWindow() {
+    binding = null
+    super.onDetachedFromWindow()
   }
 }

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
@@ -20,9 +20,9 @@ import com.jakewharton.rxbinding3.widget.textChanges
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
 import kotlinx.android.synthetic.main.patient_edit_bp_passport_view.view.*
-import kotlinx.android.synthetic.main.screen_edit_patient.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenEditPatientBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.editpatient.EditPatientValidationError.AgeExceedsMaxLimit
 import org.simple.clinic.editpatient.EditPatientValidationError.AgeExceedsMinLimit
@@ -117,6 +117,104 @@ class EditPatientScreen(context: Context, attributeSet: AttributeSet) : Relative
     screenRouter.key<EditPatientScreenKey>(this)
   }
 
+  private var binding: ScreenEditPatientBinding? = null
+
+  private val zoneEditText
+    get() = binding!!.zoneEditText
+
+  private val streetAddressEditText
+    get() = binding!!.streetAddressEditText
+
+  private val deletePatient
+    get() = binding!!.deletePatient
+
+  private val fullNameInputLayout
+    get() = binding!!.fullNameInputLayout
+
+  private val ageInputLayout
+    get() = binding!!.ageInputLayout
+
+  private val dateOfBirthInputLayout
+    get() = binding!!.dateOfBirthInputLayout
+
+  private val phoneNumberInputLayout
+    get() = binding!!.phoneNumberInputLayout
+
+  private val genderRadioGroup
+    get() = binding!!.genderRadioGroup
+
+  private val alternativeIdInputLayout
+    get() = binding!!.alternativeIdInputLayout
+
+  private val streetAddressInputLayout
+    get() = binding!!.streetAddressInputLayout
+
+  private val colonyOrVillageInputLayout
+    get() = binding!!.colonyOrVillageInputLayout
+
+  private val zoneInputLayout
+    get() = binding!!.zoneInputLayout
+
+  private val districtInputLayout
+    get() = binding!!.districtInputLayout
+
+  private val stateInputLayout
+    get() = binding!!.stateInputLayout
+
+  private val maleRadioButton
+    get() = binding!!.maleRadioButton
+
+  private val femaleRadioButton
+    get() = binding!!.femaleRadioButton
+
+  private val transgenderRadioButton
+    get() = binding!!.transgenderRadioButton
+
+  private val saveButtonFrame
+    get() = binding!!.saveButtonFrame
+
+  private val fullNameEditText
+    get() = binding!!.fullNameEditText
+
+  private val phoneNumberEditText
+    get() = binding!!.phoneNumberEditText
+
+  private val districtEditText
+    get() = binding!!.districtEditText
+
+  private val stateEditText
+    get() = binding!!.stateEditText
+
+  private val alternativeIdInputEditText
+    get() = binding!!.alternativeIdInputEditText
+
+  private val colonyOrVillageEditText
+    get() = binding!!.colonyOrVillageEditText
+
+  private val backButton
+    get() = binding!!.backButton
+
+  private val dateOfBirthEditText
+    get() = binding!!.dateOfBirthEditText
+
+  private val ageEditText
+    get() = binding!!.ageEditText
+
+  private val bpPassportsContainer
+    get() = binding!!.bpPassportsContainer
+
+  private val bpPassportsLabel
+    get() = binding!!.bpPassportsLabel
+
+  private val formScrollView
+    get() = binding!!.formScrollView
+
+  private val dateOfBirthAndAgeSeparator
+    get() = binding!!.dateOfBirthAndAgeSeparator
+
+  private val saveButton
+    get() = binding!!.saveButton
+
   private val viewRenderer = EditPatientViewRenderer(this)
 
   private val events: Observable<EditPatientEvent>
@@ -156,6 +254,8 @@ class EditPatientScreen(context: Context, attributeSet: AttributeSet) : Relative
     if (isInEditMode) {
       return
     }
+
+    binding = ScreenEditPatientBinding.bind(this)
 
     context.injector<Injector>().inject(this)
   }
@@ -228,6 +328,7 @@ class EditPatientScreen(context: Context, attributeSet: AttributeSet) : Relative
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/editpatient/deletepatient/DeletePatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/deletepatient/DeletePatientScreen.kt
@@ -11,9 +11,9 @@ import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.screen_delete_patient.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenDeletePatientBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.home.HomeScreenKey
 import org.simple.clinic.mobius.MobiusDelegate
@@ -39,6 +39,14 @@ class DeletePatientScreen(context: Context, attrs: AttributeSet) : ConstraintLay
   private val screenKey by unsafeLazy {
     screenRouter.key<DeletePatientScreenKey>(this)
   }
+
+  private var binding: ScreenDeletePatientBinding? = null
+
+  private val toolbar
+    get() = binding!!.toolbar
+
+  private val deleteReasonsRecyclerView
+    get() = binding!!.deleteReasonsRecyclerView
 
   private val deleteReasonsAdapter = ItemAdapter(DeleteReasonItem.DiffCallback())
   private val dialogEvents = PublishSubject.create<DeletePatientEvent>()
@@ -75,6 +83,8 @@ class DeletePatientScreen(context: Context, attrs: AttributeSet) : ConstraintLay
     super.onFinishInflate()
     if (isInEditMode) return
 
+    binding = ScreenDeletePatientBinding.bind(this)
+
     context.injector<DeletePatientScreenInjector>().inject(this)
 
     toolbar.setNavigationOnClickListener { screenRouter.pop() }
@@ -92,6 +102,7 @@ class DeletePatientScreen(context: Context, attrs: AttributeSet) : ConstraintLay
   override fun onDetachedFromWindow() {
     deleteConfirmationDialog.dismiss()
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpScreen.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpScreen.kt
@@ -11,11 +11,11 @@ import com.jakewharton.rxbinding3.view.clicks
 import com.jakewharton.rxbinding3.widget.editorActions
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_enterotp.view.*
 import org.simple.clinic.LOGIN_OTP_LENGTH
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.appconfig.Country
+import org.simple.clinic.databinding.ScreenEnterotpBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.router.screen.ScreenRouter
@@ -38,6 +38,32 @@ class EnterOtpScreen(
 
   @Inject
   lateinit var effectHandlerFactory: EnterOtpEffectHandler.Factory
+
+  private var binding: ScreenEnterotpBinding? = null
+
+  private val otpEntryEditText
+    get() = binding!!.otpEntryEditText
+
+  private val backButton
+    get() = binding!!.backButton
+
+  private val resendSmsButton
+    get() = binding!!.resendSmsButton
+
+  private val userPhoneNumberTextView
+    get() = binding!!.userPhoneNumberTextView
+
+  private val smsSentTextView
+    get() = binding!!.smsSentTextView
+
+  private val errorTextView
+    get() = binding!!.errorTextView
+
+  private val validateOtpProgressBar
+    get() = binding!!.validateOtpProgressBar
+
+  private val otpEntryContainer
+    get() = binding!!.otpEntryContainer
 
   private val events by unsafeLazy {
     Observable
@@ -66,6 +92,9 @@ class EnterOtpScreen(
     if (isInEditMode) {
       return
     }
+
+    binding = ScreenEnterotpBinding.bind(this)
+
     context.injector<Injector>().inject(this)
 
     otpEntryEditText.showKeyboard()
@@ -79,6 +108,7 @@ class EnterOtpScreen(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/forgotpin/confirmpin/ForgotPinConfirmPinScreen.kt
+++ b/app/src/main/java/org/simple/clinic/forgotpin/confirmpin/ForgotPinConfirmPinScreen.kt
@@ -9,9 +9,9 @@ import androidx.annotation.StringRes
 import com.jakewharton.rxbinding3.widget.editorActions
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_forgotpin_confirmpin.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenForgotpinConfirmpinBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.home.HomeScreenKey
 import org.simple.clinic.mobius.MobiusDelegate
@@ -33,6 +33,32 @@ class ForgotPinConfirmPinScreen(
 
   @Inject
   lateinit var screenRouter: ScreenRouter
+
+  private var binding: ScreenForgotpinConfirmpinBinding? = null
+
+  private val pinEntryEditText
+    get() = binding!!.pinEntryEditText
+
+  private val backButton
+    get() = binding!!.backButton
+
+  private val userNameTextView
+    get() = binding!!.userNameTextView
+
+  private val facilityNameTextView
+    get() = binding!!.facilityNameTextView
+
+  private val pinErrorTextView
+    get() = binding!!.pinErrorTextView
+
+  private val pinEntryHintTextView
+    get() = binding!!.pinEntryHintTextView
+
+  private val progressBar
+    get() = binding!!.progressBar
+
+  private val pinEntryContainer
+    get() = binding!!.pinEntryContainer
 
   private val events by unsafeLazy {
     Observable
@@ -64,11 +90,14 @@ class ForgotPinConfirmPinScreen(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
   override fun onFinishInflate() {
     super.onFinishInflate()
+
+    binding = ScreenForgotpinConfirmpinBinding.bind(this)
 
     context.injector<Injector>().inject(this)
 


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/1828/migrate-app-to-use-view-binding-instead-of-kotlin-synthetic-view-accessors