### PR TITLE
Remove dialog from history when dialog is cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Updated translations: `pa-IN`, `hi-IN`, `te-IN`, `kn-IN`, `mr-IN`, `pa-IN`, `te-IN`, `sid-ET`, `kn-IN`, `ta-IN`, `bn-BD`
 - Click on overdue patient to open patient summary
 - Show progress when loading overdue patient contact information
+- Tap outside or swipe to dismiss the bottom sheets
+- Tap outside to dismiss the dialogs
 - [In Progress: 30 Jun 2021] Added a question about hypertension treatment when creating patient
 - [In Progress: 17 Jun 2021] Overdue list improvements
   - Change overdue list UI

--- a/app/src/main/java/org/simple/clinic/contactpatient/ContactPatientBottomSheet.kt
+++ b/app/src/main/java/org/simple/clinic/contactpatient/ContactPatientBottomSheet.kt
@@ -1,15 +1,12 @@
 package org.simple.clinic.contactpatient
 
-import android.app.Dialog
 import android.content.Context
-import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
 import androidx.transition.TransitionManager
-import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.transition.MaterialFade
 import com.google.android.material.transition.MaterialSharedAxis
 import io.reactivex.Observable
@@ -42,7 +39,6 @@ import org.simple.clinic.router.screen.ActivityPermissionResult
 import org.simple.clinic.util.RequestPermissions
 import org.simple.clinic.util.RuntimePermissions
 import org.simple.clinic.util.UserClock
-import org.simple.clinic.util.overrideCancellation
 import org.simple.clinic.util.unsafeLazy
 import java.time.LocalDate
 import java.util.Locale
@@ -145,14 +141,6 @@ class ContactPatientBottomSheet : BaseBottomSheet<
     super.onAttach(context)
 
     context.injector<Injector>().inject(this)
