### PR TITLE
Add support for registering a patient in tests at a specific facility

### DIFF
--- a/app/src/androidTest/java/org/simple/clinic/di/TestAppComponent.kt
+++ b/app/src/androidTest/java/org/simple/clinic/di/TestAppComponent.kt
@@ -21,6 +21,7 @@ import org.simple.clinic.protocolv2.sync.ProtocolSyncAndroidTest
 import org.simple.clinic.rules.LocalAuthenticationRule
 import org.simple.clinic.rules.RegisterPatientRule
 import org.simple.clinic.rules.ServerAuthenticationRule
+import org.simple.clinic.rules.ServerRegistrationAtFacilityRule
 import org.simple.clinic.security.pin.BruteForceProtectionAndroidTest
 import org.simple.clinic.signature.SignatureRepositoryAndroidTest
 import org.simple.clinic.storage.DaoWithUpsertAndroidTest
@@ -110,4 +111,5 @@ interface TestAppComponent {
   fun inject(target: TeleconsultRecordRepositoryAndroidTest)
   fun inject(target: TeleconsultRecordSyncIntegrationTest)
   fun inject(target: DeleteSyncGroupDatabaseAndroidTest)
+  fun inject(target: ServerRegistrationAtFacilityRule)
 }

--- a/app/src/androidTest/java/org/simple/clinic/rules/ServerRegistrationAtFacilityRule.kt
+++ b/app/src/androidTest/java/org/simple/clinic/rules/ServerRegistrationAtFacilityRule.kt
@@ -1,0 +1,134 @@
+package org.simple.clinic.rules
+
+import android.app.Application
+import android.content.SharedPreferences
+import com.google.common.truth.Truth.assertThat
+import io.bloco.faker.components.PhoneNumber
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import org.simple.clinic.AppDatabase
+import org.simple.clinic.TestClinicApp
+import org.simple.clinic.TestData
+import org.simple.clinic.facility.Facility
+import org.simple.clinic.facility.FacilityPullResult
+import org.simple.clinic.facility.FacilitySync
+import org.simple.clinic.security.PasswordHasher
+import org.simple.clinic.user.User
+import org.simple.clinic.user.UserSession
+import org.simple.clinic.user.UserStatus
+import org.simple.clinic.user.registeruser.RegisterUser
+import org.simple.clinic.user.registeruser.RegistrationResult
+import org.simple.clinic.util.toNullable
+import javax.inject.Inject
+import javax.inject.Named
+
+/**
+ * Runs every test with an actual user on the server at a specific facility.
+ **/
+class ServerRegistrationAtFacilityRule : TestRule {
+
+  @Inject
+  lateinit var userSession: UserSession
+
+  @Inject
+  lateinit var testData: TestData
+
+  @Inject
+  lateinit var facilitySync: FacilitySync
+
+  @Inject
+  lateinit var fakePhoneNumber: PhoneNumber
+
+  @Inject
+  lateinit var appDatabase: AppDatabase
+
+  @Inject
+  lateinit var sharedPreferences: SharedPreferences
+
+  @Inject
+  lateinit var application: Application
+
+  @Inject
+  lateinit var registerUser: RegisterUser
+
+  @Inject
+  lateinit var passwordHasher: PasswordHasher
+
+  @Inject
+  @Named("user_pin")
+  lateinit var userPin: String
+
+  override fun apply(base: Statement, description: Description): Statement {
+    return object : Statement() {
+      override fun evaluate() {
+        TestClinicApp.appComponent().inject(this@ServerRegistrationAtFacilityRule)
+        try {
+          ensureLoggedInUser()
+          base.evaluate()
+        } finally {
+          clearData()
+        }
+      }
+    }
+  }
+
+  private fun ensureLoggedInUser() {
+    ensureFacilities()
+    register()
+  }
+
+  private fun ensureFacilities() {
+    val result = facilitySync.pullWithResult()
+
+    assertThat(result).isEqualTo(FacilityPullResult.Success)
+  }
+
+  private fun register() {
+    val registerFacilityAt = getFirstStoredFacility()
+
+    val registrationResult = registerUserAtFacility(registerFacilityAt)
+    if (registrationResult !is RegistrationResult.Success) {
+      throw RuntimeException("Could not register user because: $registrationResult")
+    }
+
+    verifyAccessTokenIsPresent()
+    verifyUserCanSyncData()
+  }
+
+  private fun getFirstStoredFacility(): Facility {
+    return appDatabase
+        .facilityDao()
+        .all()
+        .blockingFirst()
+        .first()
+  }
+
+  private fun registerUserAtFacility(facility: Facility): RegistrationResult {
+    val user = testData.loggedInUser(
+        phone = fakePhoneNumber.phoneNumber(),
+        pinDigest = passwordHasher.hash(userPin),
+        currentFacilityUuid = facility.uuid,
+        registrationFacilityUuid = facility.uuid
+    )
+
+    return registerUser.registerUserAtFacility(user).blockingGet()
+  }
+
+  private fun verifyAccessTokenIsPresent() {
+    val accessToken = userSession.accessToken().toNullable()
+    assertThat(accessToken).isNotNull()
+  }
+
+  private fun verifyUserCanSyncData() {
+    val loggedInUser = userSession.loggedInUser().blockingFirst().get()
+    assertThat(userSession.isUserPresentLocally()).isTrue()
+    assertThat(loggedInUser.status).isEqualTo(UserStatus.ApprovedForSyncing)
+    assertThat(loggedInUser.loggedInStatus).isEqualTo(User.LoggedInStatus.LOGGED_IN)
+  }
+
+  private fun clearData() {
+    sharedPreferences.edit().clear().commit()
+    appDatabase.clearAllTables()
+  }
+}


### PR DESCRIPTION
Currently, the `ServerAuthenticationRule` in the instrumented tests registers a user at the first stored facility. This worked for us until recently, but for the patient online lookup feature requires specific conditions to verify that it's working as expect. See https://simpledotorg.slack.com/archives/C01P71BD3NY/p1625037760002300 for more details.

This PR is to add a rule that we can then use in integration tests where specific conditions are required for registering a patient.

https://app.clubhouse.io/simpledotorg/story/3948/create-use-case-to-query-the-online-lookup-api-and-save-the-patient-profile