### PR TITLE
Bump AGP to v4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Remove unnecessary method from `Analytics`
 - Bump dependencies for [Flipper](https://fbflipper.com)
 - Bump `com.github.egslava:edittext-mask` -> '1.0.7'
+- Bump AGP to v4.2.2
 
 ### Changes
 - Updated translations: `pa-IN`, `hi-IN`, `te-IN`, `kn-IN`, `mr-IN`, `te-IN`, `sid-ET`, `kn-IN`, `ta-IN`, `bn-BD`, `bn_IN`, `so-ET`, `ti-ET`, `am-ET`, `ta-LK`

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -2,7 +2,7 @@ object Versions {
   const val minSdk = 21
   const val compileSdk = 30
   const val kotlin = "1.5.20"
-  const val agp = "4.2.1"
+  const val agp = "4.2.2"
   const val roomMetadataGenerator = "1.2.0"
 
   const val supportLib = "1.0.0"


### PR DESCRIPTION
**Release notes**: https://androidstudio.googleblog.com/2021/06/android-studio-422-available.html