### PR TITLE
Migrate app to use View Binding instead of Kotlin synthetic view accessors - 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 - Remove `ScanBpPassportActivity`
 - Migrate `TheActivity` to the new navigation framework
 - [In Progress: 20 Jan 2021] Material Theming Migration
-- [In Progress: 23 Dec 2020] Migrate app to use ViewBinding
+- [In Progress: 22 Jan 2021] Migrate app to use ViewBinding
+
 
 ## On Demo
 ### Internal

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/drugduration/DrugDurationSheet.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/drugduration/DrugDurationSheet.kt
@@ -11,10 +11,10 @@ import com.jakewharton.rxbinding3.widget.editorActions
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.sheet_drug_duration.*
 import org.simple.clinic.ClinicApp
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.SheetDrugDurationBinding
 import org.simple.clinic.di.InjectorProviderContextWrapper
 import org.simple.clinic.feature.Features
 import org.simple.clinic.mobius.MobiusDelegate
@@ -31,6 +31,17 @@ import java.util.UUID
 import javax.inject.Inject
 
 class DrugDurationSheet : BottomSheetActivity(), DrugDurationUi, DrugDurationUiActions {
+
+  private lateinit var binding: SheetDrugDurationBinding
+
+  private val drugDurationTitleTextView
+    get() = binding.drugDurationTitleTextView
+
+  private val drugDurationEditText
+    get() = binding.drugDurationEditText
+
+  private val drugDurationErrorTextView
+    get() = binding.drugDurationErrorTextView
 
   @Inject
   lateinit var locale: Locale
@@ -109,7 +120,10 @@ class DrugDurationSheet : BottomSheetActivity(), DrugDurationUi, DrugDurationUiA
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContentView(R.layout.sheet_drug_duration)
+
+    binding = SheetDrugDurationBinding.inflate(layoutInflater)
+    setContentView(binding.root)
+
     delegate.onRestoreInstanceState(savedInstanceState)
 
     drugDurationTitleTextView.text = getString(R.string.drug_duration_title, drugDuration.name, drugDuration.dosage)

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/medicinefrequency/MedicineFrequencySheet.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/medicinefrequency/MedicineFrequencySheet.kt
@@ -10,10 +10,10 @@ import com.jakewharton.rxbinding3.widget.checkedChanges
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.sheet_medicine_frequency.*
 import org.simple.clinic.ClinicApp
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.SheetMedicineFrequencyBinding
 import org.simple.clinic.di.InjectorProviderContextWrapper
 import org.simple.clinic.feature.Features
 import org.simple.clinic.mobius.MobiusDelegate
@@ -31,6 +31,17 @@ import java.util.UUID
 import javax.inject.Inject
 
 class MedicineFrequencySheet : BottomSheetActivity(), MedicineFrequencySheetUiActions {
+
+  private lateinit var binding: SheetMedicineFrequencyBinding
+
+  private val medicineFrequencyRadioGroup
+    get() = binding.medicineFrequencyRadioGroup
+
+  private val medicineFrequencyTitleTextView
+    get() = binding.medicineFrequencyTitleTextView
+
+  private val saveMedicineFrequencyButton
+    get() = binding.saveMedicineFrequencyButton
 
   @Inject
   lateinit var locale: Locale
@@ -100,7 +111,8 @@ class MedicineFrequencySheet : BottomSheetActivity(), MedicineFrequencySheetUiAc
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContentView(R.layout.sheet_medicine_frequency)
+    binding = SheetMedicineFrequencyBinding.inflate(layoutInflater)
+    setContentView(binding.root)
     medicineFrequencyTitleTextView.text = getString(R.string.drug_duration_title, medicineFrequencyExtra.name, medicineFrequencyExtra.dosage)
   }
 

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/prescription/medicines/TeleconsultMedicinesView.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/prescription/medicines/TeleconsultMedicinesView.kt
@@ -10,10 +10,10 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
-import kotlinx.android.synthetic.main.view_teleconsult_medicines.view.*
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.databinding.ListItemTeleconsultMedicineBinding
+import org.simple.clinic.databinding.ViewTeleconsultMedicinesBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.drugs.PrescribedDrug
 import org.simple.clinic.drugs.selection.PrescribedDrugsScreenKey
@@ -41,6 +41,20 @@ class TeleconsultMedicinesView(
     attrs: AttributeSet?
 ) : ConstraintLayout(context, attrs), TeleconsultMedicinesUi, TeleconsultMedicinesUiActions {
 
+  private var binding: ViewTeleconsultMedicinesBinding? = null
+
+  private val medicinesEditButton
+    get() = binding!!.medicinesEditButton
+
+  private val medicinesRecyclerView
+    get() = binding!!.medicinesRecyclerView
+
+  private val medicinesRequiredErrorTextView
+    get() = binding!!.medicinesRequiredErrorTextView
+
+  private val emptyMedicinesTextView
+    get() = binding!!.emptyMedicinesTextView
+
   @Inject
   lateinit var effectHandlerFactory: TeleconsultMedicinesEffectHandler.Factory
 
@@ -65,7 +79,8 @@ class TeleconsultMedicinesView(
   }
 
   init {
-    LayoutInflater.from(context).inflate(R.layout.view_teleconsult_medicines, this)
+    val layoutInflater = LayoutInflater.from(context)
+    binding = ViewTeleconsultMedicinesBinding.inflate(layoutInflater, this, true)
   }
 
   private val screenKey by unsafeLazy {
@@ -113,6 +128,7 @@ class TeleconsultMedicinesView(
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
+    binding = null
     delegate.stop()
   }
 

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/prescription/patientinfo/TeleconsultPatientInfoView.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/prescription/patientinfo/TeleconsultPatientInfoView.kt
@@ -3,10 +3,11 @@ package org.simple.clinic.teleconsultlog.prescription.patientinfo
 import android.content.Context
 import android.os.Parcelable
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.widget.FrameLayout
 import io.reactivex.Observable
-import kotlinx.android.synthetic.main.view_teleconsult_patient_info.view.*
 import org.simple.clinic.R
+import org.simple.clinic.databinding.ViewTeleconsultPatientInfoBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.navigation.v2.keyprovider.ScreenKeyProvider
@@ -27,6 +28,17 @@ class TeleconsultPatientInfoView constructor(
     context: Context,
     attrs: AttributeSet?
 ) : FrameLayout(context, attrs), TeleconsultPatientInfoUi {
+
+  private var binding: ViewTeleconsultPatientInfoBinding? = null
+
+  private val patientAddressTextView
+    get() = binding!!.patientAddressTextView
+
+  private val patientNameTextView
+    get() = binding!!.patientNameTextView
+
+  private val prescriptionDateTextView
+    get() = binding!!.prescriptionDateTextView
 
   @Inject
   lateinit var userClock: UserClock
@@ -59,7 +71,8 @@ class TeleconsultPatientInfoView constructor(
   }
 
   init {
-    inflate(context, R.layout.view_teleconsult_patient_info, this)
+    var layoutInflater = LayoutInflater.from(context)
+    binding = ViewTeleconsultPatientInfoBinding.inflate(layoutInflater, this, true)
   }
 
   override fun onAttachedToWindow() {
@@ -69,6 +82,7 @@ class TeleconsultPatientInfoView constructor(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
+    binding = null
     super.onDetachedFromWindow()
   }
 


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/1828/migrate-app-to-use-view-binding-instead-of-kotlin-synthetic-view-accessors