### PR TITLE
Fix confirm reset pin error text visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - New supported language: Sidama [`sid-ET`]
 - Updated home screen illustrations
 
+### Fixes
+- Fix confirm reset pin error text is not hidden by default
+
 ## 2021-06-16-7826
 ### Internal
 - Implement QR code JSON parser and extracted direct Moshi usage in `ScanSimpleIdEffectHandler`

--- a/app/src/main/res/layout/screen_forgotpin_confirmpin.xml
+++ b/app/src/main/res/layout/screen_forgotpin_confirmpin.xml
@@ -107,6 +107,7 @@
         android:text="@string/forgotpin_error_pin_mismatch"
         android:textAppearance="?attr/textAppearanceBody2"
         android:textColor="?attr/colorError"
+        android:visibility="gone"
         tools:visibility="visible" />
 
       <TextView


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/3863/confirm-reset-pin-error-text-is-not-hidden-by-default