### PR TITLE
Use macos version 11.0 to run instrumentation tests on CI

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -48,7 +48,7 @@ jobs:
   # reactivecircus/android-emulator-runner@v2 requires MacOS to run on
   # https://github.com/ReactiveCircus/android-emulator-runner
   qa_android_tests:
-    runs-on: [ macos-latest ]
+    runs-on: [ macos-11.0 ]
     needs: [ qa_purge_env ]
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Show download and share buttons in overdue list
 - Show invalid json error when `NHID` number is empty or less than 14 digits   
 - Explicitly pin OkHttp version to 4.X
+- Use macos version 11.0 to run instrumentation tests on CI
 
 ### Changes
 - Updated translations: `pa-IN`, `hi-IN`, `te-IN`, `kn-IN`, `mr-IN`, `pa-IN`, `te-IN`


### PR DESCRIPTION
- Use macos version 11.0 to run instrumentation tests
- Update CHANGELOG
