### PR TITLE
Bump JDK version in CI to 11

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: set up JDK 1.8
+      - name: set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: QA Lint
         run: ./gradlew lintQaDebug
@@ -27,10 +27,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: set up JDK 1.8
+      - name: set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: QA Unit Tests
         run: ./gradlew testQaDebugUnitTest
@@ -40,10 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: set up JDK 1.8
+      - name: set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Mobius Migration Tests
         run: ./gradlew :mobius-migration:test
@@ -55,10 +55,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: set up JDK 1.8
+      - name: set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Turn on capturing of flaky tests
         run: cat app/src/androidTest/resources/quarantine_ci.properties > app/src/androidTest/resources/quarantine.properties
@@ -77,10 +77,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: set up JDK 1.8
+      - name: set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Build ${{ matrix.buildType }} Release bundle
         run: |

--- a/.github/workflows/code_formatting_checks.yml
+++ b/.github/workflows/code_formatting_checks.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Fix code formatting issues
         run: ./gradlew spotlessApply

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Internal
 - [In Progress: 11 Nov 2020] Migrate app screens to use ViewBinding
 - Bump appcompat -> 1.2.0
+- Bump CI JDK version to 11
 
 ### Changes
 - Disable the change language feature on devices running Lollipop (API level 21, 22)


### PR DESCRIPTION
The next version of the Android Development toolchain is going to drop support for JDK 1.8. Making this change now in order to be ready for the release in advance.

https://android-developers.googleblog.com/2020/12/announcing-android-gradle-plugin.html