### PR TITLE
Migrate `BloodPressureHistoryScreen` to a fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bump sqlite-android version to 3.36.0
 - Add `minWidth` for phone number text input layout in `screen_registration_phone`
 - Add `Drug`s table
+- Migrate `BloodPressureHistoryScreen` to a fragment
 
 ### Features
 - [In Progress: 06 Jul 2021] Add support for finding a patient online from ID scan

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
@@ -128,7 +128,7 @@ class BloodPressureHistoryScreen : BaseScreen<
 
   override fun onAttach(context: Context) {
     super.onAttach(context)
-    context.injector<BloodPressureHistoryScreenInjector>().inject(this)
+    context.injector<Injector>().inject(this)
   }
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
@@ -11,6 +11,7 @@ import com.jakewharton.rxbinding3.view.detaches
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
 import io.reactivex.rxkotlin.ofType
+import kotlinx.parcelize.Parcelize
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.bp.BloodPressureHistoryListItemDataSourceFactory
@@ -24,6 +25,7 @@ import org.simple.clinic.databinding.ScreenBpHistoryBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.navigation.v2.Router
+import org.simple.clinic.navigation.v2.ScreenKey
 import org.simple.clinic.navigation.v2.keyprovider.ScreenKeyProvider
 import org.simple.clinic.patient.DateOfBirth
 import org.simple.clinic.patient.Gender
@@ -211,5 +213,14 @@ class BloodPressureHistoryScreen(
         .ofType<BloodPressureHistoryItemClicked>()
         .map { it.measurement }
         .map(::BloodPressureClicked)
+  }
+
+  @Parcelize
+  data class Key(
+      val patientId: UUID,
+      override val analyticsName: String = "Blood Pressure History"
+  ) : ScreenKey() {
+
+    override fun instantiateFragment() = BloodPressureHistoryScreen()
   }
 }

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
@@ -1,8 +1,11 @@
 package org.simple.clinic.bp.history
 
 import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.paging.PagedList
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -145,6 +148,18 @@ class BloodPressureHistoryScreen : BaseScreen<
       container: ViewGroup?
   ) = ScreenBpHistoryBinding.inflate(layoutInflater, container, false)
 
+  override fun onAttach(context: Context) {
+    super.onAttach(context)
+    context.injector<BloodPressureHistoryScreenInjector>().inject(this)
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+
+    setupBloodPressureHistoryList()
+    handleToolbarBackClick()
+  }
+
   override fun onFinishInflate() {
     super.onFinishInflate()
     if (isInEditMode) {
@@ -152,8 +167,6 @@ class BloodPressureHistoryScreen : BaseScreen<
     }
     context.injector<BloodPressureHistoryScreenInjector>().inject(this)
 
-    setupBloodPressureHistoryList()
-    handleToolbarBackClick()
   }
 
   override fun onAttachedToWindow() {

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
@@ -189,11 +189,11 @@ class BloodPressureHistoryScreen : BaseScreen<
 
   private fun setupBloodPressureHistoryList() {
     val dividerMargin = 8.dp
-    val divider = DividerItemDecorator(context = context, marginStart = dividerMargin, marginEnd = dividerMargin)
+    val divider = DividerItemDecorator(context = requireContext(), marginStart = dividerMargin, marginEnd = dividerMargin)
 
     bpHistoryList.apply {
       setHasFixedSize(true)
-      layoutManager = LinearLayoutManager(context)
+      layoutManager = LinearLayoutManager(requireContext())
       addItemDecoration(divider)
       adapter = bloodPressureHistoryAdapter
     }
@@ -211,13 +211,13 @@ class BloodPressureHistoryScreen : BaseScreen<
   }
 
   override fun openBloodPressureEntrySheet(patientUuid: UUID) {
-    val intent = BloodPressureEntrySheet.intentForNewBp(context, patientUuid)
-    context.startActivity(intent)
+    val intent = BloodPressureEntrySheet.intentForNewBp(requireContext(), patientUuid)
+    requireContext().startActivity(intent)
   }
 
   override fun openBloodPressureUpdateSheet(bpUuid: UUID) {
-    val intent = BloodPressureEntrySheet.intentForUpdateBp(context, bpUuid)
-    context.startActivity(intent)
+    val intent = BloodPressureEntrySheet.intentForUpdateBp(requireContext(), bpUuid)
+    requireContext().startActivity(intent)
   }
 
   @SuppressLint("CheckResult")

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
@@ -3,7 +3,6 @@ package org.simple.clinic.bp.history
 import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
-import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -25,7 +24,6 @@ import org.simple.clinic.databinding.ListBpHistoryItemBinding
 import org.simple.clinic.databinding.ListNewBpButtonBinding
 import org.simple.clinic.databinding.ScreenBpHistoryBinding
 import org.simple.clinic.di.injector
-import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.navigation.v2.Router
 import org.simple.clinic.navigation.v2.ScreenKey
 import org.simple.clinic.navigation.v2.fragments.BaseScreen
@@ -37,7 +35,6 @@ import org.simple.clinic.patient.displayLetterRes
 import org.simple.clinic.summary.PatientSummaryConfig
 import org.simple.clinic.util.UserClock
 import org.simple.clinic.util.UtcClock
-import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.widgets.DividerItemDecorator
 import org.simple.clinic.widgets.PagingItemAdapter_old
 import org.simple.clinic.widgets.dp
@@ -95,30 +92,6 @@ class BloodPressureHistoryScreen : BaseScreen<
       )
   )
 
