### PR TITLE
Migrate app to use View Binding instead of Kotlin synthetic view accessors - 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add shell env comment to `pre-push` hook
 - Add the Router for the new navigation framework 
 - [In Progress: 21 Dec 2020] Instant search in Faster registration
-- [In Progress: 22 Dec 2020] Migrate app to use ViewBinding
+- [In Progress: 23 Dec 2020] Migrate app to use ViewBinding
 
 ### Changes
 - Change home illustration for India

--- a/app/src/main/java/org/simple/clinic/summary/teleconsultation/contactdoctor/ContactDoctorSheet.kt
+++ b/app/src/main/java/org/simple/clinic/summary/teleconsultation/contactdoctor/ContactDoctorSheet.kt
@@ -7,11 +7,11 @@ import android.os.Bundle
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.sheet_contact_doctor.*
 import org.simple.clinic.ClinicApp
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.databinding.ListContactDoctorBinding
+import org.simple.clinic.databinding.SheetContactDoctorBinding
 import org.simple.clinic.di.InjectorProviderContextWrapper
 import org.simple.clinic.feature.Features
 import org.simple.clinic.mobius.MobiusDelegate
@@ -24,9 +24,9 @@ import org.simple.clinic.util.messagesender.WhatsAppMessageSender
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.util.withLocale
 import org.simple.clinic.util.wrap
-import org.simple.clinic.widgets.ItemAdapter
 import org.simple.clinic.widgets.BottomSheetActivity
 import org.simple.clinic.widgets.DividerItemDecorator
+import org.simple.clinic.widgets.ItemAdapter
 import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.dp
 import java.util.Locale
