### PR TITLE
Bump Kotlin version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Change `PatientSearchResultsScreen` to a fragment
 - Bump ConstraintLayout to v2.0.4
 - Add `Widget.Simple.TextField.Layout.PatientEntry.AutoComplete` style
+- Bump Kotlin to v1.4.30
 - [In Progress: 20 Jan 2021] Material Theming Migration
 - [In Progress: 08 Feb 2021] Migrate app to use ViewBinding
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -108,6 +108,7 @@ android {
 
   kotlinOptions {
     jvmTarget = 1.8
+    useIR = true
   }
 
   productFlavors {

--- a/app/src/main/java/org/simple/clinic/util/ParcelableOptional.kt
+++ b/app/src/main/java/org/simple/clinic/util/ParcelableOptional.kt
@@ -1,7 +1,7 @@
 package org.simple.clinic.util
 
+import android.os.Parcel
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
 
 /**
  * We already have an [Optional] class that we use for representing
@@ -16,12 +16,21 @@ import kotlinx.android.parcel.Parcelize
  * This class is based on the Java [Optional](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html)
  * class, but which forces the [Parcelable] interface on its types.
  **/
-@Parcelize
 data class ParcelableOptional<T : Parcelable>(
     private val value: T?
 ) : Parcelable {
 
-  companion object {
+  constructor(parcel: Parcel) : this(parcel.readParcelable(ParcelableOptional::class.java.classLoader))
+
+  companion object CREATOR : Parcelable.Creator<ParcelableOptional<Parcelable>> {
+    override fun createFromParcel(parcel: Parcel): ParcelableOptional<Parcelable> {
+      return ParcelableOptional(parcel)
+    }
+
+    override fun newArray(size: Int): Array<ParcelableOptional<Parcelable>?> {
+      return arrayOfNulls(size)
+    }
+
     fun <T : Parcelable> of(value: T?) = ParcelableOptional(value)
   }
 
@@ -49,6 +58,14 @@ data class ParcelableOptional<T : Parcelable>(
     if (value == null) throw failureSupplier()
 
     return value
+  }
+
+  override fun writeToParcel(parcel: Parcel, flags: Int) {
+    parcel.writeParcelable(value, flags)
+  }
+
+  override fun describeContents(): Int {
+    return 0
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   ext.versions = [
       minSdk                   : 21,
       compileSdk               : 30,
-      kotlin                   : '1.4.10',
+      kotlin                   : '1.4.30',
       supportLib               : '1.0.0',
       recyclerView             : '1.0.0',
       material                 : '1.3.0',


### PR DESCRIPTION
- Bump Kotlin to v1.4.30
- Add parcelable implementation to `ParcelableOptional`
- Use new JVM IR backend

Kotlin 1.4.30 changes: https://blog.jetbrains.com/kotlin/2021/02/kotlin-1-4-30-released/
New JVM IR Backend: https://blog.jetbrains.com/kotlin/2021/02/the-jvm-backend-is-in-beta-let-s-make-it-stable-together/
`@Parcelize` annotation issue: https://youtrack.jetbrains.com/issue/KT-42652

