### PR TITLE
Pin Android emulator build version to resolve emulator timeout error

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -65,6 +65,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 29
+          emulator-build: 6110076
           script: ./gradlew connectedQaDebugAndroidTest
 
   mobius_migration_tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Reverted] Use macos version 11.0 to run instrumentation tests on CI
 - Migrate `RecentPatientsScreen` to a fragment
 - Paginate recent patients list
+- Pin Android emulator build version to resolve emulator timeout error
 
 ### Changes
 - Updated translations: `pa-IN`, `hi-IN`, `te-IN`, `kn-IN`, `mr-IN`, `pa-IN`, `te-IN`, `sid-ET`, `kn-IN`, `ta-IN`, `bn-BD`


### PR DESCRIPTION
- Pin Android emulator build version to resolve emulator timeout error
- Update CHANGELOG
