### PR TITLE
Prefill search query in `InstantSearchScreen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bump Room to v2.3.0
 - Bump Paging to v3.0.0
 - Use new method of SQL performance profiling (transform generated Room DAOs)
+- Prefill search query in `InstantSearchScreen`
 
 ### Changes
 - Updated translations: `hi-IN`, `bn-BD`, `te-IN`, `bn-IN`, `am-ET`, `pa-IN`, `ti-ET`, `kn-IN`, `mr-IN`, `ta-IN`, `so-ET`, `om-ET`

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchEffect.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchEffect.kt
@@ -59,3 +59,5 @@ object OpenQrCodeScanner : InstantSearchEffect()
 data class CheckIfPatientAlreadyHasAnExistingNHID(val patientId: UUID) : InstantSearchEffect()
 
 object ShowNHIDErrorDialog : InstantSearchEffect()
+
+data class PrefillSearchQuery(val searchQuery: String) : InstantSearchEffect()

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchEffectHandler.kt
@@ -46,7 +46,12 @@ class InstantSearchEffectHandler @AssistedInject constructor(
       .addAction(OpenQrCodeScanner::class.java, uiActions::openQrCodeScanner, schedulers.ui())
       .addTransformer(CheckIfPatientAlreadyHasAnExistingNHID::class.java, checkIfPatientAlreadyHasAnExistingNHID())
       .addAction(ShowNHIDErrorDialog::class.java, uiActions::showNHIDErrorDialog, schedulers.ui())
+      .addConsumer(PrefillSearchQuery::class.java, ::prefillSearchQuery, schedulers.ui())
       .build()
+
+  private fun prefillSearchQuery(effect: PrefillSearchQuery) {
+    uiActions.prefillSearchQuery(effect.searchQuery)
+  }
 
   private fun saveNewOngoingPatientEntry(): ObservableTransformer<SaveNewOngoingPatientEntry, InstantSearchEvent> {
     return ObservableTransformer { effects ->

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchInit.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchInit.kt
@@ -16,7 +16,7 @@ class InstantSearchInit : Init<InstantSearchModel, InstantSearchEffect> {
     }
 
     if (modelToEmit.hasFacility)
-      effects.add(ValidateSearchQuery(modelToEmit.searchQuery.orEmpty()))
+      effects.add(PrefillSearchQuery(modelToEmit.searchQuery.orEmpty()))
     else
       effects.add(LoadCurrentFacility)
 

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchModel.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchModel.kt
@@ -3,10 +3,10 @@ package org.simple.clinic.instantsearch
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import org.simple.clinic.facility.Facility
+import org.simple.clinic.patient.PatientPrefillInfo
 import org.simple.clinic.patient.businessid.Identifier
 import org.simple.clinic.patient.businessid.Identifier.IdentifierType.BpPassport
 import org.simple.clinic.patient.businessid.Identifier.IdentifierType.IndiaNationalHealthId
-import org.simple.clinic.patient.PatientPrefillInfo
 
 @Parcelize
 data class InstantSearchModel(
@@ -39,10 +39,11 @@ data class InstantSearchModel(
   companion object {
     fun create(
         additionalIdentifier: Identifier?,
-        patientPrefillInfo: PatientPrefillInfo?
+        patientPrefillInfo: PatientPrefillInfo?,
+        searchQuery: String?
     ) = InstantSearchModel(
         facility = null,
-        searchQuery = null,
+        searchQuery = searchQuery,
         additionalIdentifier = additionalIdentifier,
         instantSearchProgressState = null,
         scannedQrCodeSheetAlreadyOpened = false,

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchScreen.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchScreen.kt
@@ -53,6 +53,7 @@ import org.simple.clinic.util.UtcClock
 import org.simple.clinic.widgets.ItemAdapter
 import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.hideKeyboard
+import org.simple.clinic.widgets.setTextAndCursor
 import org.simple.clinic.widgets.showKeyboard
 import org.simple.clinic.widgets.visibleOrGone
 import java.time.Instant
@@ -192,8 +193,6 @@ class InstantSearchScreen :
       router.pop()
     }
 
-    searchQueryEditText.setText(screenKey.initialSearchQuery.orEmpty())
-
     qrCodeScannerButton.visibleOrGone(features.isEnabled(InstantSearchQrCode))
 
     searchResultsView.adapter = allPatientsAdapter
@@ -291,15 +290,19 @@ class InstantSearchScreen :
     router.push(ScanSimpleIdScreenKey(OpenedFrom.InstantSearchScreen))
   }
 
+  override fun showNHIDErrorDialog() {
+    NationalHealthIDErrorDialog.show(activity.supportFragmentManager)
+  }
+
+  override fun prefillSearchQuery(initialSearchQuery: String) {
+    searchQueryEditText.setTextAndCursor(initialSearchQuery)
+  }
+
   override fun onScreenResult(requestType: Parcelable, result: ScreenResult) {
     if (requestType == BlankScannedQrCode && result is Succeeded) {
       val scannedQrCodeResult = ScannedQrCodeSheet.blankScannedQrCodeResult(result)
       blankScannedQrCodeResults.onNext(BlankScannedQrCodeResultReceived(scannedQrCodeResult))
     }
-  }
-
-  override fun showNHIDErrorDialog() {
-    NationalHealthIDErrorDialog.show(activity.supportFragmentManager)
   }
 
   private fun allPatientsItemClicks(): Observable<UiEvent> {

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchScreen.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchScreen.kt
@@ -154,7 +154,7 @@ class InstantSearchScreen :
 
   private val blankScannedQrCodeResults = PublishSubject.create<UiEvent>()
 
-  override fun defaultModel() = InstantSearchModel.create(screenKey.additionalIdentifier, screenKey.patientPrefillInfo)
+  override fun defaultModel() = InstantSearchModel.create(screenKey.additionalIdentifier, screenKey.patientPrefillInfo, screenKey.initialSearchQuery)
 
   override fun uiRenderer() = InstantSearchUiRenderer(this)
 

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchUiActions.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchUiActions.kt
@@ -24,4 +24,5 @@ interface InstantSearchUiActions {
   fun showKeyboard()
   fun openQrCodeScanner()
   fun showNHIDErrorDialog()
+  fun prefillSearchQuery(initialSearchQuery: String)
 }

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchUpdate.kt
@@ -36,11 +36,7 @@ class InstantSearchUpdate @Inject constructor(
       event: InstantSearchEvent
   ): Next<InstantSearchModel, InstantSearchEffect> {
     return when (event) {
-      is CurrentFacilityLoaded -> next(
-          model.facilityLoaded(event.facility)
-              .loadingAllPatients(),
-          LoadAllPatients(event.facility)
-      )
+      is CurrentFacilityLoaded -> currentFacilityLoaded(model, event)
       is AllPatientsLoaded -> allPatientsLoaded(model, event)
       is SearchResultsLoaded -> searchResultsLoaded(model, event)
       is SearchQueryValidated -> searchQueryValidated(model, event)
@@ -53,6 +49,23 @@ class InstantSearchUpdate @Inject constructor(
       is BlankScannedQrCodeResultReceived -> blankScannedQrCodeResult(model, event)
       is OpenQrCodeScannerClicked -> dispatch(OpenQrCodeScanner)
     }
+  }
+
+  private fun currentFacilityLoaded(model: InstantSearchModel, event: CurrentFacilityLoaded): Next<InstantSearchModel, InstantSearchEffect> {
+    val facilityLoadedModel = model.facilityLoaded(event.facility)
+    val updatedModel = if (!model.hasSearchQuery) {
+      facilityLoadedModel.loadingAllPatients()
+    } else {
+      facilityLoadedModel
+    }
+
+    val effect = if (model.hasSearchQuery) {
+      PrefillSearchQuery(model.searchQuery!!)
+    } else {
+      LoadAllPatients(event.facility)
+    }
+
+    return next(updatedModel, effect)
   }
 
   private fun searchResultClicked(

--- a/app/src/main/res/layout/screen_instant_search.xml
+++ b/app/src/main/res/layout/screen_instant_search.xml
@@ -45,6 +45,7 @@
             android:textAppearance="?attr/textAppearanceBody0"
             android:textColor="?attr/colorOnSurface"
             android:textColorHint="@color/color_on_surface_67"
+            android:saveEnabled="false"
             tools:ignore="UnusedAttribute" />
 
         </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchEffectHandlerTest.kt
@@ -384,4 +384,18 @@ class InstantSearchEffectHandlerTest {
     verify(uiActions).showNHIDErrorDialog()
     verifyNoMoreInteractions(uiActions)
   }
+
+  @Test
+  fun `when prefill initial search query effect is received, then prefill instant search query`() {
+    // given
+    val initialSearchQuery = "Ramesh"
+
+    // when
+    testCase.dispatch(PrefillSearchQuery(initialSearchQuery))
+
+    // then
+    testCase.assertNoOutgoingEvents()
+    verify(uiActions).prefillSearchQuery(initialSearchQuery)
+    verifyNoMoreInteractions(uiActions)
+  }
 }

--- a/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchInitTest.kt
@@ -17,11 +17,11 @@ class InstantSearchInitTest {
       value = "f16ebf24-14fb-46c7-9b34-b49cdc1c9453",
       type = BpPassport
   )
-  private val defaultModel = InstantSearchModel.create(identifier, null)
+  private val defaultModel = InstantSearchModel.create(identifier, null, null)
 
   @Test
   fun `when screen is created, then load current facility and show keyboard`() {
-    val model = InstantSearchModel.create(additionalIdentifier = null, patientPrefillInfo = null)
+    val model = InstantSearchModel.create(additionalIdentifier = null, patientPrefillInfo = null, searchQuery = null)
 
     initSpec
         .whenInit(model)

--- a/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchInitTest.kt
@@ -41,9 +41,8 @@ class InstantSearchInitTest {
         ))
   }
 
-
   @Test
-  fun `when screen is restored and facility is loaded, then validate search query`() {
+  fun `when screen is restored and facility is loaded, then prefill search query`() {
     val facility = TestData.facility(
         uuid = UUID.fromString("df98a72b-3392-4364-80b3-c73328bafed3"),
         name = "PHC Obvious"
@@ -57,7 +56,7 @@ class InstantSearchInitTest {
         .whenInit(facilityLoadedModel)
         .then(assertThatFirst(
             hasModel(facilityLoadedModel),
-            hasEffects(ValidateSearchQuery("Pa"))
+            hasEffects(PrefillSearchQuery("Pa"))
         ))
   }
 

--- a/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchUiRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchUiRendererTest.kt
@@ -9,7 +9,7 @@ class InstantSearchUiRendererTest {
 
   private val ui = mock<InstantSearchUi>()
   private val uiRenderer = InstantSearchUiRenderer(ui)
-  private val model = InstantSearchModel.create(null, null)
+  private val model = InstantSearchModel.create(null, null, null)
 
   @Test
   fun `when the instant search progress state is in progress, then show search progress`() {

--- a/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchUpdateTest.kt
@@ -30,7 +30,7 @@ class InstantSearchUpdateTest {
   private val defaultModel = InstantSearchModel.create(identifier, null, null)
 
   @Test
-  fun `when current facility is loaded, then update the model and load all patients`() {
+  fun `when current facility is loaded and search query is not present, then update the model and load all patients`() {
     val facility = TestData.facility(
         uuid = UUID.fromString("a613b2fc-c91c-40a3-9e8b-6da7010ce51b"),
         name = "PHC Obvious"
@@ -42,6 +42,27 @@ class InstantSearchUpdateTest {
         .then(assertThatNext(
             hasModel(defaultModel.facilityLoaded(facility).loadingAllPatients()),
             hasEffects(LoadAllPatients(facility))
+        ))
+  }
+
+  @Test
+  fun `when current facility is loaded and search query is present, then update the model and prefill the search query`() {
+    val model = InstantSearchModel.create(
+        additionalIdentifier = identifier,
+        patientPrefillInfo = null,
+        searchQuery = "Pat"
+    )
+    val facility = TestData.facility(
+        uuid = UUID.fromString("a613b2fc-c91c-40a3-9e8b-6da7010ce51b"),
+        name = "PHC Obvious"
+    )
+
+    updateSpec
+        .given(model)
+        .whenEvent(CurrentFacilityLoaded(facility))
+        .then(assertThatNext(
+            hasModel(model.facilityLoaded(facility)),
+            hasEffects(PrefillSearchQuery("Pat"))
         ))
   }
 

--- a/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchUpdateTest.kt
@@ -27,7 +27,7 @@ class InstantSearchUpdateTest {
       value = "3e5500fe-e10e-4009-a0bb-3db9009fdef6",
       type = BpPassport
   )
-  private val defaultModel = InstantSearchModel.create(identifier, null)
+  private val defaultModel = InstantSearchModel.create(identifier, null, null)
 
   @Test
   fun `when current facility is loaded, then update the model and load all patients`() {
@@ -182,7 +182,7 @@ class InstantSearchUpdateTest {
         name = "PHC Obvious"
     )
     val model = InstantSearchModel
-        .create(additionalIdentifier = null, patientPrefillInfo = null)
+        .create(additionalIdentifier = null, patientPrefillInfo = null, searchQuery = null)
         .facilityLoaded(facility)
         .searchQueryChanged("Pat")
 
@@ -212,7 +212,8 @@ class InstantSearchUpdateTest {
 
     val model = InstantSearchModel
         .create(additionalIdentifier = identifier,
-            patientPrefillInfo = patientPrefillInfo)
+            patientPrefillInfo = patientPrefillInfo,
+            searchQuery = null)
         .facilityLoaded(facility)
         .searchQueryChanged("Pat")
 
@@ -234,7 +235,7 @@ class InstantSearchUpdateTest {
         name = "PHC Obvious"
     )
     val model = InstantSearchModel
-        .create(additionalIdentifier = identifier, patientPrefillInfo = null)
+        .create(additionalIdentifier = identifier, patientPrefillInfo = null, searchQuery = null)
         .facilityLoaded(facility)
         .searchQueryChanged("Pat")
 
@@ -450,7 +451,8 @@ class InstantSearchUpdateTest {
 
     val model = InstantSearchModel
         .create(additionalIdentifier = identifier,
-            patientPrefillInfo = patientPrefillInfo)
+            patientPrefillInfo = patientPrefillInfo,
+            searchQuery = null)
         .facilityLoaded(facility)
         .searchQueryChanged("Pat")
 
@@ -481,7 +483,8 @@ class InstantSearchUpdateTest {
     val model = InstantSearchModel
         .create(
             additionalIdentifier = identifier,
-            patientPrefillInfo = patientPrefillInfo)
+            patientPrefillInfo = patientPrefillInfo,
+            searchQuery = null)
         .facilityLoaded(facility)
         .searchQueryChanged("Pat")
 


### PR DESCRIPTION
- Pass initial search query when creating `InstantSearchModel`
- Add effect to prefill search query
- When current facility is loaded and search query is present then prefill search query
- Return current model from the `BaseScreen`
- Disable implicit state of search query edit text
- When screen is restored and facility is loaded, then prefill search query
- Update CHANGELOG
