### PR TITLE
Migrate app to use View Binding instead of Kotlin synthetic view accessors - 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next Release
 ### Internal
-- [In Progress: 11 Nov 2020] Migrate app screens to use ViewBinding
+- [In Progress: 30 Nov 2020] Migrate app to use ViewBinding
 - Bump appcompat -> 1.2.0
 - Bump CI JDK version to 11
 - [In progress: 01 Dec 2020] Migrate `ShortCodeSearchResultScreen` to Mobius

--- a/app/src/main/java/org/simple/clinic/facilitypicker/FacilityPickerView.kt
+++ b/app/src/main/java/org/simple/clinic/facilitypicker/FacilityPickerView.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Parcelable
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.widget.FrameLayout
 import android.widget.RelativeLayout
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -15,9 +16,9 @@ import io.reactivex.Observable
 import io.reactivex.rxkotlin.Observables
 import io.reactivex.rxkotlin.cast
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.view_facilitypicker.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ViewFacilitypickerBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.facility.change.FacilityListItem
@@ -54,8 +55,29 @@ class FacilityPickerView(
 
   private val pickFrom: PickFrom
 
+  private var binding: ViewFacilitypickerBinding? = null
+
+  private val toolbarViewWithSearch
+    get() = binding!!.toolbarViewWithSearch
+
+  private val toolbarViewWithoutSearch
+    get() = binding!!.toolbarViewWithoutSearch
+
+  private val facilityRecyclerView
+    get() = binding!!.facilityRecyclerView
+
+  private val searchEditText
+    get() = binding!!.searchEditText
+
+  private val progressView
+    get() = binding!!.progressView
+
+  private val toolbarViewFlipper
+    get() = binding!!.toolbarViewFlipper
+
   init {
-    inflate(context, R.layout.view_facilitypicker, this)
+    val layoutInflater = LayoutInflater.from(context)
+    binding = ViewFacilitypickerBinding.inflate(layoutInflater, this)
 
     val typedArray = context.obtainStyledAttributes(attributeSet, R.styleable.FacilityPickerView)
     pickFrom = PickFrom.forAttribute(typedArray)
@@ -108,6 +130,7 @@ class FacilityPickerView(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/forgotpin/createnewpin/ForgotPinCreateNewPinScreen.kt
+++ b/app/src/main/java/org/simple/clinic/forgotpin/createnewpin/ForgotPinCreateNewPinScreen.kt
@@ -9,8 +9,8 @@ import android.widget.RelativeLayout
 import com.jakewharton.rxbinding3.widget.editorActions
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_forgotpin_createpin.view.*
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenForgotpinCreatepinBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.forgotpin.confirmpin.ForgotPinConfirmPinScreenKey
 import org.simple.clinic.mobius.MobiusDelegate
@@ -30,6 +30,20 @@ class ForgotPinCreateNewPinScreen(
 
   @Inject
   lateinit var effectHandlerFactory: ForgotPinCreateNewEffectHandler.Factory
+
+  private var binding: ScreenForgotpinCreatepinBinding? = null
+
+  private val createPinEditText
+    get() = binding!!.createPinEditText
+
+  private val userFullNameTextView
+    get() = binding!!.userFullNameTextView
+
+  private val facilityNameTextView
+    get() = binding!!.facilityNameTextView
+
+  private val createPinErrorTextView
+    get() = binding!!.createPinErrorTextView
 
   private val events by unsafeLazy {
     Observable
@@ -59,6 +73,8 @@ class ForgotPinCreateNewPinScreen(
       return
     }
 
+    binding = ScreenForgotpinCreatepinBinding.bind(this)
+
     context.injector<Injector>().inject(this)
 
     createPinEditText.showKeyboard()
@@ -71,10 +87,11 @@ class ForgotPinCreateNewPinScreen(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 

--- a/app/src/main/java/org/simple/clinic/home/HomeScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomeScreen.kt
@@ -9,9 +9,9 @@ import com.google.android.material.tabs.TabLayoutMediator
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_home.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenHomeBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.facility.change.FacilityChangeActivity
 import org.simple.clinic.home.HomeTab.OVERDUE
@@ -51,6 +51,26 @@ class HomeScreen(context: Context, attrs: AttributeSet) : RelativeLayout(context
   @Inject
   lateinit var utcClock: UtcClock
 
+  private var binding: ScreenHomeBinding? = null
+
+  private val homeScreenRootLayout
+    get() = binding!!.homeScreenRootLayout
+
+  private val viewPager
+    get() = binding!!.viewPager
+
+  private val homeTabLayout
+    get() = binding!!.homeTabLayout
+
+  private val toolbar
+    get() = binding!!.toolbar
+
+  private val helpButton
+    get() = binding!!.helpButton
+
+  private val facilitySelectButton
+    get() = binding!!.facilitySelectButton
+
   private val tabs = listOf(PATIENTS, OVERDUE, REPORTS)
 
   private val events by unsafeLazy {
@@ -80,10 +100,11 @@ class HomeScreen(context: Context, attrs: AttributeSet) : RelativeLayout(context
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 
@@ -96,6 +117,8 @@ class HomeScreen(context: Context, attrs: AttributeSet) : RelativeLayout(context
     if (isInEditMode) {
       return
     }
+
+    binding = ScreenHomeBinding.bind(this)
 
     context.injector<Injector>().inject(this)
 
@@ -112,7 +135,7 @@ class HomeScreen(context: Context, attrs: AttributeSet) : RelativeLayout(context
 
     // The WebView in "Progress" tab is expensive to load. Pre-instantiating
     // it when the app starts reduces its time-to-display.
-    viewPager.offscreenPageLimit = HomeTab.REPORTS.ordinal - HomeTab.PATIENTS.ordinal
+    viewPager.offscreenPageLimit = REPORTS.ordinal - PATIENTS.ordinal
   }
 
   private fun setupToolBar() {

--- a/app/src/main/java/org/simple/clinic/home/help/HelpScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/help/HelpScreen.kt
@@ -7,9 +7,9 @@ import android.util.AttributeSet
 import android.widget.LinearLayout
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_help.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenHelpBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.router.screen.ScreenRouter
@@ -24,6 +24,26 @@ class HelpScreen(context: Context, attrs: AttributeSet) : LinearLayout(context, 
 
   @Inject
   lateinit var effectHandlerFactory: HelpScreenEffectHandler.Factory
+
+  private var binding: ScreenHelpBinding? = null
+
+  private val toolbar
+    get() = binding!!.toolbar
+
+  private val webView
+    get() = binding!!.webView
+
+  private val tryAgainButton
+    get() = binding!!.tryAgainButton
+
+  private val progressBar
+    get() = binding!!.progressBar
+
+  private val noContentView
+    get() = binding!!.noContentView
+
+  private val errorMessageTextView
+    get() = binding!!.errorMessageTextView
 
   private val events by unsafeLazy {
     tryAgainClicks()
@@ -50,6 +70,7 @@ class HelpScreen(context: Context, attrs: AttributeSet) : LinearLayout(context, 
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
@@ -68,6 +89,8 @@ class HelpScreen(context: Context, attrs: AttributeSet) : LinearLayout(context, 
     if (isInEditMode) {
       return
     }
+
+    binding = ScreenHelpBinding.bind(this)
 
     context.injector<Injector>().inject(this)
 

--- a/app/src/main/java/org/simple/clinic/login/applock/AppLockScreen.kt
+++ b/app/src/main/java/org/simple/clinic/login/applock/AppLockScreen.kt
@@ -9,9 +9,8 @@ import androidx.appcompat.app.AppCompatActivity
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.pin_entry_card.view.*
-import kotlinx.android.synthetic.main.screen_app_lock.view.*
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenAppLockBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.router.screen.BackPressInterceptCallback
@@ -32,6 +31,26 @@ class AppLockScreen(context: Context, attrs: AttributeSet) : RelativeLayout(cont
 
   @Inject
   lateinit var effectHandlerFactory: AppLockEffectHandler.Factory
+
+  private var binding: ScreenAppLockBinding? = null
+
+  private val logoutButton
+    get() = binding!!.logoutButton
+
+  private val pinEntryCardView
+    get() = binding!!.pinEntryCardView
+
+  private val pinEditText
+    get() = binding!!.pinEntryCardView.pinEditText
+
+  private val forgotPinButton
+    get() = binding!!.pinEntryCardView.forgotPinButton
+
+  private val fullNameTextView
+    get() = binding!!.fullNameTextView
+
+  private val facilityTextView
+    get() = binding!!.facilityTextView
 
   private val events by unsafeLazy {
     Observable
@@ -63,10 +82,11 @@ class AppLockScreen(context: Context, attrs: AttributeSet) : RelativeLayout(cont
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 
@@ -79,6 +99,9 @@ class AppLockScreen(context: Context, attrs: AttributeSet) : RelativeLayout(cont
     if (isInEditMode) {
       return
     }
+
+    binding = ScreenAppLockBinding.bind(this)
+
     context.injector<Injector>().inject(this)
 
     logoutButton.setOnClickListener {
@@ -87,7 +110,7 @@ class AppLockScreen(context: Context, attrs: AttributeSet) : RelativeLayout(cont
 
     // The keyboard shows up on PIN field automatically when the app is
     // starting, but not when the user comes back from FacilityChangeScreen.
-    pinEntryCardView.pinEditText.showKeyboard()
+    pinEditText.showKeyboard()
   }
 
   private fun backClicks(): Observable<AppLockBackClicked> {
@@ -104,8 +127,7 @@ class AppLockScreen(context: Context, attrs: AttributeSet) : RelativeLayout(cont
   }
 
   private fun forgotPinClicks() =
-      pinEntryCardView
-          .forgotPinButton
+      forgotPinButton
           .clicks()
           .map { AppLockForgotPinClicked }
 
@@ -120,7 +142,7 @@ class AppLockScreen(context: Context, attrs: AttributeSet) : RelativeLayout(cont
   }
 
   override fun setFacilityName(facilityName: String) {
-    this.facilityTextView.text = facilityName
+    facilityTextView.text = facilityName
   }
 
   override fun restorePreviousScreen() {

--- a/app/src/main/java/org/simple/clinic/login/pin/LoginPinScreen.kt
+++ b/app/src/main/java/org/simple/clinic/login/pin/LoginPinScreen.kt
@@ -8,8 +8,8 @@ import androidx.appcompat.app.AppCompatActivity
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_login_pin.view.*
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenLoginPinBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.main.TheActivity
 import org.simple.clinic.mobius.MobiusDelegate
@@ -35,6 +35,17 @@ class LoginPinScreen(context: Context, attrs: AttributeSet) : RelativeLayout(con
 
   @Inject
   lateinit var activity: AppCompatActivity
+
+  private var binding: ScreenLoginPinBinding? = null
+
+  private val pinEntryCardView
+    get() = binding!!.pinEntryCardView
+
+  private val backButton
+    get() = binding!!.backButton
+
+  private val phoneNumberTextView
+    get() = binding!!.phoneNumberTextView
 
   private val events by unsafeLazy {
     Observable
@@ -64,6 +75,8 @@ class LoginPinScreen(context: Context, attrs: AttributeSet) : RelativeLayout(con
       return
     }
 
+    binding = ScreenLoginPinBinding.bind(this)
+
     context.injector<Injector>().inject(this)
 
     pinEntryCardView.setForgotButtonVisible(false)
@@ -76,10 +89,11 @@ class LoginPinScreen(context: Context, attrs: AttributeSet) : RelativeLayout(con
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 

--- a/app/src/main/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryScreen.kt
@@ -10,8 +10,8 @@ import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
-import kotlinx.android.synthetic.main.screen_new_medical_history.view.*
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenNewMedicalHistoryBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.medicalhistory.Answer
 import org.simple.clinic.medicalhistory.MedicalHistoryQuestion
@@ -50,6 +50,35 @@ class NewMedicalHistoryScreen(
   @Inject
   lateinit var effectHandlerFactory: NewMedicalHistoryEffectHandler.Factory
 
+  private var binding: ScreenNewMedicalHistoryBinding? = null
+
+  private val toolbar
+    get() = binding!!.toolbar
+
+  private val nextButtonFrame
+    get() = binding!!.nextButtonFrame
+
+  private val heartAttackQuestionView
+    get() = binding!!.heartAttackQuestionView
+
+  private val strokeQuestionView
+    get() = binding!!.strokeQuestionView
+
+  private val kidneyDiseaseQuestionView
+    get() = binding!!.kidneyDiseaseQuestionView
+
+  private val diabetesQuestionView
+    get() = binding!!.diabetesQuestionView
+
+  private val diagnosisViewContainer
+    get() = binding!!.diagnosisViewContainer
+
+  private val diabetesDiagnosisView
+    get() = binding!!.diabetesDiagnosisView
+
+  private val hypertensionDiagnosisView
+    get() = binding!!.hypertensionDiagnosisView
+
   private val questionViewEvents: Subject<NewMedicalHistoryEvent> = PublishSubject.create()
 
   private val events: Observable<NewMedicalHistoryEvent> by unsafeLazy {
@@ -78,6 +107,8 @@ class NewMedicalHistoryScreen(
       return
     }
 
+    binding = ScreenNewMedicalHistoryBinding.bind(this)
+
     context.injector<Injector>().inject(this)
 
     toolbar.setNavigationOnClickListener {
@@ -96,10 +127,11 @@ class NewMedicalHistoryScreen(
 
   override fun onDetachedFromWindow() {
     mobiusDelegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return mobiusDelegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
@@ -24,10 +24,10 @@ import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_manual_patient_entry.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.appconfig.Country
+import org.simple.clinic.databinding.ScreenManualPatientEntryBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.medicalhistory.newentry.NewMedicalHistoryScreenKey
 import org.simple.clinic.mobius.MobiusDelegate
@@ -97,6 +97,116 @@ class PatientEntryScreen(context: Context, attrs: AttributeSet) : RelativeLayout
   @Inject
   lateinit var effectHandlerInjectionFactory: PatientEntryEffectHandler.InjectionFactory
 
+  private var binding: ScreenManualPatientEntryBinding? = null
+
+  private val fullNameEditText
+    get() = binding!!.fullNameEditText
+
+  private val ageEditText
+    get() = binding!!.ageEditText
+
+  private val dateOfBirthEditText
+    get() = binding!!.dateOfBirthEditText
+
+  private val phoneNumberEditText
+    get() = binding!!.phoneNumberEditText
+
+  private val colonyOrVillageEditText
+    get() = binding!!.colonyOrVillageEditText
+
+  private val districtEditText
+    get() = binding!!.districtEditText
+
+  private val stateEditText
+    get() = binding!!.stateEditText
+
+  private val backButton
+    get() = binding!!.backButton
+
+  private val identifierTextView
+    get() = binding!!.identifierTextView
+
+  private val fullNameInputLayout
+    get() = binding!!.fullNameInputLayout
+
+  private val ageEditTextInputLayout
+    get() = binding!!.ageEditTextInputLayout
+
+  private val dateOfBirthInputLayout
+    get() = binding!!.dateOfBirthInputLayout
+
+  private val phoneNumberInputLayout
+    get() = binding!!.phoneNumberInputLayout
+
+  private val genderRadioGroup
+    get() = binding!!.genderRadioGroup
+
+  private val alternativeIdInputLayout
+    get() = binding!!.alternativeIdInputLayout
+
+  private val streetAddressInputLayout
+    get() = binding!!.streetAddressInputLayout
+
+  private val colonyOrVillageInputLayout
+    get() = binding!!.colonyOrVillageInputLayout
+
+  private val zoneInputLayout
+    get() = binding!!.zoneInputLayout
+
+  private val districtInputLayout
+    get() = binding!!.districtInputLayout
+
+  private val stateInputLayout
+    get() = binding!!.stateInputLayout
+
+  private val maleRadioButton
+    get() = binding!!.maleRadioButton
+
+  private val femaleRadioButton
+    get() = binding!!.femaleRadioButton
+
+  private val transgenderRadioButton
+    get() = binding!!.transgenderRadioButton
+
+  private val consentTextView
+    get() = binding!!.consentTextView
+
+  private val consentLabel
+    get() = binding!!.consentLabel
+
+  private val alternativeIdInputEditText
+    get() = binding!!.alternativeIdInputEditText
+
+  private val zoneEditText
+    get() = binding!!.zoneEditText
+
+  private val streetAddressEditText
+    get() = binding!!.streetAddressEditText
+
+  private val saveButtonFrame
+    get() = binding!!.saveButtonFrame
+
+  private val consentSwitch
+    get() = binding!!.consentSwitch
+
+  private val dateOfBirthAndAgeSeparator
+    get() = binding!!.dateOfBirthAndAgeSeparator
+
+  private val genderErrorTextView
+    get() = binding!!.genderErrorTextView
+
+  private val formScrollView
+    get() = binding!!.formScrollView
+
+  private val patientEntryRoot
+    get() = binding!!.patientEntryRoot
+
+  private val identifierContainer
+    get() = binding!!.identifierContainer
+
+  private val saveButton
+    get() = binding!!.saveButton
+
   // FIXME This is temporally coupled to `scrollToFirstFieldWithError()`.
   private val allTextInputFields: List<EditText> by unsafeLazy {
     listOf(
@@ -143,6 +253,8 @@ class PatientEntryScreen(context: Context, attrs: AttributeSet) : RelativeLayout
     if (isInEditMode) {
       return
     }
+
+    binding = ScreenManualPatientEntryBinding.bind(this)
 
     context.injector<Injector>().inject(this)
 
@@ -254,10 +366,11 @@ class PatientEntryScreen(context: Context, attrs: AttributeSet) : RelativeLayout
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 

--- a/app/src/main/java/org/simple/clinic/recentpatient/RecentPatientsScreen.kt
+++ b/app/src/main/java/org/simple/clinic/recentpatient/RecentPatientsScreen.kt
@@ -7,8 +7,8 @@ import android.widget.LinearLayout
 import androidx.recyclerview.widget.LinearLayoutManager
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.recent_patients_screen.view.*
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.RecentPatientsScreenBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.router.screen.ScreenRouter
@@ -39,6 +39,14 @@ class RecentPatientsScreen(
   @Inject
   lateinit var uiRendererFactory: AllRecentPatientsUiRenderer.Factory
 
+  private var binding: RecentPatientsScreenBinding? = null
+
+  private val toolbar
+    get() = binding!!.toolbar
+
+  private val recyclerView
+    get() = binding!!.recyclerView
+
   private val events by unsafeLazy {
     adapterEvents()
         .compose(ReportAnalyticsEvents())
@@ -65,6 +73,8 @@ class RecentPatientsScreen(
       return
     }
 
+    binding = RecentPatientsScreenBinding.bind(this)
+
     context.injector<Injector>().inject(this)
 
     setupScreen()
@@ -77,6 +87,7 @@ class RecentPatientsScreen(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/recentpatientsview/RecentPatientsView.kt
+++ b/app/src/main/java/org/simple/clinic/recentpatientsview/RecentPatientsView.kt
@@ -3,12 +3,13 @@ package org.simple.clinic.recentpatientsview
 import android.content.Context
 import android.os.Parcelable
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.widget.FrameLayout
 import androidx.recyclerview.widget.LinearLayoutManager
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.recent_patients.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.RecentPatientsBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.patient.PatientConfig
@@ -45,6 +46,14 @@ class RecentPatientsView(
   @Inject
   lateinit var config: PatientConfig
 
+  private var binding: RecentPatientsBinding? = null
+
+  private val recentRecyclerView
+    get() = binding!!.recentRecyclerView
+
+  private val noRecentPatientsTextView
+    get() = binding!!.noRecentPatientsTextView
+
   private val recentAdapter = ItemAdapter(RecentPatientItemTypeDiffCallback())
 
   private val events by unsafeLazy {
@@ -66,12 +75,18 @@ class RecentPatientsView(
     )
   }
 
+  init {
+    val layoutInflater = LayoutInflater.from(context)
+    binding = RecentPatientsBinding.inflate(layoutInflater, this)
+  }
+
   override fun onFinishInflate() {
     super.onFinishInflate()
+    if (isInEditMode) {
+      return
+    }
 
     context.injector<Injector>().inject(this)
-
-    inflate(context, R.layout.recent_patients, this)
 
     recentRecyclerView.apply {
       layoutManager = LinearLayoutManager(context)
@@ -87,10 +102,11 @@ class RecentPatientsView(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 

--- a/app/src/main/java/org/simple/clinic/registration/confirmfacility/ConfirmFacilitySheet.kt
+++ b/app/src/main/java/org/simple/clinic/registration/confirmfacility/ConfirmFacilitySheet.kt
@@ -4,8 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import kotlinx.android.synthetic.main.sheet_registration_confirm_facility.*
-import org.simple.clinic.R
+import org.simple.clinic.databinding.SheetRegistrationConfirmFacilityBinding
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.widgets.BottomSheetActivity
 import java.util.UUID
@@ -40,9 +39,22 @@ class ConfirmFacilitySheet : BottomSheetActivity() {
     intent.getSerializableExtra(EXTRA_FACILITY_UUID) as UUID
   }
 
+  private lateinit var binding: SheetRegistrationConfirmFacilityBinding
+
+  private val facilityNameTextView
+    get() = binding.facilityNameTextView
+
+  private val yesButton
+    get() = binding.yesButton
+
+  private val cancelButton
+    get() = binding.cancelButton
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContentView(R.layout.sheet_registration_confirm_facility)
+
+    binding = SheetRegistrationConfirmFacilityBinding.inflate(layoutInflater)
+    setContentView(binding.root)
 
     facilityNameTextView.text = facilityName
 

--- a/app/src/main/java/org/simple/clinic/scanid/ScanBpPassportActivity.kt
+++ b/app/src/main/java/org/simple/clinic/scanid/ScanBpPassportActivity.kt
@@ -6,9 +6,8 @@ import android.content.res.Configuration
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
-import kotlinx.android.synthetic.main.screen_scan_simple.*
 import org.simple.clinic.ClinicApp
-import org.simple.clinic.R
+import org.simple.clinic.databinding.ScreenScanSimpleBinding
 import org.simple.clinic.di.InjectorProviderContextWrapper
 import org.simple.clinic.feature.Features
 import org.simple.clinic.util.withLocale
@@ -16,7 +15,7 @@ import org.simple.clinic.util.wrap
 import java.util.Locale
 import javax.inject.Inject
 
-class ScanBpPassportActivity: AppCompatActivity(), ScanSimpleIdScreen.ScanResultsReceiver {
+class ScanBpPassportActivity : AppCompatActivity(), ScanSimpleIdScreen.ScanResultsReceiver {
 
   companion object {
     private const val SCAN_RESULT = "org.simple.clinic.scanid.ScanBpPassportActivity.SCAN_RESULT"
@@ -34,14 +33,21 @@ class ScanBpPassportActivity: AppCompatActivity(), ScanSimpleIdScreen.ScanResult
   lateinit var locale: Locale
 
   @Inject
-  lateinit var component: ScanBpPassportActivityComponent
+  lateinit var features: Features
 
   @Inject
-  lateinit var features: Features
+  lateinit var component: ScanBpPassportActivityComponent
+
+  private lateinit var binding: ScreenScanSimpleBinding
+
+  private val scanBpPassportView
+    get() = binding.scanBpPassportView
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContentView(R.layout.screen_scan_simple)
+
+    binding = ScreenScanSimpleBinding.inflate(layoutInflater)
+    setContentView(binding.root)
     scanBpPassportView.scanResultsReceiver = this
   }
 

--- a/app/src/main/java/org/simple/clinic/scanid/ScanSimpleIdScreen.kt
+++ b/app/src/main/java/org/simple/clinic/scanid/ScanSimpleIdScreen.kt
@@ -14,9 +14,9 @@ import com.jakewharton.rxbinding3.widget.editorActionEvents
 import com.jakewharton.rxbinding3.widget.textChangeEvents
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_scan_simple.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenScanSimpleBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.feature.Features
 import org.simple.clinic.mobius.MobiusDelegate
@@ -44,6 +44,20 @@ class ScanSimpleIdScreen(context: Context, attrs: AttributeSet) : ConstraintLayo
 
   @Inject
   lateinit var activity: AppCompatActivity
+
+  private var binding: ScreenScanSimpleBinding? = null
+
+  private val toolBar
+    get() = binding!!.toolBar
+
+  private val qrCodeScannerViewContainer
+    get() = binding!!.qrCodeScannerViewContainer
+
+  private val shortCodeText
+    get() = binding!!.shortCodeText
+
+  private val shortCodeErrorText
+    get() = binding!!.shortCodeErrorText
 
   private val keyboardVisibilityDetector = KeyboardVisibilityDetector()
 
@@ -73,10 +87,11 @@ class ScanSimpleIdScreen(context: Context, attrs: AttributeSet) : ConstraintLayo
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 
@@ -89,6 +104,9 @@ class ScanSimpleIdScreen(context: Context, attrs: AttributeSet) : ConstraintLayo
     if (isInEditMode) {
       return
     }
+
+    binding = ScreenScanSimpleBinding.bind(this)
+
     context.injector<Injector>().inject(this)
 
     // It is possible that going back via the app bar from future screens will come back to this

--- a/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheet.kt
+++ b/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheet.kt
@@ -14,10 +14,10 @@ import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
-import kotlinx.android.synthetic.main.sheet_schedule_appointment.*
 import org.simple.clinic.ClinicApp
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.SheetScheduleAppointmentBinding
 import org.simple.clinic.di.InjectorProviderContextWrapper
 import org.simple.clinic.feature.Features
 import org.simple.clinic.mobius.DeferredEventSource
@@ -87,6 +87,37 @@ class ScheduleAppointmentSheet : BottomSheetActivity(), ScheduleAppointmentUi, S
   lateinit var features: Features
 
   private lateinit var component: ScheduleAppointmentSheetComponent
+  private lateinit var binding: SheetScheduleAppointmentBinding
+
+  private val changeFacilityButton
+    get() = binding.changeFacilityButton
+
+  private val incrementDateButton
+    get() = binding.incrementDateButton
+
+  private val decrementDateButton
+    get() = binding.decrementDateButton
+
+  private val notNowButton
+    get() = binding.notNowButton
+
+  private val doneButton
+    get() = binding.doneButton
+
+  private val nextButton
+    get() = binding.nextButton
+
+  private val changeAppointmentDate
+    get() = binding.changeAppointmentDate
+
+  private val currentAppointmentDate
+    get() = binding.currentAppointmentDate
+
+  private val currentDateTextView
+    get() = binding.currentDateTextView
+
+  private val selectedFacilityName
+    get() = binding.selectedFacilityName
 
   private val onDestroys = PublishSubject.create<ScreenDestroyed>()
   private val calendarDateSelectedEvents: Subject<AppointmentCalendarDateSelected> = PublishSubject.create()
@@ -134,7 +165,10 @@ class ScheduleAppointmentSheet : BottomSheetActivity(), ScheduleAppointmentUi, S
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContentView(R.layout.sheet_schedule_appointment)
+
+    binding = SheetScheduleAppointmentBinding.inflate(layoutInflater)
+    setContentView(binding.root)
+
     delegate.onRestoreInstanceState(savedInstanceState)
 
     changeFacilityButton.setOnClickListener {

--- a/app/src/main/java/org/simple/clinic/scheduleappointment/facilityselection/FacilitySelectionActivity.kt
+++ b/app/src/main/java/org/simple/clinic/scheduleappointment/facilityselection/FacilitySelectionActivity.kt
@@ -9,10 +9,9 @@ import androidx.appcompat.app.AppCompatActivity
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.activity_select_facility.*
 import org.simple.clinic.ClinicApp
-import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ActivitySelectFacilityBinding
 import org.simple.clinic.di.InjectorProviderContextWrapper
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.feature.Features
@@ -38,10 +37,15 @@ class FacilitySelectionActivity : AppCompatActivity(), FacilitySelectionUi, Faci
   lateinit var locale: Locale
 
   @Inject
-  lateinit var effectHandlerFactory: FacilitySelectionEffectHandler.Factory
+  lateinit var features: Features
 
   @Inject
-  lateinit var features: Features
+  lateinit var effectHandlerFactory: FacilitySelectionEffectHandler.Factory
+
+  private lateinit var binding: ActivitySelectFacilityBinding
+
+  private val facilityPickerView
+    get() = binding.facilityPickerView
 
   private val events by unsafeLazy {
     facilityClicks()
@@ -65,7 +69,9 @@ class FacilitySelectionActivity : AppCompatActivity(), FacilitySelectionUi, Faci
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContentView(R.layout.activity_select_facility)
+
+    binding = ActivitySelectFacilityBinding.inflate(layoutInflater)
+    setContentView(binding.root)
 
     facilityPickerView.backClicked = this@FacilitySelectionActivity::finish
 

--- a/app/src/main/java/org/simple/clinic/search/PatientSearchScreen.kt
+++ b/app/src/main/java/org/simple/clinic/search/PatientSearchScreen.kt
@@ -13,12 +13,12 @@ import com.jakewharton.rxbinding3.widget.editorActionEvents
 import com.jakewharton.rxbinding3.widget.textChanges
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_patient_search.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.allpatientsinfacility.AllPatientsInFacilityListScrolled
 import org.simple.clinic.allpatientsinfacility.AllPatientsInFacilitySearchResultClicked
 import org.simple.clinic.allpatientsinfacility.AllPatientsInFacilityView
+import org.simple.clinic.databinding.ScreenPatientSearchBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.patient.PatientSearchCriteria
@@ -53,8 +53,22 @@ class PatientSearchScreen(
   @Inject
   lateinit var effectHandlerFactory: PatientSearchEffectHandler.Factory
 
-  private val allPatientsInFacility by unsafeLazy {
-    allPatientsInFacilityView as AllPatientsInFacilityView
+  private var binding: ScreenPatientSearchBinding? = null
+
+  private val allPatientsInFacilityView
+    get() = binding!!.allPatientsInFacilityView.rootLayout
+
+  private val searchQueryTextInputLayout
+    get() = binding!!.searchQueryTextInputLayout
+
+  private val searchQueryEditText
+    get() = binding!!.searchQueryEditText
+
+  private val searchButtonFrame
+    get() = binding!!.searchButtonFrame
+
+  private val allPatientsInFacility: AllPatientsInFacilityView by unsafeLazy {
+    allPatientsInFacilityView
   }
 
   private val screenKey by unsafeLazy {
@@ -89,6 +103,9 @@ class PatientSearchScreen(
     if (isInEditMode) {
       return
     }
+
+    binding = ScreenPatientSearchBinding.bind(this)
+
     context.injector<Injector>().inject(this)
 
     searchQueryTextInputLayout.setStartIconOnClickListener {
@@ -107,6 +124,7 @@ class PatientSearchScreen(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/search/results/PatientSearchResultsScreen.kt
+++ b/app/src/main/java/org/simple/clinic/search/results/PatientSearchResultsScreen.kt
@@ -9,8 +9,8 @@ import androidx.appcompat.app.AppCompatActivity
 import com.jakewharton.rxbinding3.view.detaches
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_patient_search_results.view.*
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenPatientSearchResultsBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.facility.alertchange.AlertFacilityChangeSheet
@@ -52,6 +52,14 @@ class PatientSearchResultsScreen(
   @Inject
   lateinit var effectHandlerInjectionFactory: PatientSearchResultsEffectHandler.InjectionFactory
 
+  private var binding: ScreenPatientSearchResultsBinding? = null
+
+  private val searchResultsView
+    get() = binding!!.searchResultsView
+
+  private val toolbar
+    get() = binding!!.toolbar
+
   private val screenKey by unsafeLazy { screenRouter.key<PatientSearchResultsScreenKey>(this) }
 
   private val events by unsafeLazy {
@@ -84,6 +92,8 @@ class PatientSearchResultsScreen(
       return
     }
 
+    binding = ScreenPatientSearchResultsBinding.bind(this)
+
     context.injector<Injector>().inject(this)
     setupScreen()
 
@@ -99,6 +109,7 @@ class PatientSearchResultsScreen(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryCardView.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryCardView.kt
@@ -16,9 +16,9 @@ import com.jakewharton.rxbinding3.widget.editorActions
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.pin_entry_card.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.PinEntryCardBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.security.di.Method
@@ -56,8 +56,33 @@ class PinEntryCardView(context: Context, attrs: AttributeSet) : CardView(context
 
   private val method: Method
 
+  private var binding: PinEntryCardBinding? = null
+
+  private val pinEditText
+    get() = binding!!.pinEditText
+
+  private val errorTextView
+    get() = binding!!.errorTextView
+
+  private val contentContainer
+    get() = binding!!.contentContainer
+
+  private val progressView
+    get() = binding!!.progressView
+
+  private val pinAndLockViewFlipper
+    get() = binding!!.pinAndLockViewFlipper
+
+  private val timeRemainingTillUnlockTextView
+    get() = binding!!.timeRemainingTillUnlockTextView
+
+  private val forgotPinButton
+    get() = binding!!.forgotPinButton
+
   init {
-    LayoutInflater.from(context).inflate(R.layout.pin_entry_card, this, true)
+    val layoutInflater = LayoutInflater.from(context)
+    binding = PinEntryCardBinding.inflate(layoutInflater, this)
+
     setPinEntryMode(PinEntryUi.Mode.PinEntry)
     setForgotButtonVisible(true)
 
@@ -120,10 +145,11 @@ class PinEntryCardView(context: Context, attrs: AttributeSet) : CardView(context
   override fun onDetachedFromWindow() {
     pinEntryLockedCountdown?.cancel()
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryCardView.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryCardView.kt
@@ -58,7 +58,7 @@ class PinEntryCardView(context: Context, attrs: AttributeSet) : CardView(context
 
   private var binding: PinEntryCardBinding? = null
 
-  private val pinEditText
+  val pinEditText
     get() = binding!!.pinEditText
 
   private val errorTextView
@@ -76,7 +76,7 @@ class PinEntryCardView(context: Context, attrs: AttributeSet) : CardView(context
   private val timeRemainingTillUnlockTextView
     get() = binding!!.timeRemainingTillUnlockTextView
 
-  private val forgotPinButton
+  val forgotPinButton
     get() = binding!!.forgotPinButton
 
   init {

--- a/app/src/main/res/layout/view_allpatientsinfacility.xml
+++ b/app/src/main/res/layout/view_allpatientsinfacility.xml
@@ -2,6 +2,7 @@
 <org.simple.clinic.allpatientsinfacility.AllPatientsInFacilityView xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/rootLayout"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:animateLayoutChanges="true">


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/1828/migrate-app-to-use-view-binding-instead-of-kotlin-synthetic-view-accessors﻿
