### PR TITLE
Bump Kotlin to v1.5.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Paginate recent patients list
 - Pin Android emulator build version to resolve emulator timeout error
 - Fix overdue list item UI indentation
+- Bump Kotlin to v1.5.20
 
 ### Changes
 - Updated translations: `pa-IN`, `hi-IN`, `te-IN`, `kn-IN`, `mr-IN`, `pa-IN`, `te-IN`, `sid-ET`, `kn-IN`, `ta-IN`, `bn-BD`

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
   const val minSdk = 21
   const val compileSdk = 30
-  const val kotlin = "1.5.10"
+  const val kotlin = "1.5.20"
   const val agp = "4.2.1"
   const val roomMetadataGenerator = "1.2.0"
 


### PR DESCRIPTION
- Bump Kotlin to v1.5.20
- Update CHANGELOG
