### PR TITLE
Migrate Sentry Android to v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     - Google Services Plugin to 4.3.5
 - Enable near realtime Firebase performance monitoring ([MORE INFO](https://firebase.google.com/docs/perf-mon/troubleshooting?authuser=0&platform=android#faq-real-time-data))
 - Refactor `BpPassportSheet` to `ScannedQrCodeSheet`
+- Bump Sentry to v4.3.0
 - [In Progress: 20 Jan 2021] Material Theme-ing Migration
 
 ## On Demo

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,11 @@ android {
     proguardFiles getDefaultProguardFile(defaultProguardFile), 'proguard-rules.pro'
 
     vectorDrawables.useSupportLibrary = true
+
+    manifestPlaceholders = [
+        sentryDsn        : sentryDsn,
+        sentryEnvironment: sentryEnvironment
+    ]
   }
 
   buildTypes {

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -13,6 +13,10 @@
       android:name="firebase_performance_logcat_enabled"
       android:value="true" />
 
+    <meta-data
+      android:name="io.sentry.auto-init"
+      android:value="false" />
+
     <receiver android:name=".DebugNotificationActionReceiver" />
 
     <receiver
@@ -33,8 +37,8 @@
 
     <activity
       android:name=".WebviewTestActivity"
-      android:label="WebViewTest"
-      android:enabled="false">
+      android:enabled="false"
+      android:label="WebViewTest">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,18 @@
       android:name="com.google.mlkit.vision.DEPENDENCIES"
       android:value="barcode" />
 
+    <meta-data
+      android:name="io.sentry.dsn"
+      android:value="${sentryDsn}" />
+
+    <meta-data
+      android:name="io.sentry.environment"
+      android:value="${sentryEnvironment}" />
+
+    <meta-data
+      android:name="io.sentry.sample-rate"
+      android:value="0.75" />
+
     <activity
       android:name=".setup.SetupActivity"
       android:launchMode="singleTask"

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
       coreTesting              : '2.0.0',
       moshi                    : '1.11.0',
       retrofit                 : '2.9.0',
-      sentry                   : '1.7.22',
+      sentry                   : '4.3.0',
       sentryGradlePlugin       : '1.7.36',
       slf4j                    : '1.7.25',
       flow                     : '1.0.0-alpha3',

--- a/gradle.properties
+++ b/gradle.properties
@@ -61,3 +61,7 @@ securityFallbackApiEndpoint=do_not_change_here
 # Currently, this is only used for assembling the APK where the build process
 # strips debug symbols from the APK.
 androidNdkVersion=21.3.6528147
+
+# Sentry config
+sentryDsn=do_not_change_here
+sentryEnvironment=dev


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/3251/migrate-sentry-android-to-v4-3-0