### PR TITLE
Don't assign a reviewer if a reviewer already exist

### DIFF
--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   auto-request-review:
     name: Auto Request Review
-    if: ${{ github.event.label.name != 'work in progress' }}
+    if: |
+      github.event.label.name != 'work in progress' &&
+      github.event.pull_request.requested_reviewers[0] == null &&
+      github.event.pull_request.requested_teams[0] == null
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Request Android Devs for review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Auto request reviewer for opened and re-opened PRs
 - Update National Health ID strings
 - Remove unwanted fields in `PatientPrefillInfo`
+- Don't auto request review if a reviewer is already assigned
 
 ### Features
 - Add NHID support in `ScanSimpleIdScreen`


### PR DESCRIPTION
In certain scenarios, it's possible the auto-request review action will assign a reviewer even if one already is present. For example, when we mark a PR as a draft without removing the reviewer and mark it ready for review, the auto-request review action will run and tries to add another reviewer.