### PR TITLE
Enable running GH actions manually for ci_checks & code_formatting_checks

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   qa_lint:

--- a/.github/workflows/code_formatting_checks.yml
+++ b/.github/workflows/code_formatting_checks.yml
@@ -5,6 +5,7 @@ name: Code formatting
 on:
   schedule:
     - cron: "30 23 * * 0-4"
+  workflow_dispatch:
 
 jobs:
   fix_code_formatting:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Migrate `LinkIdWithPatientView` to `LinkIdWithPatientSheet`
 - Convert `screen_patient_summary` to use `ConstraintLayout`
 - Bump Play Core to v1.10.0
+- Add option to manually trigger GH Actions
 - [In Progress: 20 Jan 2021] Material Theme-ing Migration
 - [In Progress: 08 Feb 2021] Migrate app to use ViewBinding
 


### PR DESCRIPTION
Just a quality of life change, for manually running GH Actions for a given branch from the Actions tab on GitHub.