### PR TITLE
Fix app crash when returning to `PatientEntryScreen` from `MedicalHistoryScreen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 ### Changes
 - Updated translations: `mr-IN`, `ta-IN`, `bn-BD`, `ti-ET`, `am_ET`, `kn_IN`, `bn_IN`, `hi_IN`
 
+### Fixes
+- Fix App crash when returning to the register patient screen before completing registration when patient date of birth is entered
+
 ## On Demo
 ### Internal
 - Disable strict mode crash for VM policy
@@ -29,7 +32,7 @@
 - Add `NoopViewRenderer`
 - Migrate `BpPassportSheet` to `BaseBottomSheet`
 
-## Features
+### Features
 - Highlight patient name and number in Instant search
 
 ## 2021-01-25-7605

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
@@ -210,10 +210,14 @@ class PatientEntryScreen(context: Context, attrs: AttributeSet) : RelativeLayout
 
   // FIXME This is temporally coupled to `scrollToFirstFieldWithError()`.
   private val allTextInputFields: List<EditText> by unsafeLazy {
+    val ageOrDateOfBirthEditText = if (ageEditTextInputLayout.visibility == View.VISIBLE) {
+      ageEditText
+    } else {
+      dateOfBirthEditText
+    }
     listOf(
         fullNameEditText,
-        ageEditText,
-        dateOfBirthEditText,
+        ageOrDateOfBirthEditText,
         phoneNumberEditText,
         colonyOrVillageEditText,
         districtEditText,

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
@@ -36,9 +36,7 @@ import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.navigation.v2.Router
 import org.simple.clinic.navigation.v2.compat.wrap
 import org.simple.clinic.newentry.country.InputFields
-import org.simple.clinic.newentry.form.AgeField
 import org.simple.clinic.newentry.form.AlternativeIdInputField
-import org.simple.clinic.newentry.form.DateOfBirthField
 import org.simple.clinic.newentry.form.DistrictField
 import org.simple.clinic.newentry.form.GenderField
 import org.simple.clinic.newentry.form.LandlineOrMobileField
@@ -183,9 +181,6 @@ class PatientEntryScreen(context: Context, attrs: AttributeSet) : RelativeLayout
 
   private val streetAddressEditText
     get() = binding!!.streetAddressEditText
-
-  private val saveButtonFrame
-    get() = binding!!.saveButtonFrame
 
   private val consentSwitch
     get() = binding!!.consentSwitch

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
@@ -287,8 +287,6 @@ class PatientEntryScreen(context: Context, attrs: AttributeSet) : RelativeLayout
   private fun showOrHideInputFields(inputFields: InputFields) {
     val allTypesOfInputFields: Map<Class<*>, View> = mapOf(
         PatientNameField::class.java to fullNameInputLayout,
-        AgeField::class.java to ageEditTextInputLayout,
-        DateOfBirthField::class.java to dateOfBirthInputLayout,
         LandlineOrMobileField::class.java to phoneNumberInputLayout,
         GenderField::class.java to genderRadioGroup,
         AlternativeIdInputField::class.java to alternativeIdInputLayout,


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/1274/app-crashes-when-returning-to-the-register-patient-screen-before-completing-registration-when-patient-date-of-birth-is-entered