### PR TITLE
Fix progress view for manual OTP entry screen is not hidden when login fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixes
 - Fix user cannot see sync button
+- Fix progress view for manual OTP entry screen is not hidden when login fails
 
 ## 2021-05-31-7801
 ### Internal

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUpdate.kt
@@ -44,7 +44,7 @@ class EnterOtpUpdate(
     val updatedModel = model.loginFinished()
     return when (val result = event.result) {
       LoginResult.Success -> next(updatedModel, ClearLoginEntry, TriggerSync)
-      else -> next(model.loginFailed(AsyncOpError.from(result)), ClearPin as EnterOtpEffect)
+      else -> next(updatedModel.loginFailed(AsyncOpError.from(result)), ClearPin as EnterOtpEffect)
     }
   }
 

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpLogicTest.kt
@@ -247,7 +247,7 @@ class EnterOtpLogicTest {
     verify(ui).showUnexpectedError()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui).hideProgress()
+    verify(ui, times(2)).hideProgress()
     verify(uiActions).clearPin()
     verifyNoMoreInteractions(ui, uiActions)
     verify(dataSync, never()).fireAndForgetSync()
@@ -267,7 +267,7 @@ class EnterOtpLogicTest {
     verify(ui).showNetworkError()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui).hideProgress()
+    verify(ui, times(2)).hideProgress()
     verify(uiActions).clearPin()
     verifyNoMoreInteractions(ui, uiActions)
     verify(dataSync, never()).fireAndForgetSync()
@@ -288,7 +288,7 @@ class EnterOtpLogicTest {
     verify(ui).showServerError(errorMessage)
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui).hideProgress()
+    verify(ui, times(2)).hideProgress()
     verify(uiActions).clearPin()
     verifyNoMoreInteractions(ui, uiActions)
     verify(dataSync, never()).fireAndForgetSync()
@@ -308,7 +308,7 @@ class EnterOtpLogicTest {
     verify(uiActions).clearPin()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui).hideProgress()
+    verify(ui, times(2)).hideProgress()
     verify(ui).showUnexpectedError()
     verifyNoMoreInteractions(ui, uiActions)
   }
@@ -327,7 +327,7 @@ class EnterOtpLogicTest {
     verify(uiActions).clearPin()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui).hideProgress()
+    verify(ui, times(2)).hideProgress()
     verify(ui).showNetworkError()
     verifyNoMoreInteractions(ui, uiActions)
   }
@@ -346,7 +346,7 @@ class EnterOtpLogicTest {
     verify(uiActions).clearPin()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui).hideProgress()
+    verify(ui, times(2)).hideProgress()
     verify(ui).showServerError("Error")
     verifyNoMoreInteractions(ui, uiActions)
   }
@@ -396,7 +396,7 @@ class EnterOtpLogicTest {
     uiEvents.onNext(EnterOtpSubmitted(otp))
 
     // then
-    verify(ui).hideProgress()
+    verify(ui, times(2)).hideProgress()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
     verify(ui).showNetworkError()
@@ -415,7 +415,7 @@ class EnterOtpLogicTest {
     uiEvents.onNext(EnterOtpSubmitted(otp))
 
     // then
-    verify(ui).hideProgress()
+    verify(ui, times(2)).hideProgress()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
     verify(ui).showServerError("Test")
@@ -434,7 +434,7 @@ class EnterOtpLogicTest {
     uiEvents.onNext(EnterOtpSubmitted(otp))
 
     // then
-    verify(ui).hideProgress()
+    verify(ui, times(2)).hideProgress()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
     verify(ui).showUnexpectedError()
@@ -899,7 +899,7 @@ class EnterOtpLogicTest {
     verify(ongoingLoginEntryRepository, never()).clearLoginEntry()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui).hideProgress()
+    verify(ui, times(2)).hideProgress()
     verify(ui).showNetworkError()
     verify(uiActions).clearPin()
     verifyNoMoreInteractions(ui, uiActions)

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpUpdateTest.kt
@@ -1,0 +1,33 @@
+package org.simple.clinic.enterotp
+
+import com.spotify.mobius.test.NextMatchers.hasModel
+import com.spotify.mobius.test.NextMatchers.hasEffects
+import com.spotify.mobius.test.UpdateSpec
+import com.spotify.mobius.test.UpdateSpec.assertThatNext
+import org.junit.Test
+import org.simple.clinic.TestData
+import org.simple.clinic.login.LoginResult.NetworkError
+import java.util.UUID
+
+class EnterOtpUpdateTest {
+  @Test
+  fun `when the login request is completed and is unsuccessful, then finish logging in and show error`() {
+    val updateSpec = UpdateSpec(EnterOtpUpdate(loginOtpRequiredLength = 6))
+    val user = TestData.loggedInUser(uuid = UUID.fromString("6fc16e72-39a5-4568-86db-1f8b1c0c08d3"))
+    val loginStartedModel = EnterOtpModel.create()
+        .userLoaded(user)
+        .enteredOtpValid()
+        .loginStarted()
+
+    updateSpec
+        .given(loginStartedModel)
+        .whenEvent(LoginUserCompleted(NetworkError))
+        .then(
+            assertThatNext(
+                hasModel(loginStartedModel.loginFinished().loginFailed(AsyncOpError.Companion.from(NetworkError))),
+                hasEffects(ClearPin)
+            )
+        )
+
+  }
+}


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/1012/progress-view-for-manual-otp-entry-screen-is-not-hidden-when-login-fails