### PR TITLE
Fix village type ahead crash when creating/editing patient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixes
 - Fix separator between Age & DOB fields not visible in patient entry & edit screens
+- Fix village type ahead crash when creating/editing patient
 
 ## On Demo
 ### Internal

--- a/app/src/main/java/org/simple/clinic/patient/PatientAddress.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientAddress.kt
@@ -99,7 +99,7 @@ data class PatientAddress(
     @Query("SELECT COUNT(uuid) FROM PatientAddress")
     abstract fun count(): Int
 
-    @Query("SELECT DISTINCT colonyOrVillage FROM PatientAddress ORDER BY colonyOrVillage ASC")
+    @Query("SELECT DISTINCT colonyOrVillage FROM PatientAddress WHERE colonyOrVillage IS NOT NULL ORDER BY colonyOrVillage ASC")
     abstract fun getColonyOrVillages(): List<String>
   }
 }

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientInitTest.kt
@@ -39,6 +39,25 @@ class EditPatientInitTest {
   }
 
   @Test
+  fun `when screen is created and village type ahead is not enabled, then do not fetch colony or villages`() {
+    val patientUuid = UUID.fromString("e40f42f4-0867-4891-ac77-95df5fe1fdef")
+    val defaultModel = EditPatientModel.from(patient, patientAddress, patientPhoneNumber, dateOfBirthFormat, bangladeshNationalId, EditPatientState.NOT_SAVING_PATIENT)
+    val initSpec = InitSpec(EditPatientInit(patient = patient,
+        address = patientAddress,
+        phoneNumber = patientPhoneNumber,
+        bangladeshNationalId = bangladeshNationalId,
+        isVillageTypeAheadEnabled = false))
+
+    initSpec.whenInit(defaultModel).then(assertThatFirst(
+        hasModel(defaultModel),
+        hasEffects(PrefillFormEffect(patient, patientAddress, patientPhoneNumber, bangladeshNationalId),
+            FetchBpPassportsEffect(patientUuid),
+            LoadInputFields
+        )
+    ))
+  }
+
+  @Test
   fun `when screen is restored, then don't fetch colony or villages`() {
     val colonyOrVillages = listOf("Colony1", "Colony2", "Colony3", "Colony4")
 

--- a/app/src/test/java/org/simple/clinic/newentry/PatientEntryInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/newentry/PatientEntryInitTest.kt
@@ -5,10 +5,16 @@ import com.spotify.mobius.test.FirstMatchers.hasModel
 import com.spotify.mobius.test.InitSpec
 import com.spotify.mobius.test.InitSpec.assertThatFirst
 import org.junit.Test
+import org.simple.clinic.editpatient.EditPatientInit
+import org.simple.clinic.editpatient.EditPatientModel
+import org.simple.clinic.editpatient.EditPatientState
+import org.simple.clinic.editpatient.FetchBpPassportsEffect
+import org.simple.clinic.editpatient.PrefillFormEffect
 import org.simple.clinic.feature.Feature
 import org.simple.clinic.feature.Features
 import org.simple.clinic.remoteconfig.DefaultValueConfigReader
 import org.simple.clinic.remoteconfig.NoOpRemoteConfigService
+import java.util.UUID
 
 class PatientEntryInitTest {
   private val initSpec = InitSpec(PatientEntryInit(isVillageTypeAheadEnabled = true))
@@ -20,6 +26,18 @@ class PatientEntryInitTest {
         hasModel(defaultModel),
         hasEffects(
             FetchPatientEntry, LoadInputFields, FetchColonyOrVillagesEffect
+        )
+    ))
+  }
+
+  @Test
+  fun `when screen is created and village type ahead is not enabled, then do not fetch colony or villages`() {
+    val initSpec = InitSpec(PatientEntryInit(isVillageTypeAheadEnabled = false))
+
+    initSpec.whenInit(defaultModel).then(assertThatFirst(
+        hasModel(defaultModel),
+        hasEffects(
+            FetchPatientEntry, LoadInputFields
         )
     ))
   }


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/3038/patient-entry-edit-crashes-when-entering-village-name