### PR TITLE
Add a compatibility layer that lets us use the older screens in the new navigation framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [In Progress: 23 Dec 2020] Migrate app to use ViewBinding
 - Track code style and lint rules for project in VCS
 - Add Instant search query
+- Add `ScreenFragmentCompat` to support using the older view-based screens in the v2 navigation framework
 
 ### Changes
 - Change home illustration for India

--- a/app/src/main/java/org/simple/clinic/navigation/v2/ScreenKey.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/ScreenKey.kt
@@ -4,10 +4,14 @@ import android.os.Bundle
 import android.os.Parcelable
 import androidx.fragment.app.Fragment
 
-abstract class ScreenKey(): Parcelable {
+abstract class ScreenKey: Parcelable {
 
   companion object {
     private const val ARGS_KEY = "org.simple.clinic.navigation.v2.ScreenKey.ARGS_KEY"
+
+    fun <T: ScreenKey> key(fragment: Fragment): T {
+      return fragment.requireArguments().getParcelable(ARGS_KEY)!!
+    }
   }
 
   open val fragmentTag: String

--- a/app/src/main/java/org/simple/clinic/navigation/v2/compat/ScreenFragmentCompat.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/compat/ScreenFragmentCompat.kt
@@ -5,9 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import org.simple.clinic.navigation.v2.HandlesBack
 import org.simple.clinic.navigation.v2.ScreenKey
 
-class ScreenFragmentCompat : Fragment() {
+class ScreenFragmentCompat: Fragment(), HandlesBack {
 
   companion object {
     fun create() = ScreenFragmentCompat()
@@ -23,5 +24,11 @@ class ScreenFragmentCompat : Fragment() {
       savedInstanceState: Bundle?
   ): View {
     return inflater.inflate(key.layoutRes(), container, false)
+  }
+
+  override fun onBackPressed(): Boolean {
+    val screen = requireView()
+
+    return (screen as? HandlesBack)?.onBackPressed() ?: false
   }
 }

--- a/app/src/main/java/org/simple/clinic/navigation/v2/compat/ScreenFragmentCompat.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/compat/ScreenFragmentCompat.kt
@@ -1,0 +1,27 @@
+package org.simple.clinic.navigation.v2.compat
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import org.simple.clinic.navigation.v2.ScreenKey
+
+class ScreenFragmentCompat : Fragment() {
+
+  companion object {
+    fun create() = ScreenFragmentCompat()
+  }
+
+  private val key by lazy(LazyThreadSafetyMode.NONE) {
+    ScreenKey.key<ScreenKeyCompat>(this).key
+  }
+
+  override fun onCreateView(
+      inflater: LayoutInflater,
+      container: ViewGroup?,
+      savedInstanceState: Bundle?
+  ): View {
+    return inflater.inflate(key.layoutRes(), container, false)
+  }
+}

--- a/app/src/main/java/org/simple/clinic/navigation/v2/compat/ScreenKeyCompat.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/compat/ScreenKeyCompat.kt
@@ -1,0 +1,18 @@
+package org.simple.clinic.navigation.v2.compat
+
+import kotlinx.android.parcel.Parcelize
+import org.simple.clinic.navigation.v2.ScreenKey
+import org.simple.clinic.router.screen.FullScreenKey
+
+@Parcelize
+data class ScreenKeyCompat(val key: FullScreenKey) : ScreenKey() {
+
+  override val fragmentTag: String
+    get() = key.javaClass.name
+
+  override fun instantiateFragment() = ScreenFragmentCompat.create()
+}
+
+fun FullScreenKey.wrap(): ScreenKey {
+  return ScreenKeyCompat(this)
+}


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/2131/add-support-for-the-new-navigation-framework

This is a follow up PR to #2241.