### PR TITLE
Add shell env comment to `pre-push` hook 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next release
+### Internal
+- Add shell env comment to `pre-push` hook
+
 ## On Demo
 ### Features
 - Add BP Passport sheet

--- a/quality/pre-push
+++ b/quality/pre-push
@@ -1,1 +1,2 @@
+#!/bin/sh
 GIT_WORK_TREE=".." ./gradlew lintQaDebug assembleQaDebugUnitTest assembleQaDebugAndroidTest


### PR DESCRIPTION
Without the shell env in the `pre-push` hook, Windows Git clients cannot identify the `pre-push` hook and fails to push the code.