### PR TITLE
Fix prescribed drugs item corner radius not being updated when order is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@
 - [In Progress: 20 Jan 2021] Material Theme-ing Migration
 - [In Progress: 08 Feb 2021] Migrate app to use ViewBinding
 
-###
+### Fixes
 - Fix date stepper showing black color when it's disabled
+- Fix prescribed drugs item corner radius not being updated when order is changed
 
 ## Demo
 ### Internal

--- a/app/src/main/java/org/simple/clinic/drugs/EditMedicinesUiRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/EditMedicinesUiRenderer.kt
@@ -36,6 +36,14 @@ class EditMedicinesUiRenderer(private val ui: EditMedicinesUi) : ViewRenderer<Ed
     val customPrescribedDrugItems = customPrescribedDrugItems(prescribedCustomDrugs)
     val drugsList = (protocolDrugSelectionItems + customPrescribedDrugItems)
         .sortedByDescending { it.prescribedDrug?.updatedAt }
+        .mapIndexed { index, drugListItem ->
+          val isTopItem = index == 0
+          when {
+            isTopItem && drugListItem is ProtocolDrugListItem -> drugListItem.withTopCorners()
+            isTopItem && drugListItem is CustomPrescribedDrugListItem -> drugListItem.withTopCorners()
+            else -> drugListItem
+          }
+        }
 
     ui.populateDrugsList(drugsList)
   }
@@ -46,7 +54,8 @@ class EditMedicinesUiRenderer(private val ui: EditMedicinesUi) : ViewRenderer<Ed
     return prescribedCustomDrugs
         .map { prescribedDrug ->
           CustomPrescribedDrugListItem(
-              prescribedDrug = prescribedDrug
+              prescribedDrug = prescribedDrug,
+              hasTopCorners = false
           )
         }
   }
@@ -59,10 +68,13 @@ class EditMedicinesUiRenderer(private val ui: EditMedicinesUi) : ViewRenderer<Ed
     return protocolDrugs
         .mapIndexed { index: Int, drugAndDosages: ProtocolDrugAndDosages ->
           val matchingPrescribedDrug = prescribedProtocolDrugs.firstOrNull { it.name == drugAndDosages.drugName }
+
           ProtocolDrugListItem(
               id = index,
               drugName = drugAndDosages.drugName,
-              prescribedDrug = matchingPrescribedDrug)
+              prescribedDrug = matchingPrescribedDrug,
+              hasTopCorners = false
+          )
         }
   }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/DrugListItem.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/DrugListItem.kt
@@ -1,7 +1,6 @@
 package org.simple.clinic.drugs.selection
 
 import androidx.recyclerview.widget.DiffUtil
-import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.ShapeAppearanceModel
 import io.reactivex.subjects.Subject
 import org.simple.clinic.R
@@ -30,7 +29,8 @@ sealed class DrugListItem(open val prescribedDrug: PrescribedDrug? = null) : Ite
 data class ProtocolDrugListItem(
     val id: Int,
     val drugName: String,
-    override val prescribedDrug: PrescribedDrug?
+    override val prescribedDrug: PrescribedDrug?,
+    val hasTopCorners: Boolean
 ) : DrugListItem(prescribedDrug) {
 
   override fun layoutResId() = R.layout.list_prescribeddrugs_protocol_drug
@@ -44,28 +44,21 @@ data class ProtocolDrugListItem(
     viewBinding.protocoldrugItemDosage.visibleOrGone(prescribedDrug != null)
     viewBinding.protocoldrugItemDosage.text = prescribedDrug?.dosage
 
-    viewBinding.prescribeddrugItemProtocoldrugRootlayout.shapeAppearanceModel = topMostCardShapeAppearanceModel(isTopMostCard = holder.adapterPosition == 0)
+    viewBinding.prescribeddrugItemProtocoldrugRootlayout.shapeAppearanceModel = shapeAppearanceModel(hasTopCorners)
 
     viewBinding.root.setOnClickListener {
       subject.onNext(DrugListItemClicked.PrescribedDrugClicked(drugName, prescribedDrug))
     }
   }
-}
 
-private fun topMostCardShapeAppearanceModel(isTopMostCard: Boolean) = if (isTopMostCard) {
-  ShapeAppearanceModel()
-      .toBuilder()
-      .setTopLeftCorner(CornerFamily.ROUNDED, 4.dp.toFloat())
-      .setTopRightCorner(CornerFamily.ROUNDED, 4.dp.toFloat())
-      .build()
-} else {
-  ShapeAppearanceModel()
-      .toBuilder()
-      .build()
+  fun withTopCorners(): ProtocolDrugListItem {
+    return copy(hasTopCorners = true)
+  }
 }
 
 data class CustomPrescribedDrugListItem(
-    override val prescribedDrug: PrescribedDrug
+    override val prescribedDrug: PrescribedDrug,
+    val hasTopCorners: Boolean
 ) : DrugListItem(prescribedDrug) {
 
   override fun layoutResId() = R.layout.list_prescribeddrugs_custom_drug
@@ -82,8 +75,11 @@ data class CustomPrescribedDrugListItem(
       subject.onNext(DrugListItemClicked.CustomPrescriptionClicked(prescribedDrug))
     }
 
-    viewBinding.prescribeddrugItemCustomdrugRootlayout.shapeAppearanceModel = topMostCardShapeAppearanceModel(isTopMostCard = holder.adapterPosition == 0)
+    viewBinding.prescribeddrugItemCustomdrugRootlayout.shapeAppearanceModel = shapeAppearanceModel(hasTopCorners)
+  }
 
