### PR TITLE
Implement Search by patient identifiers in Instant Search 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 ## Next Release
+### Features
+- Add Instant Search using Patient Identifiers (Bangladesh National id, Ethiopian medical record no., etc)
+
 ### Internal
 - Move QR code scanner preview view inside `ScanSimpleIdScreen`
 - Remove dialog & sheet from navigation back stack when dismissing
@@ -8,6 +11,7 @@
 - [In Progress: 20 Jan 2021] Material Theme-ing Migration
 - [In Progress: 08 Apr 2021] Add automatic performance profiling for the Room database queries
 - Add `IndiaNationalHealthId` as an identifier in `IdentifierType`
+- Add sql query for instant search by numeric criteria
 
 ### Changes
 - Rename `Scan BP passport` button to `Scan QR code`

--- a/app/schemas/org.simple.clinic.AppDatabase/86.json
+++ b/app/schemas/org.simple.clinic.AppDatabase/86.json
@@ -1,0 +1,1590 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 86,
+    "identityHash": "5ce8e3dca7fe7a78cae91c662a190c93",
+    "entities": [
+      {
+        "tableName": "Patient",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `addressUuid` TEXT NOT NULL, `fullName` TEXT NOT NULL, `gender` TEXT NOT NULL, `dateOfBirth` TEXT, `status` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `deletedAt` TEXT, `recordedAt` TEXT NOT NULL, `syncStatus` TEXT NOT NULL, `reminderConsent` TEXT NOT NULL, `deletedReason` TEXT, `registeredFacilityId` TEXT, `assignedFacilityId` TEXT, `age_value` INTEGER, `age_updatedAt` TEXT, PRIMARY KEY(`uuid`), FOREIGN KEY(`addressUuid`) REFERENCES `PatientAddress`(`uuid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addressUuid",
+            "columnName": "addressUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gender",
+            "columnName": "gender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateOfBirth",
+            "columnName": "dateOfBirth",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "recordedAt",
+            "columnName": "recordedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reminderConsent",
+            "columnName": "reminderConsent",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedReason",
+            "columnName": "deletedReason",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "registeredFacilityId",
+            "columnName": "registeredFacilityId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "assignedFacilityId",
+            "columnName": "assignedFacilityId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "age.value",
+            "columnName": "age_value",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "age.updatedAt",
+            "columnName": "age_updatedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_Patient_addressUuid",
+            "unique": false,
+            "columnNames": [
+              "addressUuid"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Patient_addressUuid` ON `${TABLE_NAME}` (`addressUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "PatientAddress",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "addressUuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "PatientAddress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `streetAddress` TEXT, `colonyOrVillage` TEXT, `zone` TEXT, `district` TEXT NOT NULL, `state` TEXT NOT NULL, `country` TEXT, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `deletedAt` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "streetAddress",
+            "columnName": "streetAddress",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "colonyOrVillage",
+            "columnName": "colonyOrVillage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "zone",
+            "columnName": "zone",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "district",
+            "columnName": "district",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PatientPhoneNumber",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `patientUuid` TEXT NOT NULL, `number` TEXT NOT NULL, `phoneType` TEXT NOT NULL, `active` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `deletedAt` TEXT, PRIMARY KEY(`uuid`), FOREIGN KEY(`patientUuid`) REFERENCES `Patient`(`uuid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patientUuid",
+            "columnName": "patientUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneType",
+            "columnName": "phoneType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_PatientPhoneNumber_patientUuid",
+            "unique": false,
+            "columnNames": [
+              "patientUuid"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PatientPhoneNumber_patientUuid` ON `${TABLE_NAME}` (`patientUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Patient",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "patientUuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "BloodPressureMeasurement",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `syncStatus` TEXT NOT NULL, `userUuid` TEXT NOT NULL, `facilityUuid` TEXT NOT NULL, `patientUuid` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `deletedAt` TEXT, `recordedAt` TEXT NOT NULL, `systolic` INTEGER NOT NULL, `diastolic` INTEGER NOT NULL, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userUuid",
+            "columnName": "userUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "facilityUuid",
+            "columnName": "facilityUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patientUuid",
+            "columnName": "patientUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "recordedAt",
+            "columnName": "recordedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reading.systolic",
+            "columnName": "systolic",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reading.diastolic",
+            "columnName": "diastolic",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_BloodPressureMeasurement_patientUuid",
+            "unique": false,
+            "columnNames": [
+              "patientUuid"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_BloodPressureMeasurement_patientUuid` ON `${TABLE_NAME}` (`patientUuid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PrescribedDrug",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL, `dosage` TEXT, `rxNormCode` TEXT, `isDeleted` INTEGER NOT NULL, `isProtocolDrug` INTEGER NOT NULL, `patientUuid` TEXT NOT NULL, `facilityUuid` TEXT NOT NULL, `syncStatus` TEXT NOT NULL, `frequency` TEXT, `durationInDays` INTEGER, `teleconsultationId` TEXT, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `deletedAt` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dosage",
+            "columnName": "dosage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rxNormCode",
+            "columnName": "rxNormCode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isDeleted",
+            "columnName": "isDeleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isProtocolDrug",
+            "columnName": "isProtocolDrug",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patientUuid",
+            "columnName": "patientUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "facilityUuid",
+            "columnName": "facilityUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "frequency",
+            "columnName": "frequency",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "durationInDays",
+            "columnName": "durationInDays",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "teleconsultationId",
+            "columnName": "teleconsultationId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamps.createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamps.updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamps.deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_PrescribedDrug_patientUuid",
+            "unique": false,
+            "columnNames": [
+              "patientUuid"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PrescribedDrug_patientUuid` ON `${TABLE_NAME}` (`patientUuid`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Facility",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL, `facilityType` TEXT, `streetAddress` TEXT, `villageOrColony` TEXT, `district` TEXT NOT NULL, `state` TEXT NOT NULL, `country` TEXT NOT NULL, `pinCode` TEXT, `protocolUuid` TEXT, `groupUuid` TEXT, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `syncStatus` TEXT NOT NULL, `deletedAt` TEXT, `syncGroup` TEXT NOT NULL, `location_latitude` REAL, `location_longitude` REAL, `config_diabetesManagementEnabled` INTEGER NOT NULL, `config_teleconsultationEnabled` INTEGER, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "facilityType",
+            "columnName": "facilityType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "streetAddress",
+            "columnName": "streetAddress",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "villageOrColony",
+            "columnName": "villageOrColony",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "district",
+            "columnName": "district",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "country",
+            "columnName": "country",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinCode",
+            "columnName": "pinCode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "protocolUuid",
+            "columnName": "protocolUuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "groupUuid",
+            "columnName": "groupUuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "syncGroup",
+            "columnName": "syncGroup",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location.latitude",
+            "columnName": "location_latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location.longitude",
+            "columnName": "location_longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "config.diabetesManagementEnabled",
+            "columnName": "config_diabetesManagementEnabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "config.teleconsultationEnabled",
+            "columnName": "config_teleconsultationEnabled",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "LoggedInUser",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `fullName` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, `pinDigest` TEXT NOT NULL, `status` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `loggedInStatus` TEXT NOT NULL, `registrationFacilityUuid` TEXT NOT NULL, `currentFacilityUuid` TEXT NOT NULL, `teleconsultPhoneNumber` TEXT, `capability_canTeleconsult` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinDigest",
+            "columnName": "pinDigest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "loggedInStatus",
+            "columnName": "loggedInStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "registrationFacilityUuid",
+            "columnName": "registrationFacilityUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentFacilityUuid",
+            "columnName": "currentFacilityUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "teleconsultPhoneNumber",
+            "columnName": "teleconsultPhoneNumber",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "capabilities.canTeleconsult",
+            "columnName": "capability_canTeleconsult",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Appointment",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `patientUuid` TEXT NOT NULL, `facilityUuid` TEXT NOT NULL, `scheduledDate` TEXT NOT NULL, `status` TEXT NOT NULL, `cancelReason` TEXT, `remindOn` TEXT, `agreedToVisit` INTEGER, `appointmentType` TEXT NOT NULL, `syncStatus` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `deletedAt` TEXT, `creationFacilityUuid` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patientUuid",
+            "columnName": "patientUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "facilityUuid",
+            "columnName": "facilityUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scheduledDate",
+            "columnName": "scheduledDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cancelReason",
+            "columnName": "cancelReason",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "remindOn",
+            "columnName": "remindOn",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "agreedToVisit",
+            "columnName": "agreedToVisit",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "appointmentType",
+            "columnName": "appointmentType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "creationFacilityUuid",
+            "columnName": "creationFacilityUuid",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "MedicalHistory",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `patientUuid` TEXT NOT NULL, `diagnosedWithHypertension` TEXT NOT NULL, `hasHadHeartAttack` TEXT NOT NULL, `hasHadStroke` TEXT NOT NULL, `hasHadKidneyDisease` TEXT NOT NULL, `hasDiabetes` TEXT NOT NULL, `syncStatus` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `deletedAt` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patientUuid",
+            "columnName": "patientUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "diagnosedWithHypertension",
+            "columnName": "diagnosedWithHypertension",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasHadHeartAttack",
+            "columnName": "hasHadHeartAttack",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasHadStroke",
+            "columnName": "hasHadStroke",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasHadKidneyDisease",
+            "columnName": "hasHadKidneyDisease",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "diagnosedWithDiabetes",
+            "columnName": "hasDiabetes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "OngoingLoginEntry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `phoneNumber` TEXT, `pin` TEXT, `fullName` TEXT, `pinDigest` TEXT, `registrationFacilityUuid` TEXT, `status` TEXT, `createdAt` TEXT, `updatedAt` TEXT, `teleconsultPhoneNumber` TEXT, `capability_canTeleconsult` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pin",
+            "columnName": "pin",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "pinDigest",
+            "columnName": "pinDigest",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "registrationFacilityUuid",
+            "columnName": "registrationFacilityUuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "teleconsultPhoneNumber",
+            "columnName": "teleconsultPhoneNumber",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "capabilities.canTeleconsult",
+            "columnName": "capability_canTeleconsult",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Protocol",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `name` TEXT NOT NULL, `followUpDays` INTEGER NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `syncStatus` TEXT NOT NULL, `deletedAt` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "followUpDays",
+            "columnName": "followUpDays",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "ProtocolDrug",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `protocolUuid` TEXT NOT NULL, `name` TEXT NOT NULL, `rxNormCode` TEXT, `dosage` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `deletedAt` TEXT, `order` INTEGER NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`protocolUuid`) REFERENCES `Protocol`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "protocolUuid",
+            "columnName": "protocolUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rxNormCode",
+            "columnName": "rxNormCode",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "dosage",
+            "columnName": "dosage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_ProtocolDrug_protocolUuid",
+            "unique": false,
+            "columnNames": [
+              "protocolUuid"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_ProtocolDrug_protocolUuid` ON `${TABLE_NAME}` (`protocolUuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Protocol",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "protocolUuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "BusinessId",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `patientUuid` TEXT NOT NULL, `metaVersion` TEXT NOT NULL, `meta` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `deletedAt` TEXT, `identifier` TEXT NOT NULL, `identifierType` TEXT NOT NULL, PRIMARY KEY(`uuid`), FOREIGN KEY(`patientUuid`) REFERENCES `Patient`(`uuid`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patientUuid",
+            "columnName": "patientUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metaDataVersion",
+            "columnName": "metaVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metaData",
+            "columnName": "meta",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "identifier.value",
+            "columnName": "identifier",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identifier.type",
+            "columnName": "identifierType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_BusinessId_patientUuid",
+            "unique": false,
+            "columnNames": [
+              "patientUuid"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_BusinessId_patientUuid` ON `${TABLE_NAME}` (`patientUuid`)"
+          },
+          {
+            "name": "index_BusinessId_identifier",
+            "unique": false,
+            "columnNames": [
+              "identifier"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_BusinessId_identifier` ON `${TABLE_NAME}` (`identifier`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Patient",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "patientUuid"
+            ],
+            "referencedColumns": [
+              "uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "MissingPhoneReminder",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`patientUuid` TEXT NOT NULL, `remindedAt` TEXT NOT NULL, PRIMARY KEY(`patientUuid`))",
+        "fields": [
+          {
+            "fieldPath": "patientUuid",
+            "columnName": "patientUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remindedAt",
+            "columnName": "remindedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "patientUuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "BloodSugarMeasurements",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uuid` TEXT NOT NULL, `recordedAt` TEXT NOT NULL, `patientUuid` TEXT NOT NULL, `userUuid` TEXT NOT NULL, `facilityUuid` TEXT NOT NULL, `syncStatus` TEXT NOT NULL, `reading_value` TEXT NOT NULL, `reading_type` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `deletedAt` TEXT, PRIMARY KEY(`uuid`))",
+        "fields": [
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordedAt",
+            "columnName": "recordedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patientUuid",
+            "columnName": "patientUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userUuid",
+            "columnName": "userUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "facilityUuid",
+            "columnName": "facilityUuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reading.value",
+            "columnName": "reading_value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reading.type",
+            "columnName": "reading_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamps.createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamps.updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamps.deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "TextRecords",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `text` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "TeleconsultationFacilityInfo",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`teleconsultationFacilityId` TEXT NOT NULL, `facilityId` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `deletedAt` TEXT, `syncStatus` TEXT NOT NULL, PRIMARY KEY(`teleconsultationFacilityId`))",
+        "fields": [
+          {
+            "fieldPath": "teleconsultationFacilityId",
+            "columnName": "teleconsultationFacilityId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "facilityId",
+            "columnName": "facilityId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "teleconsultationFacilityId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "MedicalOfficer",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`medicalOfficerId` TEXT NOT NULL, `fullName` TEXT NOT NULL, `phoneNumber` TEXT NOT NULL, PRIMARY KEY(`medicalOfficerId`))",
+        "fields": [
+          {
+            "fieldPath": "medicalOfficerId",
+            "columnName": "medicalOfficerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullName",
+            "columnName": "fullName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phoneNumber",
+            "columnName": "phoneNumber",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "medicalOfficerId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "TeleconsultationFacilityMedicalOfficersCrossRef",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`teleconsultationFacilityId` TEXT NOT NULL, `medicalOfficerId` TEXT NOT NULL, PRIMARY KEY(`teleconsultationFacilityId`, `medicalOfficerId`))",
+        "fields": [
+          {
+            "fieldPath": "teleconsultationFacilityId",
+            "columnName": "teleconsultationFacilityId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "medicalOfficerId",
+            "columnName": "medicalOfficerId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "teleconsultationFacilityId",
+            "medicalOfficerId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "TeleconsultRecord",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `patientId` TEXT NOT NULL, `medicalOfficerId` TEXT NOT NULL, `syncStatus` TEXT NOT NULL, `request_requesterId` TEXT, `request_facilityId` TEXT, `request_requestedAt` TEXT, `request_requesterCompletionStatus` TEXT, `record_recordedAt` TEXT, `record_teleconsultationType` TEXT, `record_patientTookMedicines` TEXT, `record_patientConsented` TEXT, `record_medicalOfficerNumber` TEXT, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL, `deletedAt` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patientId",
+            "columnName": "patientId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "medicalOfficerId",
+            "columnName": "medicalOfficerId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "syncStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "teleconsultRequestInfo.requesterId",
+            "columnName": "request_requesterId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "teleconsultRequestInfo.facilityId",
+            "columnName": "request_facilityId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "teleconsultRequestInfo.requestedAt",
+            "columnName": "request_requestedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "teleconsultRequestInfo.requesterCompletionStatus",
+            "columnName": "request_requesterCompletionStatus",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "teleconsultRecordInfo.recordedAt",
+            "columnName": "record_recordedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "teleconsultRecordInfo.teleconsultationType",
+            "columnName": "record_teleconsultationType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "teleconsultRecordInfo.patientTookMedicines",
+            "columnName": "record_patientTookMedicines",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "teleconsultRecordInfo.patientConsented",
+            "columnName": "record_patientConsented",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "teleconsultRecordInfo.medicalOfficerNumber",
+            "columnName": "record_medicalOfficerNumber",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamp.createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp.updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp.deletedAt",
+            "columnName": "deletedAt",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [
+      {
+        "viewName": "OverdueAppointment",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT P.fullName, P.gender, P.dateOfBirth, P.age_value, P.age_updatedAt, P.assignedFacilityId patientAssignedFacilityUuid,\n\n          A.uuid appt_uuid, A.patientUuid appt_patientUuid, A.facilityUuid appt_facilityUuid, A.scheduledDate appt_scheduledDate, A.status appt_status,\n          A.cancelReason appt_cancelReason, A.remindOn appt_remindOn, A.agreedToVisit appt_agreedToVisit, A.appointmentType appt_appointmentType,\n          A.syncStatus appt_syncStatus, A.createdAt appt_createdAt, A.updatedAt appt_updatedAt, A.creationFacilityUuid appt_creationFacilityUuid,\n\n          PPN.uuid phone_uuid, PPN.patientUuid phone_patientUuid, PPN.number phone_number, PPN.phoneType phone_phoneType, PPN.active phone_active,\n          PPN.createdAt phone_createdAt, PPN.updatedAt phone_updatedAt,\n\n          MH.hasDiabetes diagnosedWithDiabetes, MH.diagnosedWithHypertension diagnosedWithHypertension,\n\n          (\n            CASE\n                WHEN BP.uuid IS NULL THEN BloodSugar.recordedAt\n                WHEN BloodSugar.uuid IS NULL THEN BP.recordedAt\n                ELSE MAX(BP.recordedAt, BloodSugar.recordedAt)\n            END\n          ) AS patientLastSeen,\n\n          (\n            CASE\n              WHEN BloodSugar.reading_type = 'fasting' AND CAST (BloodSugar.reading_value AS REAL) >= 200 THEN 1\n              WHEN BloodSugar.reading_type = 'random' AND CAST (BloodSugar.reading_value AS REAL) >= 300 THEN 1\n              WHEN BloodSugar.reading_type = 'post_prandial' AND CAST (BloodSugar.reading_value AS REAL) >= 300 THEN 1\n              WHEN BloodSugar.reading_type = 'hba1c' AND CAST (BloodSugar.reading_value AS REAL) >= 9 THEN 1\n              WHEN BP.systolic >= 180 OR BP.diastolic >= 110 THEN 1\n              WHEN (MH.hasHadHeartAttack = 'yes' OR MH.hasHadStroke = 'yes') AND (BP.systolic >= 140 OR BP.diastolic >= 110) \n                THEN 1 \n              ELSE 0\n            END\n          ) AS isAtHighRisk,\n          \n          PA.streetAddress patient_address_streetAddress, PA.colonyOrVillage patient_address_colonyOrVillage,\n          PA.district patient_address_district, PA.state patient_address_state,\n          \n          AF.name appointmentFacilityName\n\n          FROM Patient P\n\n          INNER JOIN Appointment A ON A.patientUuid = P.uuid\n          LEFT JOIN PatientPhoneNumber PPN ON (PPN.patientUuid = P.uuid AND PPN.deletedAt IS NULL)\n          LEFT JOIN MedicalHistory MH ON MH.patientUuid = P.uuid\n          LEFT JOIN PatientAddress PA ON PA.uuid = P.addressUuid\n\n          LEFT JOIN (\n            SELECT * FROM BloodPressureMeasurement WHERE deletedAt IS NULL GROUP BY patientUuid HAVING max(recordedAt)\n          ) BP ON BP.patientUuid = P.uuid\n\n          LEFT JOIN (\n            SELECT * FROM BloodSugarMeasurements WHERE deletedAt IS NULL GROUP BY patientUuid HAVING max(recordedAt)\n          ) BloodSugar ON BloodSugar.patientUuid = P.uuid\n          \n          LEFT JOIN Facility AF ON AF.uuid == A.facilityUuid\n          \n          WHERE \n            P.deletedAt IS NULL\n            AND A.deletedAt IS NULL\n            AND A.status = 'scheduled'\n            AND PPN.number IS NOT NULL\n            AND (BP.recordedAt IS NOT NULL OR BloodSugar.recordedAt IS NOT NULL)"
+      },
+      {
+        "viewName": "PatientSearchResult",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT P.uuid, P.fullName, P.gender, P.dateOfBirth, P.age_value, P.age_updatedAt, P.assignedFacilityId, P.status, P.createdAt, P.updatedAt, P.syncStatus, P.recordedAt,\n  PA.uuid addr_uuid, PA.streetAddress addr_streetAddress, PA.colonyOrVillage addr_colonyOrVillage, PA.zone addr_zone, PA.district addr_district,\n  PA.state addr_state, PA.country addr_country,\n  PA.createdAt addr_createdAt, PA.updatedAt addr_updatedAt,\n  PP.uuid phoneUuid, PP.number phoneNumber, PP.phoneType phoneType, PP.active phoneActive, PP.createdAt phoneCreatedAt, PP.updatedAt phoneUpdatedAt,\n  PatientLastSeen.lastSeenTime lastSeen_lastSeenOn, F.name lastSeen_lastSeenAtFacilityName, PatientLastSeen.lastSeenFacilityUuid lastSeen_lastSeenAtFacilityUuid,\n  B.identifier id_identifier, B.identifierType id_identifierType\n  FROM Patient P\n  INNER JOIN PatientAddress PA ON PA.uuid = P.addressUuid\n  LEFT JOIN PatientPhoneNumber PP ON PP.patientUuid = P.uuid\n  LEFT JOIN (\n      SELECT P.uuid patientUuid,\n      (\n          CASE\n              WHEN LatestBloodSugar.uuid IS NULL THEN LatestBP.recordedAt\n              WHEN LatestBP.uuid IS NULL THEN LatestBloodSugar.recordedAt\n              ELSE MAX(LatestBP.recordedAt, LatestBloodSugar.recordedAt)\n          END\n      ) lastSeenTime,\n      (\n          CASE\n              WHEN LatestBloodSugar.uuid IS NULL THEN LatestBP.facilityUuid\n              WHEN LatestBP.uuid IS NULL THEN LatestBloodSugar.facilityUuid\n              WHEN LatestBP.recordedAt > LatestBloodSugar.recordedAt THEN LatestBP.facilityUuid\n              ELSE LatestBloodSugar.facilityUuid\n          END\n      ) lastSeenFacilityUuid\n      FROM Patient P\n      LEFT JOIN (\n          SELECT BP.uuid, BP.patientUuid, BP.recordedAt, F.uuid facilityUuid FROM BloodPressureMeasurement BP\n          INNER JOIN Facility F ON F.uuid = BP.facilityUuid\n          WHERE BP.deletedAt IS NULL\n          GROUP BY BP.patientUuid HAVING MAX(BP.recordedAt)\n      ) LatestBP ON LatestBP.patientUuid = P.uuid\n      LEFT JOIN (\n          SELECT BloodSugar.uuid, BloodSugar.patientUuid, BloodSugar.recordedAt, F.uuid facilityUuid FROM BloodSugarMeasurements BloodSugar\n          INNER JOIN Facility F ON F.uuid = BloodSugar.facilityUuid\n          WHERE BloodSugar.deletedAt IS NULL\n          GROUP BY BloodSugar.patientUuid HAVING MAX(BloodSugar.recordedAt)\n      ) LatestBloodSugar ON LatestBloodSugar.patientUuid = P.uuid\n      WHERE LatestBP.uuid IS NOT NULL OR LatestBloodSugar.uuid IS NOT NULL\n  ) PatientLastSeen ON PatientLastSeen.patientUuid = P.uuid\n  LEFT JOIN Facility F ON F.uuid = PatientLastSeen.lastSeenFacilityUuid\n  LEFT JOIN BusinessId B ON B.patientUuid = P.uuid"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5ce8e3dca7fe7a78cae91c662a190c93')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/org/simple/clinic/storage/migrations/Migration86AndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/storage/migrations/Migration86AndroidTest.kt
@@ -1,0 +1,14 @@
+package org.simple.clinic.storage.migrations
+
+import org.junit.Test
+import org.simple.clinic.assertViewExists
+
+class Migration86AndroidTest : BaseDatabaseMigrationTest(85, 86) {
+
+  @Test
+  fun the_patient_search_result_view_should_be_added() {
+    before.assertViewExists("PatientSearchResult")
+    after.assertViewExists("PatientSearchResult")
+  }
+}
+

--- a/app/src/main/java/org/simple/clinic/AppDatabase.kt
+++ b/app/src/main/java/org/simple/clinic/AppDatabase.kt
@@ -80,7 +80,7 @@ import org.simple.clinic.util.room.UuidRoomTypeConverter
       OverdueAppointment::class,
       PatientSearchResult::class
     ],
-    version = 85,
+    version = 86,
     exportSchema = true
 )
 @TypeConverters(

--- a/app/src/main/java/org/simple/clinic/feature/Feature.kt
+++ b/app/src/main/java/org/simple/clinic/feature/Feature.kt
@@ -27,5 +27,6 @@ enum class Feature(
   OverdueCount(true, "overdue_count"),
   VillageTypeAhead(false, "village_type_ahead"),
   InstantSearchQrCode(true, "instant_search_qr_code"),
-  EthiopianCalendar(true, "ethiopian_calendar")
+  EthiopianCalendar(true, "ethiopian_calendar"),
+  InstantSearchByPatientIdentifier(false, "instant_search_by_patient_identifier")
 }

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchScreen.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchScreen.kt
@@ -30,6 +30,7 @@ import org.simple.clinic.di.injector
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.facility.alertchange.AlertFacilityChangeSheet
 import org.simple.clinic.facility.alertchange.Continuation
+import org.simple.clinic.feature.Feature.InstantSearchByPatientIdentifier
 import org.simple.clinic.feature.Feature.InstantSearchQrCode
 import org.simple.clinic.feature.Features
 import org.simple.clinic.navigation.v2.ExpectsResult
@@ -175,7 +176,7 @@ class InstantSearchScreen :
       .compose(ReportAnalyticsEvents())
       .cast<InstantSearchEvent>()
 
-  override fun createUpdate() = InstantSearchUpdate()
+  override fun createUpdate() = InstantSearchUpdate(features.isEnabled(InstantSearchByPatientIdentifier))
 
   override fun createInit() = InstantSearchInit()
 

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchUpdate.kt
@@ -12,6 +12,9 @@ import org.simple.clinic.mobius.dispatch
 import org.simple.clinic.mobius.next
 import org.simple.clinic.patient.OngoingNewPatientEntry
 import org.simple.clinic.patient.PatientSearchCriteria
+import org.simple.clinic.patient.PatientSearchCriteria.Name
+import org.simple.clinic.patient.PatientSearchCriteria.NumericCriteria
+import org.simple.clinic.patient.PatientSearchCriteria.PhoneNumber
 import org.simple.clinic.patient.businessid.Identifier
 import javax.inject.Inject
 
@@ -68,8 +71,9 @@ class InstantSearchUpdate @Inject constructor(
 
   private fun registerNewPatient(model: InstantSearchModel): Next<InstantSearchModel, InstantSearchEffect> {
     var ongoingPatientEntry = when (val searchCriteria = searchCriteriaFromInput(model.searchQuery.orEmpty(), model.additionalIdentifier)) {
-      is PatientSearchCriteria.Name -> OngoingNewPatientEntry.fromFullName(searchCriteria.patientName)
-      is PatientSearchCriteria.PhoneNumber -> OngoingNewPatientEntry.fromPhoneNumber(searchCriteria.phoneNumber)
+      is Name -> OngoingNewPatientEntry.fromFullName(searchCriteria.patientName)
+      is PhoneNumber -> OngoingNewPatientEntry.fromPhoneNumber(searchCriteria.phoneNumber)
+      is NumericCriteria -> OngoingNewPatientEntry.fromPhoneNumber(searchCriteria.numericCriteria)
     }
 
     if (model.hasAdditionalIdentifier) {
@@ -114,8 +118,20 @@ class InstantSearchUpdate @Inject constructor(
       additionalIdentifier: Identifier?
   ): PatientSearchCriteria {
     return when {
-      digitsRegex.matches(inputString) -> PatientSearchCriteria.PhoneNumber(inputString.filterNot { it.isWhitespace() }, additionalIdentifier)
-      else -> PatientSearchCriteria.Name(inputString, additionalIdentifier)
+      digitsRegex.matches(inputString) -> numericPatientSearchCriteriaBasedOnFeatureFlag(isInstantSearchByIdentifierEnabled, inputString.filterNot { it.isWhitespace() }, additionalIdentifier)
+      else -> Name(inputString, additionalIdentifier)
+    }
+  }
+
+  private fun numericPatientSearchCriteriaBasedOnFeatureFlag(
+      isInstantSearchByIdentifierEnabled: Boolean,
+      inputString: String,
+      additionalIdentifier: Identifier?
+  ): PatientSearchCriteria {
+    return if (isInstantSearchByIdentifierEnabled) {
+      NumericCriteria(inputString, additionalIdentifier)
+    } else {
+      PhoneNumber(inputString, additionalIdentifier)
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchUpdate.kt
@@ -13,8 +13,11 @@ import org.simple.clinic.mobius.next
 import org.simple.clinic.patient.OngoingNewPatientEntry
 import org.simple.clinic.patient.PatientSearchCriteria
 import org.simple.clinic.patient.businessid.Identifier
+import javax.inject.Inject
 
-class InstantSearchUpdate : Update<InstantSearchModel, InstantSearchEvent, InstantSearchEffect> {
+class InstantSearchUpdate @Inject constructor(
+    private val isInstantSearchByIdentifierEnabled: Boolean
+) : Update<InstantSearchModel, InstantSearchEvent, InstantSearchEffect> {
 
   /**
    * Regular expression that matches digits with interleaved white spaces

--- a/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
@@ -12,6 +12,7 @@ import org.simple.clinic.facility.Facility
 import org.simple.clinic.overdue.Appointment.AppointmentType.Manual
 import org.simple.clinic.overdue.Appointment.Status.Scheduled
 import org.simple.clinic.patient.PatientSearchCriteria.Name
+import org.simple.clinic.patient.PatientSearchCriteria.NumericCriteria
 import org.simple.clinic.patient.PatientSearchCriteria.PhoneNumber
 import org.simple.clinic.patient.SyncStatus.DONE
 import org.simple.clinic.patient.SyncStatus.PENDING
@@ -58,6 +59,7 @@ class PatientRepository @Inject constructor(
     return when (criteria) {
       is Name -> searchByName(criteria.patientName)
       is PhoneNumber -> searchByPhoneNumber(criteria.phoneNumber)
+      is NumericCriteria -> searchByNumericCriteria(criteria.numericCriteria)
     }
   }
 
@@ -66,6 +68,7 @@ class PatientRepository @Inject constructor(
     return when (criteria) {
       is Name -> searchByName2(criteria.patientName, facilityId)
       is PhoneNumber -> searchByPhoneNumber2(criteria.phoneNumber, facilityId)
+      is NumericCriteria -> searchByNumericCriteria2(criteria.numericCriteria, facilityId)
     }
   }
 
@@ -82,6 +85,14 @@ class PatientRepository @Inject constructor(
         clock = utcClock,
         operation = "Instant Search Patient:Loading Search Result for Facility: $facilityId") {
       database.patientSearchDao().searchByPhoneNumber2(phoneNumber, facilityId)
+    }
+  }
+
+  private fun searchByNumericCriteria2(numericCriteria: String, facilityId: UUID): List<PatientSearchResult> {
+    return reportTimeTaken(
+        clock = utcClock,
+        operation = "Instant Search Patient:Loading Search Result for Facility: $facilityId") {
+      database.patientSearchDao().searchByNumericCriteria2(numericCriteria, facilityId)
     }
   }
 
@@ -149,6 +160,12 @@ class PatientRepository @Inject constructor(
     return database
         .patientSearchDao()
         .searchByPhoneNumber(phoneNumber, config.limitOfSearchResults)
+  }
+
+  private fun searchByNumericCriteria(numericCriteria: String): List<PatientSearchResult> {
+    return database
+        .patientSearchDao()
+        .searchByNumericCriteria(numericCriteria, config.limitOfSearchResults)
   }
 
   fun patient(uuid: UUID): Observable<Optional<Patient>> {

--- a/app/src/main/java/org/simple/clinic/patient/PatientSearchCriteria.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientSearchCriteria.kt
@@ -17,4 +17,10 @@ sealed class PatientSearchCriteria(val additionalIdentifier: Identifier?) : Parc
       val phoneNumber: String,
       private val _additionalIdentifier: Identifier? = null
   ) : PatientSearchCriteria(_additionalIdentifier)
+
+  @Parcelize
+  data class NumericCriteria(
+      val numericCriteria: String,
+      private val _additionalIdentifier: Identifier? = null
+  ): PatientSearchCriteria(_additionalIdentifier)
 }

--- a/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
@@ -194,6 +194,24 @@ data class PatientSearchResult(
         ORDER BY priority ASC, phoneNumberPosition ASC
     """)
     fun searchByPhoneNumber2(phoneNumber: String, facilityId: UUID): List<PatientSearchResult>
+
+    @Query("""
+        SELECT DISTINCT
+            searchResult.*, 
+            (
+                CASE
+                    WHEN P.assignedFacilityId = :facilityId THEN 0
+                    ELSE 1
+                END
+            ) AS priority,
+            INSTR(phoneNumber, :numericCriteria) phoneNumberPosition, 
+            INSTR(id_identifier, :numericCriteria) identifierPosition FROM PatientSearchResult searchResult
+        LEFT JOIN Patient P ON P.uuid = searchResult.uuid
+        WHERE P.deletedAt IS NULL AND phoneNumberPosition > 0 OR identifierPosition > 0
+        GROUP BY P.uuid
+        ORDER BY priority ASC, phoneNumberPosition ASC, identifierPosition ASC
+        """)
+    fun searchByNumericCriteria(numericCriteria: String, facilityId: UUID): List<PatientSearchResult>
   }
 
   data class PatientNameAndId(val uuid: UUID, val fullName: String)

--- a/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
@@ -6,7 +6,8 @@ import androidx.room.DatabaseView
 import androidx.room.Embedded
 import androidx.room.Query
 import io.reactivex.Flowable
-import kotlinx.parcelize.Parcelize
+import kotlinx.android.parcel.Parcelize
+import org.simple.clinic.patient.businessid.Identifier
 import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
@@ -17,7 +18,8 @@ import java.util.UUID
   PA.state addr_state, PA.country addr_country,
   PA.createdAt addr_createdAt, PA.updatedAt addr_updatedAt,
   PP.uuid phoneUuid, PP.number phoneNumber, PP.phoneType phoneType, PP.active phoneActive, PP.createdAt phoneCreatedAt, PP.updatedAt phoneUpdatedAt,
-  PatientLastSeen.lastSeenTime lastSeen_lastSeenOn, F.name lastSeen_lastSeenAtFacilityName, PatientLastSeen.lastSeenFacilityUuid lastSeen_lastSeenAtFacilityUuid
+  PatientLastSeen.lastSeenTime lastSeen_lastSeenOn, F.name lastSeen_lastSeenAtFacilityName, PatientLastSeen.lastSeenFacilityUuid lastSeen_lastSeenAtFacilityUuid,
+  B.identifier id_identifier, B.identifierType id_identifierType
   FROM Patient P
   INNER JOIN PatientAddress PA ON PA.uuid = P.addressUuid
   LEFT JOIN PatientPhoneNumber PP ON PP.patientUuid = P.uuid
@@ -54,6 +56,7 @@ import java.util.UUID
       WHERE LatestBP.uuid IS NOT NULL OR LatestBloodSugar.uuid IS NOT NULL
   ) PatientLastSeen ON PatientLastSeen.patientUuid = P.uuid
   LEFT JOIN Facility F ON F.uuid = PatientLastSeen.lastSeenFacilityUuid
+  LEFT JOIN BusinessId B ON B.patientUuid = P.uuid
 """)
 @Parcelize
 data class PatientSearchResult(
@@ -97,7 +100,10 @@ data class PatientSearchResult(
     val phoneUpdatedAt: Instant?,
 
     @Embedded(prefix = "lastSeen_")
-    val lastSeen: LastSeen?
+    val lastSeen: LastSeen?,
+
+    @Embedded(prefix = "id_")
+    val identifier: Identifier?
 ) : Parcelable {
 
   override fun toString(): String {

--- a/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
@@ -196,6 +196,16 @@ data class PatientSearchResult(
     fun searchByPhoneNumber2(phoneNumber: String, facilityId: UUID): List<PatientSearchResult>
 
     @Query("""
+         SELECT DISTINCT * FROM 
+        PatientSearchResult searchResult
+        LEFT JOIN Patient P ON P.uuid = searchResult.uuid
+        WHERE id_identifier LIKE '%' || :numericCriteria || '%' OR phoneNumber LIKE '%' || :numericCriteria || '%'  AND P.deletedAt IS NULL
+        GROUP BY P.uuid
+        ORDER BY id_identifier, phoneNumber COLLATE NOCASE ASC LIMIT :limit
+        """)
+    fun searchByNumericCriteria(numericCriteria: String, limit: Int): List<PatientSearchResult>
+
+    @Query("""
         SELECT DISTINCT
             searchResult.*, 
             (
@@ -211,7 +221,7 @@ data class PatientSearchResult(
         GROUP BY P.uuid
         ORDER BY priority ASC, phoneNumberPosition ASC, identifierPosition ASC
         """)
-    fun searchByNumericCriteria(numericCriteria: String, facilityId: UUID): List<PatientSearchResult>
+    fun searchByNumericCriteria2(numericCriteria: String, facilityId: UUID): List<PatientSearchResult>
   }
 
   data class PatientNameAndId(val uuid: UUID, val fullName: String)

--- a/app/src/main/java/org/simple/clinic/search/results/PatientSearchResultsEvent.kt
+++ b/app/src/main/java/org/simple/clinic/search/results/PatientSearchResultsEvent.kt
@@ -21,6 +21,7 @@ data class PatientSearchResultRegisterNewPatient(
       val criteriaAnalyticsName = when (searchCriteria) {
         is PatientSearchCriteria.Name -> "Name"
         is PatientSearchCriteria.PhoneNumber -> "Phone Number"
+        is PatientSearchCriteria.NumericCriteria -> "Numeric Criteria"
       }
       return "Patient Search Results:Register New Patient:$criteriaAnalyticsName"
     }

--- a/app/src/main/java/org/simple/clinic/search/results/PatientSearchResultsScreen.kt
+++ b/app/src/main/java/org/simple/clinic/search/results/PatientSearchResultsScreen.kt
@@ -19,6 +19,7 @@ import org.simple.clinic.navigation.v2.fragments.BaseScreen
 import org.simple.clinic.newentry.PatientEntryScreenKey
 import org.simple.clinic.patient.PatientSearchCriteria
 import org.simple.clinic.patient.PatientSearchCriteria.Name
+import org.simple.clinic.patient.PatientSearchCriteria.NumericCriteria
 import org.simple.clinic.patient.PatientSearchCriteria.PhoneNumber
 import org.simple.clinic.patient.businessid.Identifier
 import org.simple.clinic.router.ScreenResultBus
@@ -126,6 +127,7 @@ class PatientSearchResultsScreen :
     return when (patientSearchCriteria) {
       is Name -> patientSearchCriteria.patientName
       is PhoneNumber -> patientSearchCriteria.phoneNumber
+      is NumericCriteria -> patientSearchCriteria.numericCriteria
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/search/results/PatientSearchResultsUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/search/results/PatientSearchResultsUpdate.kt
@@ -41,6 +41,7 @@ class PatientSearchResultsUpdate : Update<PatientSearchResultsModel, PatientSear
     var ongoingNewPatientEntry = when (searchCriteria) {
       is PatientSearchCriteria.Name -> OngoingNewPatientEntry.fromFullName(searchCriteria.patientName)
       is PatientSearchCriteria.PhoneNumber -> OngoingNewPatientEntry.fromPhoneNumber(searchCriteria.phoneNumber)
+      is PatientSearchCriteria.NumericCriteria -> OngoingNewPatientEntry.fromPhoneNumber(searchCriteria.numericCriteria)
     }
 
     if (searchCriteria.additionalIdentifier != null) {

--- a/app/src/main/java/org/simple/clinic/searchresultsview/SearchResultsEvent.kt
+++ b/app/src/main/java/org/simple/clinic/searchresultsview/SearchResultsEvent.kt
@@ -10,6 +10,7 @@ data class SearchPatientWithCriteria(val criteria: PatientSearchCriteria) : Sear
   override val analyticsName: String = when (criteria) {
     is PatientSearchCriteria.Name -> "Search Results:Search By Patient Name"
     is PatientSearchCriteria.PhoneNumber -> "Search Results:Search By Patient Phone Number"
+    is PatientSearchCriteria.NumericCriteria -> "Search Results:Search By Patient Numeric Identifier"
   }
 }
 

--- a/app/src/main/java/org/simple/clinic/storage/migrations/Migration_86.kt
+++ b/app/src/main/java/org/simple/clinic/storage/migrations/Migration_86.kt
@@ -1,0 +1,60 @@
+package org.simple.clinic.storage.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import org.simple.clinic.storage.inTransaction
+import javax.inject.Inject
+
+@Suppress("ClassName")
+class Migration_86 @Inject constructor() : Migration(85, 86) {
+  override fun migrate(database: SupportSQLiteDatabase) {
+    database.inTransaction {
+      execSQL(""" DROP VIEW "PatientSearchResult" """)
+
+      execSQL("""CREATE VIEW `PatientSearchResult` AS SELECT P.uuid, P.fullName, P.gender, P.dateOfBirth, P.age_value, P.age_updatedAt, P.assignedFacilityId, P.status, P.createdAt, P.updatedAt, P.syncStatus, P.recordedAt,
+  PA.uuid addr_uuid, PA.streetAddress addr_streetAddress, PA.colonyOrVillage addr_colonyOrVillage, PA.zone addr_zone, PA.district addr_district,
+  PA.state addr_state, PA.country addr_country,
+  PA.createdAt addr_createdAt, PA.updatedAt addr_updatedAt,
+  PP.uuid phoneUuid, PP.number phoneNumber, PP.phoneType phoneType, PP.active phoneActive, PP.createdAt phoneCreatedAt, PP.updatedAt phoneUpdatedAt,
+  PatientLastSeen.lastSeenTime lastSeen_lastSeenOn, F.name lastSeen_lastSeenAtFacilityName, PatientLastSeen.lastSeenFacilityUuid lastSeen_lastSeenAtFacilityUuid,
+  B.identifier id_identifier, B.identifierType id_identifierType
+  FROM Patient P
+  INNER JOIN PatientAddress PA ON PA.uuid = P.addressUuid
+  LEFT JOIN PatientPhoneNumber PP ON PP.patientUuid = P.uuid
+  LEFT JOIN (
+      SELECT P.uuid patientUuid,
+      (
+          CASE
+              WHEN LatestBloodSugar.uuid IS NULL THEN LatestBP.recordedAt
+              WHEN LatestBP.uuid IS NULL THEN LatestBloodSugar.recordedAt
+              ELSE MAX(LatestBP.recordedAt, LatestBloodSugar.recordedAt)
+          END
+      ) lastSeenTime,
+      (
+          CASE
+              WHEN LatestBloodSugar.uuid IS NULL THEN LatestBP.facilityUuid
+              WHEN LatestBP.uuid IS NULL THEN LatestBloodSugar.facilityUuid
+              WHEN LatestBP.recordedAt > LatestBloodSugar.recordedAt THEN LatestBP.facilityUuid
+              ELSE LatestBloodSugar.facilityUuid
+          END
+      ) lastSeenFacilityUuid
+      FROM Patient P
+      LEFT JOIN (
+          SELECT BP.uuid, BP.patientUuid, BP.recordedAt, F.uuid facilityUuid FROM BloodPressureMeasurement BP
+          INNER JOIN Facility F ON F.uuid = BP.facilityUuid
+          WHERE BP.deletedAt IS NULL
+          GROUP BY BP.patientUuid HAVING MAX(BP.recordedAt)
+      ) LatestBP ON LatestBP.patientUuid = P.uuid
+      LEFT JOIN (
+          SELECT BloodSugar.uuid, BloodSugar.patientUuid, BloodSugar.recordedAt, F.uuid facilityUuid FROM BloodSugarMeasurements BloodSugar
+          INNER JOIN Facility F ON F.uuid = BloodSugar.facilityUuid
+          WHERE BloodSugar.deletedAt IS NULL
+          GROUP BY BloodSugar.patientUuid HAVING MAX(BloodSugar.recordedAt)
+      ) LatestBloodSugar ON LatestBloodSugar.patientUuid = P.uuid
+      WHERE LatestBP.uuid IS NOT NULL OR LatestBloodSugar.uuid IS NOT NULL
+  ) PatientLastSeen ON PatientLastSeen.patientUuid = P.uuid
+  LEFT JOIN Facility F ON F.uuid = PatientLastSeen.lastSeenFacilityUuid
+  LEFT JOIN BusinessId B ON B.patientUuid = P.uuid""")
+    }
+  }
+}

--- a/app/src/main/java/org/simple/clinic/storage/migrations/RoomMigrationsModule.kt
+++ b/app/src/main/java/org/simple/clinic/storage/migrations/RoomMigrationsModule.kt
@@ -90,7 +90,8 @@ class RoomMigrationsModule {
       migration82: Migration_82,
       migration83: Migration_83,
       migration84: Migration_84,
-      migration85: Migration_85
+      migration85: Migration_85,
+      migration86: Migration_86
   ): List<Migration> {
     return listOf(
         migration_3_4,
@@ -174,7 +175,8 @@ class RoomMigrationsModule {
         migration82,
         migration83,
         migration84,
-        migration85
+        migration85,
+        migration86
     )
   }
 }

--- a/app/src/sharedTest/java/org/simple/clinic/TestData.kt
+++ b/app/src/sharedTest/java/org/simple/clinic/TestData.kt
@@ -43,6 +43,7 @@ import org.simple.clinic.patient.businessid.BusinessId
 import org.simple.clinic.patient.businessid.BusinessId.MetaDataVersion
 import org.simple.clinic.patient.businessid.BusinessId.MetaDataVersion.BpPassportMetaDataV1
 import org.simple.clinic.patient.businessid.Identifier
+import org.simple.clinic.patient.businessid.Identifier.IdentifierType.BpPassport
 import org.simple.clinic.patient.sync.BusinessIdPayload
 import org.simple.clinic.patient.sync.PatientAddressPayload
 import org.simple.clinic.patient.sync.PatientPayload
@@ -230,7 +231,7 @@ object TestData {
   fun businessId(
       uuid: UUID = UUID.randomUUID(),
       patientUuid: UUID = UUID.randomUUID(),
-      identifier: Identifier = Identifier(value = UUID.randomUUID().toString(), type = Identifier.IdentifierType.BpPassport),
+      identifier: Identifier = Identifier(value = UUID.randomUUID().toString(), type = BpPassport),
       meta: String = "",
       metaDataVersion: MetaDataVersion = BpPassportMetaDataV1,
       createdAt: Instant = Instant.now(),
@@ -336,7 +337,7 @@ object TestData {
   fun businessIdPayload(
       uuid: UUID = UUID.randomUUID(),
       identifier: String = UUID.randomUUID().toString(),
-      identifierType: Identifier.IdentifierType = Identifier.IdentifierType.BpPassport,
+      identifierType: Identifier.IdentifierType = BpPassport,
       metaDataVersion: MetaDataVersion = BpPassportMetaDataV1,
       meta: String = "",
       createdAt: Instant = Instant.now(),
@@ -1011,7 +1012,11 @@ object TestData {
           lastSeenAtFacilityName = "Some Facility",
           lastSeenAtFacilityUuid = UUID.randomUUID()
       ),
-      assignedFacilityId: UUID? = null
+      assignedFacilityId: UUID? = null,
+      identifier: Identifier = Identifier(
+          value = UUID.randomUUID().toString(),
+          type = BpPassport
+      )
   ): PatientSearchResult {
     return PatientSearchResult(
         uuid = uuid,
@@ -1031,7 +1036,8 @@ object TestData {
         phoneActive = phoneActive,
         phoneCreatedAt = phoneCreatedAt,
         phoneUpdatedAt = phoneUpdatedAt,
-        lastSeen = lastSeen
+        lastSeen = lastSeen,
+        identifier = identifier
     )
   }
 

--- a/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchUpdateTest.kt
@@ -9,15 +9,19 @@ import org.junit.Test
 import org.simple.clinic.TestData
 import org.simple.clinic.bp.assignbppassport.AddToExistingPatient
 import org.simple.clinic.bp.assignbppassport.RegisterNewPatient
+import org.simple.clinic.feature.Feature
+import org.simple.clinic.feature.Features
 import org.simple.clinic.patient.OngoingNewPatientEntry
 import org.simple.clinic.patient.PatientSearchCriteria
 import org.simple.clinic.patient.businessid.Identifier
 import org.simple.clinic.patient.businessid.Identifier.IdentifierType.BpPassport
+import org.simple.clinic.remoteconfig.DefaultValueConfigReader
+import org.simple.clinic.remoteconfig.NoOpRemoteConfigService
 import java.util.UUID
 
 class InstantSearchUpdateTest {
 
-  private val updateSpec = UpdateSpec(InstantSearchUpdate())
+  private val updateSpec = UpdateSpec(InstantSearchUpdate(true))
   private val identifier = TestData.identifier(
       value = "3e5500fe-e10e-4009-a0bb-3db9009fdef6",
       type = BpPassport

--- a/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchUpdateTest.kt
@@ -9,19 +9,15 @@ import org.junit.Test
 import org.simple.clinic.TestData
 import org.simple.clinic.bp.assignbppassport.AddToExistingPatient
 import org.simple.clinic.bp.assignbppassport.RegisterNewPatient
-import org.simple.clinic.feature.Feature
-import org.simple.clinic.feature.Features
 import org.simple.clinic.patient.OngoingNewPatientEntry
 import org.simple.clinic.patient.PatientSearchCriteria
 import org.simple.clinic.patient.businessid.Identifier
 import org.simple.clinic.patient.businessid.Identifier.IdentifierType.BpPassport
-import org.simple.clinic.remoteconfig.DefaultValueConfigReader
-import org.simple.clinic.remoteconfig.NoOpRemoteConfigService
 import java.util.UUID
 
 class InstantSearchUpdateTest {
 
-  private val updateSpec = UpdateSpec(InstantSearchUpdate(true))
+  private val updateSpec = UpdateSpec(InstantSearchUpdate(false))
   private val identifier = TestData.identifier(
       value = "3e5500fe-e10e-4009-a0bb-3db9009fdef6",
       type = BpPassport
@@ -378,6 +374,56 @@ class InstantSearchUpdateTest {
         .then(assertThatNext(
             hasNoModel(),
             hasEffects(OpenQrCodeScanner)
+        ))
+  }
+
+  @Test
+  fun `when search query is valid with a numeric criteria and instant search by patient identifier feature flag is enabled, then load search results with numeric criteria`() {
+    val updateSpec = UpdateSpec(InstantSearchUpdate(true))
+    val facility = TestData.facility(
+        uuid = UUID.fromString("f7951ae6-e6c0-4b79-bf3e-2ddd637fa7b4"),
+        name = "PHC Obvious"
+    )
+    val numericSearchQuery = "9876"
+    val searchQueryModel = defaultModel
+        .facilityLoaded(facility)
+        .searchQueryChanged(numericSearchQuery)
+
+    updateSpec
+        .given(searchQueryModel)
+        .whenEvent(SearchQueryValidated(InstantSearchValidator.Result.Valid(numericSearchQuery)))
+        .then(assertThatNext(
+            hasModel(searchQueryModel.loadingSearchResults()),
+            hasEffects(
+                HideNoPatientsInFacility,
+                HideNoSearchResults,
+                SearchWithCriteria(PatientSearchCriteria.NumericCriteria(numericSearchQuery, identifier), facility)
+            )
+        ))
+  }
+
+  @Test
+  fun `when search query is valid with a numeric criteria and instant search by patient identifier feature flag is disabled, then load search results with phone number criteria`() {
+    val updateSpec = UpdateSpec(InstantSearchUpdate(false))
+    val facility = TestData.facility(
+        uuid = UUID.fromString("f7951ae6-e6c0-4b79-bf3e-2ddd637fa7b4"),
+        name = "PHC Obvious"
+    )
+    val numericSearchQuery = "9876"
+    val searchQueryModel = defaultModel
+        .facilityLoaded(facility)
+        .searchQueryChanged(numericSearchQuery)
+
+    updateSpec
+        .given(searchQueryModel)
+        .whenEvent(SearchQueryValidated(InstantSearchValidator.Result.Valid(numericSearchQuery)))
+        .then(assertThatNext(
+            hasModel(searchQueryModel.loadingSearchResults()),
+            hasEffects(
+                HideNoPatientsInFacility,
+                HideNoSearchResults,
+                SearchWithCriteria(PatientSearchCriteria.PhoneNumber(numericSearchQuery, identifier), facility)
+            )
         ))
   }
 }


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/2225/search-by-patient-identifiers-bangladesh-national-id-etc

When user searches from a numeric criteria and wants to register a new patient/update an existing entry then they add it as a phone number. Currently this is how I've implemented this flow. Lmk if you think this is not how it should work. @vinaysshenoy 