### PR TITLE
Purge the QA environment before running the instrumented tests in CI

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -35,10 +35,20 @@ jobs:
       - name: QA Unit Tests
         run: ./gradlew testQaDebugUnitTest
 
+  qa_purge_env:
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: Purge QA server
+        run: |
+          curl -v --request DELETE \
+          --url https://api-qa.simple.org/qa/purge \
+          --header 'Authorization: Bearer ${{ secrets.QA_PURGE_TOKEN }}'
+
   # reactivecircus/android-emulator-runner@v2 requires MacOS to run on
   # https://github.com/ReactiveCircus/android-emulator-runner
   qa_android_tests:
     runs-on: [ macos-latest ]
+    needs: [qa_purge_env]
     steps:
       - uses: actions/checkout@v2
 
@@ -160,13 +170,3 @@ jobs:
           USER_EMAIL: ${{ secrets.USER_EMAIL }}
           BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: .github/scripts/amend_and_push.sh
-
-  qa_purge_env:
-    runs-on: [ubuntu-latest]
-    needs: [qa_lint, qa_unit_tests, qa_android_tests, mobius_migration_tests]
-    steps:
-      - name: Purge QA server
-        run: |
-          curl -v --request DELETE \
-          --url https://api-qa.simple.org/qa/purge \
-          --header 'Authorization: Bearer ${{ secrets.QA_PURGE_TOKEN }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Release
 ### Internal
+- Purge the QA environment before running the instrumented tests instead of after in CI
+
+## Next Release
+### Internal
 - Add shell env comment to `pre-push` hook
 - Add the Router for the new navigation framework 
 - Track code style and lint rules for project in VCS


### PR DESCRIPTION
Since we use static patient IDs in tests, but the facility is randomly selected, it was possible to get into a situation where instrumented tests would continuously fail until the server was manually purged. This resolves the issue by running the purge task before triggering the instrumented tests.

More details here: https://simpledotorg.slack.com/archives/CFK2PHJ1L/p1609913473022000