+  fun withTopCorners(): CustomPrescribedDrugListItem {
+    return copy(hasTopCorners = true)
   }
 }
 
@@ -96,6 +92,18 @@ object AddNewPrescriptionListItem : DrugListItem() {
 
     viewBinding.prescribeddrugItemAddnewprescription.setOnClickListener { subject.onNext(DrugListItemClicked.AddNewPrescriptionClicked) }
   }
+}
+
+private fun shapeAppearanceModel(hasTopCorners: Boolean) = if (hasTopCorners) {
+  ShapeAppearanceModel
+      .builder()
+      .setTopLeftCornerSize(4.dp.toFloat())
+      .setTopRightCornerSize(4.dp.toFloat())
+      .build()
+} else {
+  ShapeAppearanceModel
+      .builder()
+      .build()
 }
 
 sealed class DrugListItemClicked {

--- a/app/src/test/java/org/simple/clinic/drugs/EditMedicinesUiRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/EditMedicinesUiRendererTest.kt
@@ -7,8 +7,8 @@ import org.junit.Test
 import org.simple.clinic.TestData
 import org.simple.clinic.drugs.EditMedicineButtonState.REFILL_MEDICINE
 import org.simple.clinic.drugs.EditMedicineButtonState.SAVE_MEDICINE
-import org.simple.clinic.drugs.selection.EditMedicinesUi
 import org.simple.clinic.drugs.selection.CustomPrescribedDrugListItem
+import org.simple.clinic.drugs.selection.EditMedicinesUi
 import org.simple.clinic.drugs.selection.ProtocolDrugListItem
 import org.simple.clinic.protocol.ProtocolDrugAndDosages
 import java.time.Instant
@@ -79,10 +79,11 @@ class EditMedicinesUiRendererTest {
         ProtocolDrugListItem(
             id = 0,
             drugName = amlodipine10mg.name,
-            prescribedDrug = amlodipine10mgPrescription),
-        CustomPrescribedDrugListItem(telmisartan40mgPrescription),
-        CustomPrescribedDrugListItem(fooPrescription),
-        CustomPrescribedDrugListItem(barPrescription))
+            prescribedDrug = amlodipine10mgPrescription,
+            hasTopCorners = true),
+        CustomPrescribedDrugListItem(prescribedDrug = telmisartan40mgPrescription, hasTopCorners = false),
+        CustomPrescribedDrugListItem(prescribedDrug = fooPrescription, hasTopCorners = false),
+        CustomPrescribedDrugListItem(prescribedDrug = barPrescription, hasTopCorners = false))
 
     verify(ui).populateDrugsList(drugsList)
     verify(ui).showDoneButton()
@@ -147,10 +148,11 @@ class EditMedicinesUiRendererTest {
         ProtocolDrugListItem(
             id = 0,
             drugName = amlodipine10mg.name,
-            prescribedDrug = amlodipine10mgPrescription),
-        CustomPrescribedDrugListItem(telmisartan40mgPrescription),
-        CustomPrescribedDrugListItem(fooPrescription),
-        CustomPrescribedDrugListItem(barPrescription))
+            prescribedDrug = amlodipine10mgPrescription,
+            hasTopCorners = true),
+        CustomPrescribedDrugListItem(prescribedDrug = telmisartan40mgPrescription, hasTopCorners = false),
+        CustomPrescribedDrugListItem(prescribedDrug = fooPrescription, hasTopCorners = false),
+        CustomPrescribedDrugListItem(prescribedDrug = barPrescription, hasTopCorners = false))
 
     verify(ui).populateDrugsList(drugsList)
     verify(ui).showDoneButton()
