### PR TITLE
Add drug stock option in progress screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Internal
 - [In Progress: 20 Jan 2021] Material Theme-ing Migration
 - [In Progress: 08 Feb 2021] Migrate app to use ViewBinding
+- Add drug stock option in progress
 
 ### Changes
 - Update translations: `mr-IN`, `bn-IN`, `ti-ET`, `te-IN`, `pa-IN`

--- a/app/src/main/java/org/simple/clinic/home/report/ReportsEvent.kt
+++ b/app/src/main/java/org/simple/clinic/home/report/ReportsEvent.kt
@@ -5,3 +5,5 @@ import org.simple.clinic.util.Optional
 sealed class ReportsEvent
 
 data class ReportsLoaded(val reportsContent: Optional<String>) : ReportsEvent()
+
+object WebBackClicked : ReportsEvent()

--- a/app/src/main/java/org/simple/clinic/home/report/ReportsScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/report/ReportsScreen.kt
@@ -6,6 +6,8 @@ import android.os.Parcelable
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import io.reactivex.Observable
+import io.reactivex.rxkotlin.cast
+import io.reactivex.subjects.PublishSubject
 import kotlinx.android.synthetic.main.screen_report.view.*
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
@@ -18,11 +20,19 @@ class ReportsScreen(context: Context, attrs: AttributeSet) : FrameLayout(context
   @Inject
   lateinit var effectHandler: ReportsEffectHandler
 
+  private val webViewBackClicks = PublishSubject.create<ReportsEvent>()
+
+  private val events: Observable<ReportsEvent> by unsafeLazy {
+    Observable
+        .mergeArray(webViewBackClicks)
+        .cast()
+  }
+
   private val delegate by unsafeLazy {
     val uiRenderer = ReportsUiRenderer(this)
 
     MobiusDelegate.forView(
-        events = Observable.never(),
+        events = events,
         defaultModel = ReportsModel.create(),
         init = ReportsInit(),
         update = ReportsUpdate(),
@@ -40,7 +50,9 @@ class ReportsScreen(context: Context, attrs: AttributeSet) : FrameLayout(context
     }
 
     webView.settings.javaScriptEnabled = true
-    webView.webViewClient = ReportsWebViewClient()
+    webView.webViewClient = ReportsWebViewClient(
+        backClicked = { webViewBackClicks.onNext(WebBackClicked) }
+    )
 
     context.injector<Injector>().inject(this)
   }
@@ -55,7 +67,7 @@ class ReportsScreen(context: Context, attrs: AttributeSet) : FrameLayout(context
     super.onDetachedFromWindow()
   }
 
-  override fun onSaveInstanceState(): Parcelable? {
+  override fun onSaveInstanceState(): Parcelable {
     return delegate.onSaveInstanceState(super.onSaveInstanceState())
   }
 

--- a/app/src/main/java/org/simple/clinic/home/report/ReportsScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/report/ReportsScreen.kt
@@ -40,6 +40,7 @@ class ReportsScreen(context: Context, attrs: AttributeSet) : FrameLayout(context
     }
 
     webView.settings.javaScriptEnabled = true
+    webView.webViewClient = ReportsWebViewClient()
 
     context.injector<Injector>().inject(this)
   }

--- a/app/src/main/java/org/simple/clinic/home/report/ReportsUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/home/report/ReportsUpdate.kt
@@ -2,6 +2,7 @@ package org.simple.clinic.home.report
 
 import com.spotify.mobius.Next
 import com.spotify.mobius.Update
+import org.simple.clinic.mobius.dispatch
 import org.simple.clinic.mobius.next
 
 class ReportsUpdate : Update<ReportsModel, ReportsEvent, ReportsEffect> {
@@ -10,6 +11,7 @@ class ReportsUpdate : Update<ReportsModel, ReportsEvent, ReportsEffect> {
       is ReportsLoaded -> {
         next(model.reportsContentLoaded(event.reportsContent))
       }
+      WebBackClicked -> dispatch(LoadReports)
     }
   }
 }

--- a/app/src/main/java/org/simple/clinic/home/report/ReportsWebViewClient.kt
+++ b/app/src/main/java/org/simple/clinic/home/report/ReportsWebViewClient.kt
@@ -1,0 +1,15 @@
+package org.simple.clinic.home.report
+
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+
+class ReportsWebViewClient : WebViewClient() {
+
+  override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+    val url = request?.url?.toString() ?: return super.shouldOverrideUrlLoading(view, request)
+
+    view?.loadUrl(url)
+    return false
+  }
+}

--- a/app/src/main/java/org/simple/clinic/home/report/ReportsWebViewClient.kt
+++ b/app/src/main/java/org/simple/clinic/home/report/ReportsWebViewClient.kt
@@ -4,11 +4,16 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 
-class ReportsWebViewClient : WebViewClient() {
+class ReportsWebViewClient(
+    private val backClicked: () -> Unit
+) : WebViewClient() {
 
   override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
     val url = request?.url?.toString() ?: return super.shouldOverrideUrlLoading(view, request)
 
+    if (url == "simple://progress-tab") {
+      backClicked.invoke()
+    }
     view?.loadUrl(url)
     return false
   }

--- a/app/src/test/java/org/simple/clinic/home/report/ReportsUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/report/ReportsUpdateTest.kt
@@ -1,0 +1,23 @@
+package org.simple.clinic.home.report
+
+import com.spotify.mobius.test.NextMatchers.hasEffects
+import com.spotify.mobius.test.NextMatchers.hasNoModel
+import com.spotify.mobius.test.UpdateSpec
+import com.spotify.mobius.test.UpdateSpec.assertThatNext
+import org.junit.Test
+
+class ReportsUpdateTest {
+
+  @Test
+  fun `when back button in reports web view is clicked, then load reports`() {
+    val model = ReportsModel.create()
+
+    UpdateSpec(ReportsUpdate())
+        .given(model)
+        .whenEvent(WebBackClicked)
+        .then(assertThatNext(
+            hasNoModel(),
+            hasEffects(LoadReports)
+        ))
+  }
+}


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/2224/add-drug-stock-form-to-progress-tab-behind-a-feature-flag

https://app.clubhouse.io/simpledotorg/story/2929/handle-navigation-and-from-drug-stock-success-page-in-the-android-app