### PR TITLE
Bump annotation dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Deprecate `PatientRepository#search`
 - Remove RxBinding2
 - Use `ExperimentalGetImage` for `BitmapUtils#getBitmap`
+- Bump Annotation library to v1.2.0
+- Add Annotation experimental library
 
 ### Features
 - Add NHID support in `PatientEntryScreen`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -371,6 +371,7 @@ dependencies {
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}")
 
   implementation("androidx.annotation:annotation:${versions.annotation}")
+  implementation("androidx.annotation:annotation-experimental:${versions.annotationExperimental}")
 
   implementation("androidx.recyclerview:recyclerview:${versions.recyclerView}")
   implementation("com.google.android.material:material:${versions.material}")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -335,7 +335,7 @@ dependencies {
     because("not mandatory, but Truth recommends adding this dependency for better error reporting")
   }
 
-  androidTestImplementation("androidx.annotation:annotation:${versions.supportLib}")
+  androidTestImplementation("androidx.annotation:annotation:${versions.annotation}")
 
   androidTestImplementation("androidx.test:runner:${versions.androidXTest}")
   androidTestImplementation("androidx.test:rules:${versions.androidXTest}")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -370,6 +370,8 @@ dependencies {
 
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}")
 
+  implementation("androidx.annotation:annotation:${versions.annotation}")
+
   implementation("androidx.recyclerview:recyclerview:${versions.recyclerView}")
   implementation("com.google.android.material:material:${versions.material}")
   implementation("androidx.cardview:cardview:${versions.cardview}")

--- a/app/src/main/java/org/simple/clinic/util/BitmapUtils.kt
+++ b/app/src/main/java/org/simple/clinic/util/BitmapUtils.kt
@@ -22,7 +22,8 @@ import android.graphics.Matrix
 import android.graphics.Rect
 import android.graphics.YuvImage
 import android.media.Image.Plane
-import androidx.annotation.experimental.UseExperimental
+import androidx.annotation.OptIn
+import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageProxy
 import org.simple.clinic.platform.crash.CrashReporter
 import java.io.ByteArrayOutputStream
@@ -55,7 +56,7 @@ class BitmapUtils @Inject constructor(private val crashReporter: CrashReporter) 
   }
 
   /** Converts a YUV_420_888 image from CameraX API to a bitmap.  */
-  @UseExperimental(markerClass = androidx.camera.core.ExperimentalGetImage::class)
+  @OptIn(markerClass = [ExperimentalGetImage::class])
   fun getBitmap(image: ImageProxy): Bitmap? {
     val frameMetadata = FrameMetadata.Builder()
         .setWidth(image.width)

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -81,6 +81,7 @@ object Versions {
   const val threetenExtra = "1.6.0"
   const val spotless = "5.6.1"
   const val annotation = "1.2.0"
+  const val annotationExperimental = "1.1.0"
 }
 
 val versions = Versions

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -80,6 +80,7 @@ object Versions {
   const val androidXCoreKtx = "1.3.2"
   const val threetenExtra = "1.6.0"
   const val spotless = "5.6.1"
+  const val annotation = "1.2.0"
 }
 
 val versions = Versions


### PR DESCRIPTION
- Bump AndroidX annotation library to v1.2.0
- Add AndroidX annotation dependency
- Add AndroidX annotation experimental dependency
- Use `OptIn` annotation for `ExperimentalGetImage` usage in `BitmapUtils`
- Update CHANGELOG