-  private val events: Observable<BloodPressureHistoryScreenEvent> by unsafeLazy {
-    Observable
-        .merge(
-            addNewBpClicked(),
-            bloodPressureClicked()
-        )
-        .compose(ReportAnalyticsEvents())
-        .cast()
-  }
-
-  private val uiRenderer = BloodPressureHistoryScreenUiRenderer(this)
-
-  private val delegate: MobiusDelegate<BloodPressureHistoryScreenModel, BloodPressureHistoryScreenEvent, BloodPressureHistoryScreenEffect> by unsafeLazy {
-    val screenKey = screenKeyProvider.keyFor<BloodPressureHistoryScreenKey>(this)
-    MobiusDelegate.forView(
-        events = events,
-        defaultModel = BloodPressureHistoryScreenModel.create(screenKey.patientUuid),
-        init = BloodPressureHistoryScreenInit(),
-        update = BloodPressureHistoryScreenUpdate(),
-        effectHandler = effectHandler.create(this).build(),
-        modelUpdateListener = uiRenderer::render
-    )
-  }
-
   private val bpHistoryList
     get() = binding.bpHistoryList
 
@@ -158,33 +131,6 @@ class BloodPressureHistoryScreen : BaseScreen<
 
     setupBloodPressureHistoryList()
     handleToolbarBackClick()
-  }
-
-  override fun onFinishInflate() {
-    super.onFinishInflate()
-    if (isInEditMode) {
-      return
-    }
-    context.injector<BloodPressureHistoryScreenInjector>().inject(this)
-
-  }
-
-  override fun onAttachedToWindow() {
-    super.onAttachedToWindow()
-    delegate.start()
-  }
-
-  override fun onDetachedFromWindow() {
-    delegate.stop()
-    super.onDetachedFromWindow()
-  }
-
-  override fun onSaveInstanceState(): Parcelable? {
-    return delegate.onSaveInstanceState(super.onSaveInstanceState())
-  }
-
-  override fun onRestoreInstanceState(state: Parcelable?) {
-    super.onRestoreInstanceState(delegate.onRestoreInstanceState(state))
   }
 
   private fun setupBloodPressureHistoryList() {

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
@@ -218,4 +218,8 @@ class BloodPressureHistoryScreen : BaseScreen<
 
     override fun instantiateFragment() = BloodPressureHistoryScreen()
   }
