### PR TITLE
Fix BP Passport sheet reopens after it is dismissed

### DIFF
--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchInit.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchInit.kt
@@ -9,7 +9,7 @@ class InstantSearchInit : Init<InstantSearchModel, InstantSearchEffect> {
   override fun init(model: InstantSearchModel): First<InstantSearchModel, InstantSearchEffect> {
     val effects = mutableSetOf<InstantSearchEffect>()
 
-    if (model.hasAdditionalIdentifier)
+    if (model.hasAdditionalIdentifier && !model.bpPassportSheetAlreadyOpened)
       effects.add(OpenBpPassportSheet(model.additionalIdentifier!!))
 
     if (model.hasFacility)

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchInit.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchInit.kt
@@ -7,16 +7,19 @@ import com.spotify.mobius.Init
 class InstantSearchInit : Init<InstantSearchModel, InstantSearchEffect> {
 
   override fun init(model: InstantSearchModel): First<InstantSearchModel, InstantSearchEffect> {
+    var modelToEmit = model
     val effects = mutableSetOf<InstantSearchEffect>()
 
-    if (model.hasAdditionalIdentifier && !model.bpPassportSheetAlreadyOpened)
-      effects.add(OpenBpPassportSheet(model.additionalIdentifier!!))
+    if (modelToEmit.hasAdditionalIdentifier && !modelToEmit.bpPassportSheetAlreadyOpened) {
+      effects.add(OpenBpPassportSheet(modelToEmit.additionalIdentifier!!))
+      modelToEmit = modelToEmit.bpPassportSheetOpened()
+    }
 
-    if (model.hasFacility)
-      effects.add(ValidateSearchQuery(model.searchQuery.orEmpty()))
+    if (modelToEmit.hasFacility)
+      effects.add(ValidateSearchQuery(modelToEmit.searchQuery.orEmpty()))
     else
       effects.add(LoadCurrentFacility)
 
-    return first(model, effects)
+    return first(modelToEmit, effects)
   }
 }

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchModel.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchModel.kt
@@ -56,4 +56,8 @@ data class InstantSearchModel(
   fun searchResultsLoaded(): InstantSearchModel {
     return copy(instantSearchProgressState = InstantSearchProgressState.DONE)
   }
+
+  fun bpPassportSheetOpened(): InstantSearchModel {
+    return copy(bpPassportSheetAlreadyOpened = true)
+  }
 }

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchModel.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchModel.kt
@@ -10,7 +10,8 @@ data class InstantSearchModel(
     val facility: Facility?,
     val searchQuery: String?,
     val additionalIdentifier: Identifier?,
-    val instantSearchProgressState: InstantSearchProgressState?
+    val instantSearchProgressState: InstantSearchProgressState?,
+    val bpPassportSheetAlreadyOpened: Boolean
 ) : Parcelable {
 
   val hasFacility: Boolean
@@ -27,7 +28,8 @@ data class InstantSearchModel(
         facility = null,
         searchQuery = null,
         additionalIdentifier = additionalIdentifier,
-        instantSearchProgressState = null
+        instantSearchProgressState = null,
+        bpPassportSheetAlreadyOpened = false
     )
   }
 

--- a/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchInitTest.kt
@@ -2,11 +2,15 @@ package org.simple.clinic.instantsearch
 
 import com.spotify.mobius.test.FirstMatchers.hasEffects
 import com.spotify.mobius.test.FirstMatchers.hasModel
+import com.spotify.mobius.test.FirstMatchers.hasNoEffects
 import com.spotify.mobius.test.InitSpec
 import com.spotify.mobius.test.InitSpec.assertThatFirst
+import org.hamcrest.TypeSafeDiagnosingMatcher
 import org.junit.Test
 import org.simple.clinic.TestData
 import org.simple.clinic.patient.businessid.Identifier.IdentifierType.BpPassport
+import org.simple.clinic.util.matchers.IterableNotContaining
+import org.simple.clinic.util.matchers.IterableNotContaining.Companion.doesNotContain
 import java.util.UUID
 
 class InstantSearchInitTest {
@@ -56,6 +60,18 @@ class InstantSearchInitTest {
         .then(assertThatFirst(
             hasModel(facilityLoadedModel),
             hasEffects(ValidateSearchQuery("Pa"), OpenBpPassportSheet(identifier))
+        ))
+  }
+
+  @Test
+  fun `when screen is restored after receiving the BP Passport sheet result, then do not open bp passport sheet`() {
+    val model = defaultModel.bpPassportSheetOpened()
+
+    initSpec
+        .whenInit(model)
+        .then(assertThatFirst(
+            hasModel(model),
+            hasEffects(doesNotContain(OpenBpPassportSheet(identifier)))
         ))
   }
 }

--- a/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchInitTest.kt
@@ -2,14 +2,11 @@ package org.simple.clinic.instantsearch
 
 import com.spotify.mobius.test.FirstMatchers.hasEffects
 import com.spotify.mobius.test.FirstMatchers.hasModel
-import com.spotify.mobius.test.FirstMatchers.hasNoEffects
 import com.spotify.mobius.test.InitSpec
 import com.spotify.mobius.test.InitSpec.assertThatFirst
-import org.hamcrest.TypeSafeDiagnosingMatcher
 import org.junit.Test
 import org.simple.clinic.TestData
 import org.simple.clinic.patient.businessid.Identifier.IdentifierType.BpPassport
-import org.simple.clinic.util.matchers.IterableNotContaining
 import org.simple.clinic.util.matchers.IterableNotContaining.Companion.doesNotContain
 import java.util.UUID
 
@@ -39,7 +36,7 @@ class InstantSearchInitTest {
     initSpec
         .whenInit(defaultModel)
         .then(assertThatFirst(
-            hasModel(defaultModel),
+            hasModel(defaultModel.bpPassportSheetOpened()),
             hasEffects(LoadCurrentFacility, OpenBpPassportSheet(identifier))
         ))
   }
@@ -52,6 +49,7 @@ class InstantSearchInitTest {
         name = "PHC Obvious"
     )
     val facilityLoadedModel = defaultModel
+        .bpPassportSheetOpened()
         .facilityLoaded(facility)
         .searchQueryChanged("Pa")
 
@@ -59,7 +57,7 @@ class InstantSearchInitTest {
         .whenInit(facilityLoadedModel)
         .then(assertThatFirst(
             hasModel(facilityLoadedModel),
-            hasEffects(ValidateSearchQuery("Pa"), OpenBpPassportSheet(identifier))
+            hasEffects(ValidateSearchQuery("Pa"))
         ))
   }
 

--- a/app/src/test/java/org/simple/clinic/util/matchers/IterableNotContaining.kt
+++ b/app/src/test/java/org/simple/clinic/util/matchers/IterableNotContaining.kt
@@ -1,0 +1,24 @@
+package org.simple.clinic.util.matchers
+
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
+
+class IterableNotContaining<F>(
+    private val itemToTest: F
+) : TypeSafeMatcher<Iterable<F>>() {
+
+  companion object {
+    fun <F> doesNotContain(itemToTest: F): Matcher<Iterable<F>> {
+      return IterableNotContaining(itemToTest)
+    }
+  }
+
+  override fun describeTo(description: Description) {
+    description.appendText("does not contain: $itemToTest")
+  }
+
+  override fun matchesSafely(items: Iterable<F>): Boolean {
+    return itemToTest !in items
+  }
+}


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/2421/the-bp-passport-scan-sheet-is-continuously-being-shown