-  }
-
-  override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-    val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
-
-    dialog.overrideCancellation(::backPressed)
-
-    return dialog
   }
 
   override fun onRequestPermissionsResult(

--- a/app/src/main/java/org/simple/clinic/datepicker/calendar/CalendarDatePicker.kt
+++ b/app/src/main/java/org/simple/clinic/datepicker/calendar/CalendarDatePicker.kt
@@ -13,7 +13,6 @@ import org.simple.clinic.navigation.v2.Router
 import org.simple.clinic.navigation.v2.ScreenKey
 import org.simple.clinic.navigation.v2.Succeeded
 import org.simple.clinic.util.UserClock
-import org.simple.clinic.util.overrideCancellation
 import org.simple.clinic.util.toUtcInstant
 import org.simple.clinic.util.unsafeLazy
 import java.time.LocalDate
@@ -37,7 +36,6 @@ class CalendarDatePicker : DialogFragment() {
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
     val dialog = datePickerDialog()
 
-    dialog.overrideCancellation(::backPressed)
     dialog.setButton(BUTTON_NEGATIVE, getString(android.R.string.cancel)) { _, _ -> backPressed() }
 
     return dialog

--- a/app/src/main/java/org/simple/clinic/datepicker/calendar/CalendarDatePicker.kt
+++ b/app/src/main/java/org/simple/clinic/datepicker/calendar/CalendarDatePicker.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.datepicker.calendar
 import android.app.DatePickerDialog
 import android.app.Dialog
 import android.content.Context
+import android.content.DialogInterface
 import android.content.DialogInterface.BUTTON_NEGATIVE
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
@@ -39,6 +40,11 @@ class CalendarDatePicker : DialogFragment() {
     dialog.setButton(BUTTON_NEGATIVE, getString(android.R.string.cancel)) { _, _ -> backPressed() }
 
     return dialog
+  }
+
+  override fun onCancel(dialog: DialogInterface) {
+    backPressed()
+    super.onCancel(dialog)
   }
 
   private fun datePickerDialog(): DatePickerDialog {

--- a/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseBottomSheet.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseBottomSheet.kt
@@ -24,7 +24,6 @@ import org.simple.clinic.mobius.ViewRenderer
 import org.simple.clinic.mobius.eventSources
 import org.simple.clinic.mobius.first
 import org.simple.clinic.navigation.v2.ScreenKey
-import org.simple.clinic.util.overrideCancellation
 import org.simple.clinic.util.unsafeLazy
 
 abstract class BaseBottomSheet<K : ScreenKey, B : ViewBinding, M : Parcelable, E, F> : BottomSheetDialogFragment() {
@@ -94,11 +93,6 @@ abstract class BaseBottomSheet<K : ScreenKey, B : ViewBinding, M : Parcelable, E
 
     behavior = dialog.behavior
     behavior?.addBottomSheetCallback(bottomSheetCallback)
-
-    // This is needed because the router is not aware of the changes
-    // in the history when the bottom sheet dialog is dismissed in the
-    // normal fashion.
-    dialog.overrideCancellation(::backPressed)
 
     return dialog
   }

--- a/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseBottomSheet.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseBottomSheet.kt
@@ -53,8 +53,9 @@ abstract class BaseBottomSheet<K : ScreenKey, B : ViewBinding, M : Parcelable, E
   private var behavior: BottomSheetBehavior<FrameLayout>? = null
   private val bottomSheetCallback = object : BottomSheetBehavior.BottomSheetCallback() {
     override fun onStateChanged(bottomSheet: View, newState: Int) {
-      if (newState == BottomSheetBehavior.STATE_DRAGGING) {
-        behavior?.state = BottomSheetBehavior.STATE_EXPANDED
+      if (newState == BottomSheetBehavior.STATE_HIDDEN) {
+        backPressed()
+        dismiss()
       }
     }
 

--- a/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseBottomSheet.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseBottomSheet.kt
@@ -1,6 +1,7 @@
 package org.simple.clinic.navigation.v2.fragments
 
 import android.app.Dialog
+import android.content.DialogInterface
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
@@ -136,8 +137,8 @@ abstract class BaseBottomSheet<K : ScreenKey, B : ViewBinding, M : Parcelable, E
     outState.putParcelable(KEY_MODEL, controller.model)
   }
 
-  override fun dismiss() {
+  override fun onCancel(dialog: DialogInterface) {
     backPressed()
-    super.dismiss()
+    super.onCancel(dialog)
   }
 }

--- a/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
@@ -18,7 +18,6 @@ import org.simple.clinic.mobius.ViewRenderer
 import org.simple.clinic.mobius.eventSources
 import org.simple.clinic.mobius.first
 import org.simple.clinic.navigation.v2.ScreenKey
-import org.simple.clinic.util.overrideCancellation
 import org.simple.clinic.util.unsafeLazy
 
 abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F, R : ViewRenderer<M>> : DialogFragment() {
@@ -56,14 +55,7 @@ abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F, R : ViewRenderer<
   open fun additionalEventSources(): List<EventSource<E>> = emptyList()
 
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-    val dialog = createDialog(savedInstanceState)
-
-    // This is needed because the router is not aware of the changes
-    // in the history when the bottom sheet dialog is dismissed in the
-    // normal fashion.
-    dialog.overrideCancellation(::backPressed)
-
-    return dialog
+    return createDialog(savedInstanceState)
   }
 
   private fun backPressed() {

--- a/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
@@ -1,6 +1,7 @@
 package org.simple.clinic.navigation.v2.fragments
 
 import android.app.Dialog
+import android.content.DialogInterface
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.View
@@ -94,8 +95,8 @@ abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F, R : ViewRenderer<
     outState.putParcelable(KEY_MODEL, controller.model)
   }
 
-  override fun dismiss() {
+  override fun onCancel(dialog: DialogInterface) {
     backPressed()
-    super.dismiss()
+    super.onCancel(dialog)
   }
 }

--- a/app/src/main/java/org/simple/clinic/util/AndroidExtensions.kt
+++ b/app/src/main/java/org/simple/clinic/util/AndroidExtensions.kt
@@ -64,16 +64,3 @@ private fun Configuration.isLocaleAlreadyOverriden(): Boolean {
     else -> false
   }
 }
-
-inline fun Dialog.overrideCancellation(crossinline backPressed: () -> Unit) {
-  setCancelable(false)
-  setCanceledOnTouchOutside(false)
-  setOnKeyListener { _, keyCode, event ->
-    if (event.action == KeyEvent.ACTION_UP && keyCode == KeyEvent.KEYCODE_BACK) {
-      backPressed()
-      true
-    } else {
-      false
-    }
-  }
-}


### PR DESCRIPTION
- Remove `overrideCancellation` usage in `BaseBottomSheet`
- Trigger backpress to remove bottom sheet from navigation router when `onCancel` is called
- When bottom sheet is swiped down, then trigger backpress on navigation router
- Remove `overrideCancellation` usage in `ContactPatientBottomSheet`
- Remove `overrideCancellation` usage in `BaseDialog`
- Trigger router backpress when `onCancel` is called
- Remove `overrideCancellation` usage in `CalendarDatePicker`
- Trigger router backpress when `onCancel` is called
- Remove `overrideCancellation` extension
- Update CHANGELOG