+
+  interface Injector {
+    fun inject(target: BloodPressureHistoryScreen)
+  }
 }

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenInjector.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenInjector.kt
@@ -1,5 +1,0 @@
-package org.simple.clinic.bp.history
-
-interface BloodPressureHistoryScreenInjector {
-  fun inject(target: BloodPressureHistoryScreen)
-}

--- a/app/src/main/java/org/simple/clinic/main/TheActivityComponent.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityComponent.kt
@@ -10,7 +10,7 @@ import io.reactivex.Observable
 import org.simple.clinic.activity.ActivityLifecycle
 import org.simple.clinic.activity.RxActivityLifecycle
 import org.simple.clinic.bloodsugar.history.BloodSugarHistoryScreenInjector
-import org.simple.clinic.bp.history.BloodPressureHistoryScreenInjector
+import org.simple.clinic.bp.history.BloodPressureHistoryScreen
 import org.simple.clinic.contactpatient.ContactPatientBottomSheet
 import org.simple.clinic.contactpatient.views.SetAppointmentReminderView
 import org.simple.clinic.datepicker.calendar.CalendarDatePicker
@@ -79,7 +79,7 @@ interface TheActivityComponent :
     MedicalHistorySummaryViewInjector,
     DrugSummaryViewInjector,
     BloodSugarSummaryViewInjector,
-    BloodPressureHistoryScreenInjector,
+    BloodPressureHistoryScreen.Injector,
     BloodPressureSummaryViewInjector,
     BloodSugarHistoryScreenInjector,
     AccessDeniedScreenInjector,

--- a/app/src/main/java/org/simple/clinic/summary/bloodpressures/view/BloodPressureSummaryView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/bloodpressures/view/BloodPressureSummaryView.kt
@@ -18,7 +18,7 @@ import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.bp.BloodPressureMeasurement
 import org.simple.clinic.bp.entry.BloodPressureEntrySheet
-import org.simple.clinic.bp.history.BloodPressureHistoryScreenKey
+import org.simple.clinic.bp.history.BloodPressureHistoryScreen
 import org.simple.clinic.databinding.PatientsummaryBpsummaryContentBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.facility.Facility
@@ -26,7 +26,6 @@ import org.simple.clinic.facility.alertchange.AlertFacilityChangeSheet
 import org.simple.clinic.facility.alertchange.Continuation.ContinueToActivity
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.navigation.v2.Router
-import org.simple.clinic.navigation.v2.compat.wrap
 import org.simple.clinic.navigation.v2.keyprovider.ScreenKeyProvider
 import org.simple.clinic.router.ScreenResultBus
 import org.simple.clinic.router.screen.ActivityResult
@@ -231,7 +230,7 @@ class BloodPressureSummaryView(
   }
 
   override fun showBloodPressureHistoryScreen(patientUuid: UUID) {
-    router.push(BloodPressureHistoryScreenKey(patientUuid).wrap())
+    router.push(BloodPressureHistoryScreen.Key(patientUuid))
   }
 
   override fun registerSummaryModelUpdateCallback(callback: PatientSummaryModelUpdateCallback?) {

--- a/app/src/main/res/layout/screen_bp_history.xml
+++ b/app/src/main/res/layout/screen_bp_history.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<org.simple.clinic.bp.history.BloodPressureHistoryScreen xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
@@ -36,4 +36,4 @@
 
   </com.google.android.material.card.MaterialCardView>
 
-</org.simple.clinic.bp.history.BloodPressureHistoryScreen>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- Use `ConstraintLayout` as parent in `screen_bp_history`
- Add `ScreenKey` in `BloodPressureHistoryScreen`
- Use new `BloodPressureHistoryScreen.Key` for opening blood pressure history screen
- Extend `BaseScreen` in `BloodPressureHistoryScreen`
- Override lifecycle methods of the fragment
- Use `requireContext` instead of `context
- Remove unused code
- Replace `detaches` usage with `viewLifecycleOwnerLiveData`
- Update CHANGELOG
