### PR TITLE
Fix `ContactPatientBottomSheet` not going back to call patient view on back click in call later mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   
 ### Fixes
 - Fix invalid qr code error when scanning a valid Indian NHID
+- Fix `ContactPatientBottomSheet` not going back to call patient view on back click in call later mode
   
 ## On Demo
 ### Internal

--- a/app/src/main/java/org/simple/clinic/contactpatient/ContactPatientBottomSheet.kt
+++ b/app/src/main/java/org/simple/clinic/contactpatient/ContactPatientBottomSheet.kt
@@ -1,6 +1,8 @@
 package org.simple.clinic.contactpatient
 
+import android.app.Dialog
 import android.content.Context
+import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View.GONE
@@ -39,6 +41,7 @@ import org.simple.clinic.router.screen.ActivityPermissionResult
 import org.simple.clinic.util.RequestPermissions
 import org.simple.clinic.util.RuntimePermissions
 import org.simple.clinic.util.UserClock
+import org.simple.clinic.util.onBackPressed
 import org.simple.clinic.util.unsafeLazy
 import java.time.LocalDate
 import java.util.Locale
@@ -141,6 +144,12 @@ class ContactPatientBottomSheet : BaseBottomSheet<
     super.onAttach(context)
 
     context.injector<Injector>().inject(this)
+  }
+
+  override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+    return super.onCreateDialog(savedInstanceState).apply {
+      onBackPressed(::backPressed)
+    }
   }
 
   override fun onRequestPermissionsResult(

--- a/app/src/main/java/org/simple/clinic/util/AndroidExtensions.kt
+++ b/app/src/main/java/org/simple/clinic/util/AndroidExtensions.kt
@@ -64,3 +64,14 @@ private fun Configuration.isLocaleAlreadyOverriden(): Boolean {
     else -> false
   }
 }
+
+inline fun Dialog.onBackPressed(crossinline backPressed: () -> Unit) {
+  setOnKeyListener { _, keyCode, event ->
+    if (event.action == KeyEvent.ACTION_UP && keyCode == KeyEvent.KEYCODE_BACK) {
+      backPressed()
+      true
+    } else {
+      false
+    }
+  }
+}


### PR DESCRIPTION
**Testing steps**:
- Go to overdue list
- Open contact patient bottom sheet
- Select "Remind to call later..."
- Click Android back button
- It should go back to call patient view