### PR TITLE
Add Lookup API service definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next Release
 ### Features
-- [In Progress: 24 Jun 2021] Add support for finding a patient online from ID scan
+- [In Progress: 25 Jun 2021] Add support for finding a patient online from ID scan
 
 ### Internal
 - Migrate `OverdueAppointment` to add patients without phone number

--- a/app/src/main/java/org/simple/clinic/di/network/NetworkModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/network/NetworkModule.kt
@@ -17,7 +17,7 @@ import org.simple.clinic.patient.PatientStatus
 import org.simple.clinic.patient.ReminderConsent
 import org.simple.clinic.patient.businessid.BusinessId
 import org.simple.clinic.patient.businessid.Identifier
-import org.simple.clinic.patient.onlinelookup.DurationFromSecondsMoshiAdapter
+import org.simple.clinic.patient.onlinelookup.api.DurationFromSecondsMoshiAdapter
 import org.simple.clinic.patient.sync.PatientPayload
 import org.simple.clinic.remoteconfig.ConfigReader
 import org.simple.clinic.scanid.IndiaNHIDDateOfBirthMoshiAdapter

--- a/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/DurationFromSecondsMoshiAdapter.kt
+++ b/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/DurationFromSecondsMoshiAdapter.kt
@@ -1,4 +1,4 @@
-package org.simple.clinic.patient.onlinelookup
+package org.simple.clinic.patient.onlinelookup.api
 
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson

--- a/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/PatientOnlineLookupRequest.kt
+++ b/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/PatientOnlineLookupRequest.kt
@@ -1,0 +1,11 @@
+package org.simple.clinic.patient.onlinelookup.api
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PatientOnlineLookupRequest(
+
+    @Json(name = "identifier")
+    val identifier: String
+)

--- a/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/PatientOnlineLookupResponsePayload.kt
+++ b/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/PatientOnlineLookupResponsePayload.kt
@@ -2,11 +2,11 @@ package org.simple.clinic.patient.onlinelookup.api
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import org.simple.clinic.bloodsugar.BloodSugarMeasurement
-import org.simple.clinic.bp.BloodPressureMeasurement
-import org.simple.clinic.drugs.PrescribedDrug
-import org.simple.clinic.medicalhistory.MedicalHistory
-import org.simple.clinic.overdue.Appointment
+import org.simple.clinic.bloodsugar.sync.BloodSugarMeasurementPayload
+import org.simple.clinic.bp.sync.BloodPressureMeasurementPayload
+import org.simple.clinic.drugs.sync.PrescribedDrugPayload
+import org.simple.clinic.medicalhistory.sync.MedicalHistoryPayload
+import org.simple.clinic.overdue.AppointmentPayload
 import org.simple.clinic.patient.DeletedReason
 import org.simple.clinic.patient.Gender
 import org.simple.clinic.patient.PatientStatus
@@ -75,19 +75,19 @@ data class PatientOnlineLookupResponsePayload(
     val assignedFacilityId: UUID?,
 
     @Json(name = "appointments")
-    val appointments: List<Appointment>,
+    val appointments: List<AppointmentPayload>,
 
     @Json(name = "blood_pressures")
-    val bloodPressures: List<BloodPressureMeasurement>,
+    val bloodPressures: List<BloodPressureMeasurementPayload>,
 
     @Json(name = "blood_sugars")
-    val bloodSugars: List<BloodSugarMeasurement>,
+    val bloodSugars: List<BloodSugarMeasurementPayload>,
 
     @Json(name = "medical_history")
-    val medicalHistory: MedicalHistory,
+    val medicalHistory: MedicalHistoryPayload,
 
     @Json(name = "prescribed_drugs")
-    val prescribedDrugs: List<PrescribedDrug>,
+    val prescribedDrugs: List<PrescribedDrugPayload>,
 
     @Json(name = "retention")
     val retention: RecordRetention

--- a/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/PatientOnlineLookupResponsePayload.kt
+++ b/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/PatientOnlineLookupResponsePayload.kt
@@ -1,4 +1,4 @@
-package org.simple.clinic.patient.onlinelookup
+package org.simple.clinic.patient.onlinelookup.api
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass

--- a/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/RecordRetention.kt
+++ b/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/RecordRetention.kt
@@ -1,4 +1,4 @@
-package org.simple.clinic.patient.onlinelookup
+package org.simple.clinic.patient.onlinelookup.api
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass

--- a/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/RetentionType.kt
+++ b/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/RetentionType.kt
@@ -1,4 +1,4 @@
-package org.simple.clinic.patient.onlinelookup
+package org.simple.clinic.patient.onlinelookup.api
 
 import com.squareup.moshi.Json
 

--- a/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/SecondsDuration.kt
+++ b/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/SecondsDuration.kt
@@ -1,4 +1,4 @@
-package org.simple.clinic.patient.onlinelookup
+package org.simple.clinic.patient.onlinelookup.api
 
 import com.squareup.moshi.JsonQualifier
 import kotlin.annotation.Retention

--- a/app/src/main/java/org/simple/clinic/patient/sync/PatientSyncApi.kt
+++ b/app/src/main/java/org/simple/clinic/patient/sync/PatientSyncApi.kt
@@ -1,5 +1,7 @@
 package org.simple.clinic.patient.sync
 
+import org.simple.clinic.patient.onlinelookup.api.PatientOnlineLookupRequest
+import org.simple.clinic.patient.onlinelookup.api.PatientOnlineLookupResponsePayload
 import org.simple.clinic.sync.DataPushResponse
 import retrofit2.Call
 import retrofit2.http.Body
@@ -21,4 +23,9 @@ interface PatientSyncApi {
       @Query("limit") recordsToPull: Int,
       @Query("process_token") lastPullTimestamp: String? = null
   ): Call<PatientPullResponse>
+
+  @POST("v4/patients/lookup")
+  fun lookup(
+      @Body body: PatientOnlineLookupRequest
+  ): Call<PatientOnlineLookupResponsePayload>
 }

--- a/app/src/test/java/org/simple/clinic/patient/onlinelookup/RetentionMoshiAdapterTest.kt
+++ b/app/src/test/java/org/simple/clinic/patient/onlinelookup/RetentionMoshiAdapterTest.kt
@@ -3,6 +3,9 @@ package org.simple.clinic.patient.onlinelookup
 import com.google.common.truth.Truth.assertThat
 import com.squareup.moshi.Moshi
 import org.junit.Test
+import org.simple.clinic.patient.onlinelookup.api.DurationFromSecondsMoshiAdapter
+import org.simple.clinic.patient.onlinelookup.api.RecordRetention
+import org.simple.clinic.patient.onlinelookup.api.RetentionType
 import java.time.Duration
 
 class RetentionMoshiAdapterTest {


### PR DESCRIPTION
# Notes
There is a deviation between the _current_ API documentation and the one defined in the code. The relevant discussions are in these Slack threads.

- https://simpledotorg.slack.com/archives/C01P71BD3NY/p1624525771010100
- https://simpledotorg.slack.com/archives/C01P71BD3NY/p1624533709024400

https://app.clubhouse.io/simpledotorg/story/3807/add-support-for-online-patient-lookup-api