@@ -34,6 +34,11 @@ import java.util.UUID
 import javax.inject.Inject
 
 class ContactDoctorSheet : BottomSheetActivity(), ContactDoctorUi, ContactDoctorUiActions {
+
+  private lateinit var binding: SheetContactDoctorBinding
+
+  private val doctorsRecyclerView
+    get() = binding.doctorsRecyclerView
 
   companion object {
     private const val EXTRA_PATIENT_UUID = "patientUuid"
@@ -117,7 +122,8 @@ class ContactDoctorSheet : BottomSheetActivity(), ContactDoctorUi, ContactDoctor
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContentView(R.layout.sheet_contact_doctor)
+    binding = SheetContactDoctorBinding.inflate(layoutInflater)
+    setContentView(binding.root)
     delegate.onRestoreInstanceState(savedInstanceState)
 
     doctorsRecyclerView.adapter = itemAdapter

--- a/app/src/main/java/org/simple/clinic/summary/teleconsultation/status/TeleconsultStatusSheet.kt
+++ b/app/src/main/java/org/simple/clinic/summary/teleconsultation/status/TeleconsultStatusSheet.kt
@@ -11,10 +11,10 @@ import com.jakewharton.rxbinding3.widget.checkedChanges
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.sheet_teleconsult_status.*
 import org.simple.clinic.ClinicApp
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.SheetTeleconsultStatusBinding
 import org.simple.clinic.di.InjectorProviderContextWrapper
 import org.simple.clinic.feature.Features
 import org.simple.clinic.mobius.MobiusDelegate
@@ -31,6 +31,14 @@ import java.util.UUID
 import javax.inject.Inject
 
 class TeleconsultStatusSheet : BottomSheetActivity(), TeleconsultStatusUi, TeleconsultStatusUiAction {
+
+  private lateinit var binding: SheetTeleconsultStatusBinding
+
+  private val teleconsultStatusDoneButton
+    get() = binding.teleconsultStatusDoneButton
+
+  private val teleconsultStatusRadioGroup
+    get() = binding.teleconsultStatusRadioGroup
 
   companion object {
     private const val EXTRA_TELECONSULT_RECORD_ID = "teleconsultRecordId"
@@ -101,7 +109,8 @@ class TeleconsultStatusSheet : BottomSheetActivity(), TeleconsultStatusUi, Telec
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContentView(R.layout.sheet_teleconsult_status)
+    binding = SheetTeleconsultStatusBinding.inflate(layoutInflater)
+    setContentView(binding.root)
     delegate.onRestoreInstanceState(savedInstanceState)
   }
 

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/prescription/TeleconsultPrescriptionScreen.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/prescription/TeleconsultPrescriptionScreen.kt
@@ -8,9 +8,9 @@ import com.jakewharton.rxbinding3.appcompat.navigationClicks
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_teleconsult_prescription.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenTeleconsultPrescriptionBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.patient.DateOfBirth
@@ -29,6 +29,20 @@ class TeleconsultPrescriptionScreen constructor(
     context: Context,
     attrs: AttributeSet?
 ) : ConstraintLayout(context, attrs), TeleconsultPrescriptionUi, TeleconsultPrescriptionUiActions {
+
+  private var binding: ScreenTeleconsultPrescriptionBinding? = null
+
+  private val toolbar
+    get() = binding!!.toolbar
+
+  private val teleconsultPrescriptionDoctorInfoView
+    get() = binding!!.teleconsultPrescriptionDoctorInfoView
+
+  private val teleconsultPrescriptionMedicinesView
+    get() = binding!!.teleconsultPrescriptionMedicinesView
+
+  private val nextButton
+    get() = binding!!.nextButton
 
   @Inject
   lateinit var screenRouter: ScreenRouter
@@ -73,10 +87,11 @@ class TeleconsultPrescriptionScreen constructor(
   override fun onDetachedFromWindow() {
     hideKeyboard()
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 
@@ -87,6 +102,8 @@ class TeleconsultPrescriptionScreen constructor(
   override fun onFinishInflate() {
     super.onFinishInflate()
     if (isInEditMode) return
+
+    binding = ScreenTeleconsultPrescriptionBinding.bind(this)
     context.injector<Injector>().inject(this)
   }
 

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/shareprescription/TeleconsultSharePrescriptionScreen.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/shareprescription/TeleconsultSharePrescriptionScreen.kt
@@ -16,10 +16,10 @@ import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.screen_teleconsult_share_prescription.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.databinding.ListItemTeleconsultSharePrescriptionMedicineBinding
+import org.simple.clinic.databinding.ScreenTeleconsultSharePrescriptionBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.drugs.PrescribedDrug
 import org.simple.clinic.home.HomeScreenKey
@@ -49,6 +49,44 @@ class TeleconsultSharePrescriptionScreen constructor(
     context: Context,
     attributeSet: AttributeSet?
 ) : ConstraintLayout(context, attributeSet), TeleconsultSharePrescriptionUi, TeleconsultSharePrescriptionUiActions {
+
+  private var binding: ScreenTeleconsultSharePrescriptionBinding? = null
+
+  private val medicinesRecyclerView
+    get() = binding!!.medicinesRecyclerView
+
+  private val instructionsTextView
+    get() = binding!!.instructionsTextView
+
+  private val shareButton
+    get() = binding!!.shareButton
+
+  private val layoutSharePrescription
+    get() = binding!!.layoutSharePrescription
+
+  private val downloadButton
+    get() = binding!!.downloadButton
+
+  private val doneButton
+    get() = binding!!.doneButton
+
+  private val toolbar
+    get() = binding!!.toolbar
+
+  private val signatureImageView
+    get() = binding!!.signatureImageView
+
+  private val prescriptionDateTextView
+    get() = binding!!.prescriptionDateTextView
+
+  private val medicalRegistrationIdTextView
+    get() = binding!!.medicalRegistrationIdTextView
+
+  private val patientAddressTextView
+    get() = binding!!.patientAddressTextView
+
+  private val patientNameTextView
+    get() = binding!!.patientNameTextView
 
   @Inject
   lateinit var screenRouter: ScreenRouter
@@ -116,10 +154,11 @@ class TeleconsultSharePrescriptionScreen constructor(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 
@@ -131,6 +170,8 @@ class TeleconsultSharePrescriptionScreen constructor(
     super.onFinishInflate()
     if (isInEditMode) return
     context.injector<Injector>().inject(this)
+
+    binding = ScreenTeleconsultSharePrescriptionBinding.bind(this)
 
     showMedicalInstructions()
     medicinesRecyclerView.adapter = teleconsultSharePrescriptionMedicinesAdapter

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/success/TeleConsultSuccessScreen.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/success/TeleConsultSuccessScreen.kt
@@ -6,8 +6,8 @@ import android.util.AttributeSet
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
-import kotlinx.android.synthetic.main.screen_teleconsult_success.view.*
 import org.simple.clinic.R
+import org.simple.clinic.databinding.ScreenTeleconsultSuccessBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.home.HomeScreenKey
 import org.simple.clinic.mobius.MobiusDelegate
@@ -27,6 +27,17 @@ class TeleConsultSuccessScreen(
     context: Context,
     attributeSet: AttributeSet
 ) : ConstraintLayout(context, attributeSet), TeleConsultSuccessScreenUiActions, TeleConsultSuccessUi {
+
+  private var binding: ScreenTeleconsultSuccessBinding? = null
+
+  private val prescriptionNoButton
+    get() = binding!!.prescriptionNoButton
+
+  private val prescriptionYesButton
+    get() = binding!!.prescriptionYesButton
+
+  private val toolbar
+    get() = binding!!.toolbar
 
   @Inject
   lateinit var effectHandler: TeleConsultSuccessEffectHandler.Factory
@@ -64,6 +75,7 @@ class TeleConsultSuccessScreen(
     if (isInEditMode) {
       return
     }
+    binding = ScreenTeleconsultSuccessBinding.bind(this)
     context.injector<Injector>().inject(this)
     backClicks()
   }
@@ -89,10 +101,11 @@ class TeleConsultSuccessScreen(
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
+    binding = null
     mobiusDelegate.stop()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return mobiusDelegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/teleconsultrecord/screen/TeleconsultRecordScreen.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/teleconsultrecord/screen/TeleconsultRecordScreen.kt
@@ -9,9 +9,9 @@ import com.jakewharton.rxbinding3.appcompat.navigationClicks
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.screen_teleconsult_record.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.ScreenTeleconsultRecordBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.patient.DateOfBirth
@@ -39,6 +39,23 @@ class TeleconsultRecordScreen(
     context: Context,
     attrs: AttributeSet
 ) : ConstraintLayout(context, attrs), TeleconsultRecordUi, UiActions {
+
+  private var binding: ScreenTeleconsultRecordBinding? = null
+
+  private val toolbar
+    get() = binding!!.toolbar
+
+  private val teleconsultTypeRadioGroup
+    get() = binding!!.teleconsultTypeRadioGroup
+
+  private val patientTookMedicineCheckBox
+    get() = binding!!.patientTookMedicineCheckBox
+
+  private val doneButton
+    get() = binding!!.doneButton
+
+  private val patientConsentedCheckBox
+    get() = binding!!.patientConsentedCheckBox
 
   @Inject
   lateinit var screenRouter: ScreenRouter
@@ -94,10 +111,11 @@ class TeleconsultRecordScreen(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 
@@ -108,6 +126,8 @@ class TeleconsultRecordScreen(
   override fun onFinishInflate() {
     super.onFinishInflate()
     if (isInEditMode) return
+
+    binding = ScreenTeleconsultRecordBinding.bind(this)
 
     context.injector<Injector>().inject(this)
   }

--- a/app/src/main/java/org/simple/clinic/widgets/qrcodescanner/QrCodeScannerView.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/qrcodescanner/QrCodeScannerView.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.widgets.qrcodescanner
 import android.content.Context
 import android.util.AttributeSet
 import android.util.DisplayMetrics
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.FrameLayout
 import androidx.appcompat.app.AppCompatActivity
@@ -14,8 +15,7 @@ import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.core.content.ContextCompat
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
-import kotlinx.android.synthetic.main.view_qrcode_scanner.view.*
-import org.simple.clinic.R
+import org.simple.clinic.databinding.ViewQrcodeScannerBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.feature.Feature
 import org.simple.clinic.feature.Features
@@ -31,6 +31,14 @@ constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
 ) : FrameLayout(context, attrs, defStyleAttr), IQrCodeScannerView {
+
+  private var binding: ViewQrcodeScannerBinding? = null
+
+  private val previewView
+    get() = binding!!.previewView
+
+  private val viewFinderImageView
+    get() = binding!!.viewFinderImageView
 
   companion object {
     private const val RATIO_4_3_VALUE = 4.0 / 3.0
@@ -53,7 +61,8 @@ constructor(
   private val cameraProviderFuture = ProcessCameraProvider.getInstance(context.applicationContext)
 
   init {
-    View.inflate(context, R.layout.view_qrcode_scanner, this)
+    val layoutInflater = LayoutInflater.from(context)
+    binding = ViewQrcodeScannerBinding.inflate(layoutInflater, this, true)
   }
 
   override fun onFinishInflate() {
@@ -130,6 +139,7 @@ constructor(
 
   override fun onDetachedFromWindow() {
     cameraExecutor.shutdown()
+    binding = null
     super.onDetachedFromWindow()
   }
 


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/1828/migrate-app-to-use-view-binding-instead-of-kotlin-synthetic-view-accessors