### PR TITLE
Fix highlight color for instant search using phone number  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Bump RootBeer to v0.0.9
 - Bump AGP to v4.2.0
 - [In Progress: 20 Jan 2021] Material Theme-ing Migration
+- Add a common color resource for all search string query highlights
+
+### Fixes
+- Fix highlight color for instant search using phone number  
 
 ## 2021-05-03-7756
 ### Features

--- a/app/src/main/java/org/simple/clinic/facility/change/FacilityListItem.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/FacilityListItem.kt
@@ -74,7 +74,7 @@ sealed class FacilityListItem : ItemAdapter.Item<FacilityListItem.FacilityItemCl
       when (name) {
         is Highlighted -> {
           val highlightedName = SpannableStringBuilder(name.text)
-          val highlightColor = ContextCompat.getColor(holder.itemView.context, R.color.facility_search_query_highlight)
+          val highlightColor = ContextCompat.getColor(holder.itemView.context, R.color.search_query_highlight)
           highlightedName.setSpan(BackgroundColorSpan(highlightColor), name.highlightStart, name.highlightEnd, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
           binding.facilityNameTextView.text = highlightedName
         }

--- a/app/src/main/java/org/simple/clinic/widgets/PatientSearchResultItemView.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/PatientSearchResultItemView.kt
@@ -186,7 +186,7 @@ class PatientSearchResultItemView(
     val patientName = when (val name = getPatientName(searchQuery, model, DateOfBirth.fromPatientSearchResultViewModel(model, userClock))) {
       is Name.Highlighted -> {
         val highlightName = SpannableStringBuilder(name.patientName)
-        val highlightColor = context.resolveColor(colorRes = R.color.instant_search_query_highlight)
+        val highlightColor = context.resolveColor(colorRes = R.color.search_query_highlight)
         highlightName.setSpan(BackgroundColorSpan(highlightColor), name.highlightStart, name.highlightEnd, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
         highlightName
       }

--- a/app/src/main/java/org/simple/clinic/widgets/PatientSearchResultItemView.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/PatientSearchResultItemView.kt
@@ -142,7 +142,7 @@ class PatientSearchResultItemView(
     val patientPhoneNumber = when (val number = getPatientPhoneNumber(patientSearchResult.phoneNumber, searchQuery)) {
       is PhoneNumber.Highlighted -> {
         val highlightNumber = SpannableStringBuilder(number.patientNumber)
-        val highlightColor = context.resolveColor(colorRes = R.color.simple_light_blue_100)
+        val highlightColor = context.resolveColor(colorRes = R.color.search_query_highlight)
         highlightNumber.setSpan(BackgroundColorSpan(highlightColor), number.highlightStart, number.highlightEnd, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
         highlightNumber
       }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -33,7 +33,6 @@
 
   <color name="transparent">#00000000</color>
 
-  <color name="facility_search_query_highlight">#52FFC800</color>
-  <color name="instant_search_query_highlight">#52FFC800</color>
+  <color name="search_query_highlight">#52FFC800</color>
 
 </resources>


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/3360/if-you-do-an-instant-search-by-name-the-highlight-colour-is-yellow-but-it-s-blue-when-you-search-by-phone-number