@@ -215,10 +217,75 @@ class EditMedicinesUiRendererTest {
         ProtocolDrugListItem(
             id = 0,
             drugName = amlodipine10mg.name,
-            prescribedDrug = amlodipine10mgPrescription),
-        CustomPrescribedDrugListItem(telmisartan40mgPrescription),
-        CustomPrescribedDrugListItem(fooPrescription),
-        CustomPrescribedDrugListItem(barPrescription))
+            prescribedDrug = amlodipine10mgPrescription,
+            hasTopCorners = true),
+        CustomPrescribedDrugListItem(prescribedDrug = telmisartan40mgPrescription, hasTopCorners = false),
+        CustomPrescribedDrugListItem(prescribedDrug = fooPrescription, hasTopCorners = false),
+        CustomPrescribedDrugListItem(prescribedDrug = barPrescription, hasTopCorners = false))
+
+    verify(ui).populateDrugsList(drugsList)
+    verify(ui).showRefillMedicineButton()
+    verify(ui).hideDoneButton()
+    verifyNoMoreInteractions(ui)
+  }
+
+  @Test
+  fun `when custom drug is top of the list, then apply corner radius`() {
+    // given
+    val amlodipine5mg = TestData.protocolDrug(name = "Amlodipine", dosage = "5mg")
+    val amlodipine10mg = TestData.protocolDrug(name = "Amlodipine", dosage = "10mg")
+
+    val protocolDrugAndDosages = listOf(
+        ProtocolDrugAndDosages(amlodipine10mg.name, listOf(amlodipine5mg, amlodipine10mg))
+    )
+
+    val amlodipine10mgPrescription = TestData.prescription(
+        uuid = UUID.fromString("90e28866-90f6-48a0-add1-cf44aa43209c"),
+        name = "Amlodipine",
+        dosage = "10mg",
+        isProtocolDrug = true,
+        updatedAt = Instant.parse("2018-01-01T00:00:00Z")
+    )
+    val telmisartan40mgPrescription = TestData.prescription(
+        uuid = UUID.fromString("ac3cfff0-2ebf-4c9c-adab-a41cc8a0bbeb"),
+        name = "Telmisartan",
+        dosage = "40mg",
+        isProtocolDrug = true,
+        updatedAt = Instant.parse("2018-01-01T00:00:00Z")
+    )
+    val fooPrescription = TestData.prescription(
+        uuid = UUID.fromString("68dc8060-bed4-4e1b-9891-7d77cad9639e"),
+        name = "Foo",
+        dosage = "2 pills",
+        isProtocolDrug = false,
+        updatedAt = Instant.parse("2018-01-01T00:00:00Z")
+    )
+    val barPrescription = TestData.prescription(
+        uuid = UUID.fromString("b5eb5dfa-f131-4d9f-a2d2-41d56aa109da"),
+        name = "Bar",
+        dosage = null,
+        isProtocolDrug = false,
+        updatedAt = Instant.parse("2018-01-01T00:00:00Z")
+    )
+    val prescriptions = listOf(
+        telmisartan40mgPrescription,
+        fooPrescription,
+        barPrescription)
+
+    val prescribedDrugsFetchedModel = defaultModel
+        .protocolDrugsFetched(protocolDrugAndDosages)
+        .prescribedDrugsFetched(prescriptions)
+        .editMedicineDrugStateFetched(REFILL_MEDICINE)
+
+    // when
+    uiRenderer.render(prescribedDrugsFetchedModel)
+
+    // then
+    val drugsList = listOf(
+        CustomPrescribedDrugListItem(prescribedDrug = telmisartan40mgPrescription, hasTopCorners = true),
+        CustomPrescribedDrugListItem(prescribedDrug = fooPrescription, hasTopCorners = false),
+        CustomPrescribedDrugListItem(prescribedDrug = barPrescription, hasTopCorners = false),
+        ProtocolDrugListItem(id = 0, drugName = amlodipine10mg.name, prescribedDrug = null, hasTopCorners = false))
 
     verify(ui).populateDrugsList(drugsList)
     verify(ui).showRefillMedicineButton()

--- a/app/src/test/java/org/simple/clinic/drugs/selection/EditMedicinesScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/EditMedicinesScreenLogicTest.kt
@@ -160,15 +160,17 @@ class EditMedicinesScreenLogicTest {
         ProtocolDrugListItem(
             id = 0,
             drugName = amlodipine10mg.name,
-            prescribedDrug = amlodipine10mgPrescription),
-        CustomPrescribedDrugListItem(telmisartan9000mgPrescription),
-        CustomPrescribedDrugListItem(reesesPrescription),
-        CustomPrescribedDrugListItem(fooPrescription),
-        CustomPrescribedDrugListItem(barPrescription),
+            prescribedDrug = amlodipine10mgPrescription,
+            hasTopCorners = true),
+        CustomPrescribedDrugListItem(prescribedDrug = telmisartan9000mgPrescription, hasTopCorners = false),
+        CustomPrescribedDrugListItem(prescribedDrug = reesesPrescription, hasTopCorners = false),
+        CustomPrescribedDrugListItem(prescribedDrug = fooPrescription, hasTopCorners = false),
+        CustomPrescribedDrugListItem(prescribedDrug = barPrescription, hasTopCorners = false),
         ProtocolDrugListItem(
             id = 1,
             drugName = telmisartan40mg.name,
-            prescribedDrug = null))
+            prescribedDrug = null,
+            hasTopCorners = false))
 
     verify(ui).populateDrugsList(expectedUiModels)
   }


### PR DESCRIPTION
Without this we are getting a weird UI glitch where the top corner radius are being preserved if a new item is pushed to top.

*Reproducing steps*
- Add a dosage to protocol/custom drug to move it to top of the list
- The item that is pushed down now has top corner radius even though it's not longer the first item