### PR TITLE
Fix crash on edit medicines screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 ### Internal
 - Revert view binding migration for `RecentPatientsView`
 
+### Fixes
+- Fix a crash that could happen when closing the edit medicines screen
+
 ## On Demo
 ### Internal
 - Bump appcompat -> 1.2.0

--- a/app/src/main/java/org/simple/clinic/drugs/selection/EditMedicinesScreen.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/EditMedicinesScreen.kt
@@ -181,11 +181,13 @@ class EditMedicinesScreen(context: Context, attrs: AttributeSet) : LinearLayout(
 
     // Scroll to end to show newly added prescriptions.
     if (hasNewItems) {
-      recyclerView.postDelayed({
-        if (binding != null) {
-          recyclerView.smoothScrollToPosition(recyclerView.adapter!!.itemCount - 1)
-        }
-      }, 300)
+      recyclerView.postDelayed(::scrollListToLastPosition, 300)
+    }
+  }
+
+  private fun scrollListToLastPosition() {
+    if (binding != null) {
+      recyclerView.smoothScrollToPosition(recyclerView.adapter!!.itemCount - 1)
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/drugs/selection/EditMedicinesScreen.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/EditMedicinesScreen.kt
@@ -35,10 +35,8 @@ import org.simple.clinic.router.screen.ScreenRouter
 import org.simple.clinic.summary.GroupieItemWithUiEvents
 import org.simple.clinic.util.UserClock
 import org.simple.clinic.util.UtcClock
-import org.simple.clinic.util.toLocalDateAtZone
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.widgets.UiEvent
-import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 import javax.inject.Inject
@@ -183,9 +181,11 @@ class EditMedicinesScreen(context: Context, attrs: AttributeSet) : LinearLayout(
 
     // Scroll to end to show newly added prescriptions.
     if (hasNewItems) {
-      recyclerView.postDelayed(
-          { recyclerView.smoothScrollToPosition(recyclerView.adapter!!.itemCount - 1) },
-          300)
+      recyclerView.postDelayed({
+        if (binding != null) {
+          recyclerView.smoothScrollToPosition(recyclerView.adapter!!.itemCount - 1)
+        }
+      }, 300)
     }
   }
 


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/2047/dequeue-runnable-when-editmedicinesscreen-is-detached

# Steps to verify
- On `master`, change the delay to execute the recycler view scroll operation in `EditMedicinesScreen#populateDrugsList` to a larger value.
- Run the app and add a custom drug. Once the drug is added and before the earlier specified duration completes, press back and exit the `EditMedicinesScreen`.
- Once the delay is complete, the app will crash.
- Repeat the same task on the current branch 