### PR TITLE
Fix garbled gradle logs when running pre-push hook in Git Bash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add Instant search query
 - Add `ScreenFragmentCompat` to support using the older view-based screens in the v2 navigation framework
 - Add convenience classes for creating screens for the new navigation framework
+- Fix garbled gradle logs when running pre-push hook in Git Bash
 
 ### Fixes
 - Fix BPpassport prefill value to have display value

--- a/quality/pre-push
+++ b/quality/pre-push
@@ -1,2 +1,13 @@
 #!/bin/sh
-GIT_WORK_TREE=".." ./gradlew lintQaDebug assembleQaDebugUnitTest assembleQaDebugAndroidTest
+readonly MSYS="msys"
+readonly OSTYPE="$OSTYPE"
+
+CONSOLE_PRINT_TYPE="auto"
+
+if [[ ${OSTYPE} -eq ${MSYS} ]]; then
+    CONSOLE_PRINT_TYPE="plain"
+else
+    CONSOLE_PRINT_TYPE="auto"
+fi
+
+GIT_WORK_TREE=".." ./gradlew --console="$CONSOLE_PRINT_TYPE" lintQaDebug assembleQaDebugUnitTest assembleQaDebugAndroidTest


### PR DESCRIPTION
Git Bash is printing garbled logs because it cannot figure out how to print the rich content from Gradle logs (ex: progress) when running the pre-push hook. In order to resolve that and make the logs readable, we set the console type for the pre-push hook.

**Reproduction steps**:
- Open Git Bash
- Run pre-push hook without these changes
> Prints garbled logs
- Run pre-push hook with these changes
> Prints plain logs
