### PR TITLE
Migrate app to use View Binding instead of Kotlin synthetic view accessors - 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add BP Passport sheet
 
 ### Internal
-- [In Progress: 15 Dec 2020] Migrate app to use ViewBinding
+- [In Progress: 18 Dec 2020] Migrate app to use ViewBinding
 - Add PR comment commands for running instrumented tests and rebasing PR
 - Add breadcrumbs for different stages in search operations
 - Cleanup `ImageSrcDetector`

--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityView.kt
@@ -5,14 +5,14 @@ import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import androidx.appcompat.app.AppCompatActivity
 import androidx.cardview.widget.CardView
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.patientsummary_assigned_facility_content.view.*
-import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.PatientsummaryAssignedFacilityContentBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.router.screen.ActivityResult
@@ -31,8 +31,17 @@ class AssignedFacilityView(
     attrs: AttributeSet
 ) : CardView(context, attrs), AssignedFacilityUi, UiActions, PatientSummaryChildView {
 
+  private var binding: PatientsummaryAssignedFacilityContentBinding? = null
+
+  private val assignedFacilityTextView
+    get() = binding!!.assignedFacilityTextView
+
+  private val changeAssignedFacilityButton
+    get() = binding!!.changeAssignedFacilityButton
+
   init {
-    inflate(context, R.layout.patientsummary_assigned_facility_content, this)
+    val layoutInflater = LayoutInflater.from(context)
+    binding = PatientsummaryAssignedFacilityContentBinding.inflate(layoutInflater, this, true)
   }
 
   @Inject
@@ -89,10 +98,11 @@ class AssignedFacilityView(
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
+    binding = null
     delegate.stop()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/bloodpressures/view/BloodPressureSummaryView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/bloodpressures/view/BloodPressureSummaryView.kt
@@ -14,12 +14,12 @@ import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.patientsummary_bpsummary_content.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.bp.BloodPressureMeasurement
 import org.simple.clinic.bp.entry.BloodPressureEntrySheet
 import org.simple.clinic.bp.history.BloodPressureHistoryScreenKey
+import org.simple.clinic.databinding.PatientsummaryBpsummaryContentBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.facility.alertchange.AlertFacilityChangeSheet
@@ -67,6 +67,20 @@ class BloodPressureSummaryView(
     context: Context,
     attrs: AttributeSet
 ) : CardView(context, attrs), BloodPressureSummaryViewUi, BloodPressureSummaryViewUiActions, PatientSummaryChildView {
+
+  private var binding: PatientsummaryBpsummaryContentBinding? = null
+
+  private val newBPItemContainer
+    get() = binding!!.newBPItemContainer
+
+  private val placeHolderMessageTextView
+    get() = binding!!.placeHolderMessageTextView
+
+  private val seeAll
+    get() = binding!!.seeAll
+
+  private val addNewBP
+    get() = binding!!.addNewBP
 
   @Inject
   lateinit var activity: AppCompatActivity
@@ -138,7 +152,8 @@ class BloodPressureSummaryView(
   var bpRecorded: BpRecorded? = null
 
   init {
-    inflate(context, R.layout.patientsummary_bpsummary_content, this)
+    val layoutInflater = LayoutInflater.from(context)
+    binding = PatientsummaryBpsummaryContentBinding.inflate(layoutInflater, this, true)
   }
 
   override fun onFinishInflate() {
@@ -163,10 +178,11 @@ class BloodPressureSummaryView(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/bloodsugar/view/BloodSugarSummaryView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/bloodsugar/view/BloodSugarSummaryView.kt
@@ -16,7 +16,6 @@ import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.patientsummary_bloodsugarsummary_content.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.bloodsugar.BloodSugarMeasurement
@@ -26,6 +25,7 @@ import org.simple.clinic.bloodsugar.Unknown
 import org.simple.clinic.bloodsugar.entry.BloodSugarEntrySheet
 import org.simple.clinic.bloodsugar.history.BloodSugarHistoryScreenKey
 import org.simple.clinic.bloodsugar.selection.type.BloodSugarTypePickerSheet
+import org.simple.clinic.databinding.PatientsummaryBloodsugarsummaryContentBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.facility.alertchange.AlertFacilityChangeSheet
@@ -74,6 +74,20 @@ class BloodSugarSummaryView(
     context: Context,
     attributes: AttributeSet
 ) : CardView(context, attributes), BloodSugarSummaryViewUi, UiActions, PatientSummaryChildView {
+
+  private var binding: PatientsummaryBloodsugarsummaryContentBinding? = null
+
+  private val addNewBloodSugar
+    get() = binding!!.addNewBloodSugar
+
+  private val bloodSugarSeeAll
+    get() = binding!!.bloodSugarSeeAll
+
+  private val bloodSugarItemContainer
+    get() = binding!!.bloodSugarItemContainer
+
+  private val noBloodSugarTextView
+    get() = binding!!.noBloodSugarTextView
 
   @Inject
   lateinit var activity: AppCompatActivity
@@ -152,7 +166,8 @@ class BloodSugarSummaryView(
   }
 
   init {
-    LayoutInflater.from(context).inflate(R.layout.patientsummary_bloodsugarsummary_content, this, true)
+    val layoutInflater = LayoutInflater.from(context)
+    binding = PatientsummaryBloodsugarsummaryContentBinding.inflate(layoutInflater, this, true)
   }
 
   override fun onFinishInflate() {
@@ -176,10 +191,11 @@ class BloodSugarSummaryView(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/linkId/LinkIdWithPatientView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/linkId/LinkIdWithPatientView.kt
@@ -4,16 +4,16 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Parcelable
 import android.util.AttributeSet
-import android.view.View
+import android.view.LayoutInflater
 import android.widget.FrameLayout
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
-import kotlinx.android.synthetic.main.link_id_with_patient_view.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.LinkIdWithPatientViewBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.main.TheActivity
 import org.simple.clinic.mobius.MobiusDelegate
@@ -67,6 +67,23 @@ class LinkIdWithPatientView(
     attributeSet: AttributeSet
 ) : FrameLayout(context, attributeSet), LinkIdWithPatientViewUi, LinkIdWithPatientUiActions {
 
+  private var binding: LinkIdWithPatientViewBinding? = null
+
+  private val backgroundView
+    get() = binding!!.backgroundView
+
+  private val addButton
+    get() = binding!!.addButton
+
+  private val cancelButton
+    get() = binding!!.cancelButton
+
+  private val idTextView
+    get() = binding!!.idTextView
+
+  private val contentContainer
+    get() = binding!!.contentContainer
+
   @Inject
   lateinit var effectHandlerFactory: LinkIdWithPatientEffectHandler.Factory
 
@@ -103,10 +120,11 @@ class LinkIdWithPatientView(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 
@@ -117,7 +135,9 @@ class LinkIdWithPatientView(
   @SuppressLint("CheckResult")
   override fun onFinishInflate() {
     super.onFinishInflate()
-    View.inflate(context, R.layout.link_id_with_patient_view, this)
+    val layoutInflater = LayoutInflater.from(context)
+    binding = LinkIdWithPatientViewBinding.inflate(layoutInflater, this)
+
     if (isInEditMode) {
       return
     }

--- a/app/src/main/java/org/simple/clinic/summary/medicalhistory/MedicalHistorySummaryView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/medicalhistory/MedicalHistorySummaryView.kt
@@ -9,9 +9,9 @@ import androidx.appcompat.app.AppCompatActivity
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.medicalhistory_summary_view.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.MedicalhistorySummaryViewBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.medicalhistory.Answer
 import org.simple.clinic.medicalhistory.MedicalHistory
@@ -37,6 +37,29 @@ class MedicalHistorySummaryView(
     attributeSet: AttributeSet
 ) : FrameLayout(context, attributeSet), MedicalHistorySummaryUi, PatientSummaryChildView {
 
+  private var binding: MedicalhistorySummaryViewBinding? = null
+
+  private val heartAttackQuestionView
+    get() = binding!!.heartAttackQuestionView
+
+  private val strokeQuestionView
+    get() = binding!!.strokeQuestionView
+
+  private val kidneyDiseaseQuestionView
+    get() = binding!!.kidneyDiseaseQuestionView
+
+  private val diabetesQuestionView
+    get() = binding!!.diabetesQuestionView
+
+  private val hypertensionDiagnosisView
+    get() = binding!!.hypertensionDiagnosisView
+
+  private val diabetesDiagnosisView
+    get() = binding!!.diabetesDiagnosisView
+
+  private val diagnosisViewContainer
+    get() = binding!!.diagnosisViewContainer
+
   private val internalEvents = PublishSubject.create<MedicalHistorySummaryEvent>()
 
   @Inject
@@ -49,7 +72,8 @@ class MedicalHistorySummaryView(
   lateinit var effectHandler: MedicalHistorySummaryEffectHandler
 
   init {
-    LayoutInflater.from(context).inflate(R.layout.medicalhistory_summary_view, this, true)
+    val layoutInflater = LayoutInflater.from(context)
+    binding = MedicalhistorySummaryViewBinding.inflate(layoutInflater, this, true)
   }
 
   private var modelUpdateCallback: PatientSummaryModelUpdateCallback? = null
@@ -97,10 +121,11 @@ class MedicalHistorySummaryView(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/prescribeddrugs/DrugSummaryView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/prescribeddrugs/DrugSummaryView.kt
@@ -11,9 +11,9 @@ import com.jakewharton.rxbinding3.view.detaches
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.drugs_summary_view.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.DrugsSummaryViewBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.drugs.PrescribedDrug
 import org.simple.clinic.drugs.selection.PrescribedDrugsScreenKey
@@ -45,6 +45,17 @@ class DrugSummaryView(
     context: Context,
     attributeSet: AttributeSet
 ) : CardView(context, attributeSet), DrugSummaryUi, DrugSummaryUiActions, PatientSummaryChildView {
+
+  private var binding: DrugsSummaryViewBinding? = null
+
+  private val updateButton
+    get() = binding!!.updateButton
+
+  private val drugsSummaryContainer
+    get() = binding!!.drugsSummaryContainer
+
+  private val emptyMedicinesTextView
+    get() = binding!!.emptyMedicinesTextView
 
   @Inject
   @Named("full_date")
@@ -95,7 +106,8 @@ class DrugSummaryView(
   }
 
   init {
-    inflate(context, R.layout.drugs_summary_view, this)
+    val layoutInflater = LayoutInflater.from(context)
+    binding = DrugsSummaryViewBinding.inflate(layoutInflater, this, true)
   }
 
   override fun onAttachedToWindow() {
@@ -105,10 +117,11 @@ class DrugSummaryView(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/1828/migrate-app-to-use-view-binding-instead-of-kotlin-synthetic-view-accessors