### PR TITLE
Fix overdue list not changing when switching facility from overdue screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ### Fixes
 - Fix invalid qr code error when scanning a valid Indian NHID
 - Fix `ContactPatientBottomSheet` not going back to call patient view on back click in call later mode
+- Fix overdue list not changing when switching facility from overdue screen
   
 ## On Demo
 ### Internal

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueEffectHandler.kt
@@ -4,17 +4,17 @@ import com.spotify.mobius.rx2.RxMobius
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.overdue.AppointmentRepository
 import org.simple.clinic.util.PagerFactory
 import org.simple.clinic.util.scheduler.SchedulersProvider
-import javax.inject.Provider
 
 class OverdueEffectHandler @AssistedInject constructor(
     private val schedulers: SchedulersProvider,
     private val appointmentRepository: AppointmentRepository,
-    private val currentFacility: Provider<Facility>,
+    private val currentFacilityStream: Observable<Facility>,
     private val pagerFactory: PagerFactory,
     private val overdueAppointmentsConfig: OverdueAppointmentsConfig,
     @Assisted private val uiActions: OverdueUiActions

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueEffectHandler.kt
@@ -47,7 +47,7 @@ class OverdueEffectHandler @AssistedInject constructor(
     return ObservableTransformer { effects ->
       effects
           .observeOn(schedulers.io())
-          .map { currentFacility.get() }
+          .switchMap { currentFacilityStream }
           .map(::CurrentFacilityLoaded)
     }
   }

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
@@ -188,14 +188,14 @@ class OverdueScreen : BaseScreen<
 
   private fun overdueListAdapterLoadStateListener(loadStates: CombinedLoadStates) {
     val isSyncingPatientData = lastSyncedState.get().lastSyncProgress == SyncProgress.SYNCING
-    val isLoading = loadStates.refresh is LoadState.Loading
+    val isLoadingInitialData = loadStates.refresh is LoadState.Loading
     val endOfPaginationReached = loadStates.append.endOfPaginationReached
     val hasNoAdapterItems = overdueListAdapter.itemCount == 0
 
     val shouldShowEmptyView = endOfPaginationReached && hasNoAdapterItems
 
-    overdueProgressBar.visibleOrGone(isVisible = (isLoading || isSyncingPatientData) && hasNoAdapterItems)
-    viewForEmptyList.visibleOrGone(isVisible = shouldShowEmptyView && !isLoading && !isSyncingPatientData)
+    overdueProgressBar.visibleOrGone(isVisible = (isLoadingInitialData || isSyncingPatientData) && hasNoAdapterItems)
+    viewForEmptyList.visibleOrGone(isVisible = shouldShowEmptyView && !isLoadingInitialData && !isSyncingPatientData)
     overdueRecyclerView.visibleOrGone(isVisible = !shouldShowEmptyView)
   }
 

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
@@ -189,14 +189,20 @@ class OverdueScreen : BaseScreen<
   private fun overdueListAdapterLoadStateListener(loadStates: CombinedLoadStates) {
     val isSyncingPatientData = lastSyncedState.get().lastSyncProgress == SyncProgress.SYNCING
     val isLoadingInitialData = loadStates.refresh is LoadState.Loading
-    val endOfPaginationReached = loadStates.append.endOfPaginationReached
-    val hasNoAdapterItems = overdueListAdapter.itemCount == 0
 
-    val shouldShowEmptyView = endOfPaginationReached && hasNoAdapterItems
+    if (isSyncingPatientData || isLoadingInitialData) {
+      overdueProgressBar.visibility = View.VISIBLE
+      viewForEmptyList.visibility = View.GONE
+      overdueRecyclerView.visibility = View.GONE
+    } else {
+      val endOfPaginationReached = loadStates.append.endOfPaginationReached
+      val hasNoAdapterItems = overdueListAdapter.itemCount == 0
+      val shouldShowEmptyView = endOfPaginationReached && hasNoAdapterItems
 
-    overdueProgressBar.visibleOrGone(isVisible = (isLoadingInitialData || isSyncingPatientData) && hasNoAdapterItems)
-    viewForEmptyList.visibleOrGone(isVisible = shouldShowEmptyView && !isLoadingInitialData && !isSyncingPatientData)
-    overdueRecyclerView.visibleOrGone(isVisible = !shouldShowEmptyView)
+      overdueProgressBar.visibility = View.GONE
+      viewForEmptyList.visibleOrGone(isVisible = shouldShowEmptyView)
+      overdueRecyclerView.visibleOrGone(isVisible = !shouldShowEmptyView)
+    }
   }
 
   private fun downloadOverdueListClicks(): Observable<UiEvent> {

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
@@ -189,8 +189,9 @@ class OverdueScreen : BaseScreen<
   private fun overdueListAdapterLoadStateListener(loadStates: CombinedLoadStates) {
     val isSyncingPatientData = lastSyncedState.get().lastSyncProgress == SyncProgress.SYNCING
     val isLoadingInitialData = loadStates.refresh is LoadState.Loading
+    val hasOverdueListFullyLoaded = isSyncingPatientData || isLoadingInitialData
 
-    if (isSyncingPatientData || isLoadingInitialData) {
+    if (hasOverdueListFullyLoaded) {
       overdueProgressBar.visibility = View.VISIBLE
       viewForEmptyList.visibility = View.GONE
       overdueRecyclerView.visibility = View.GONE

--- a/app/src/test/java/org/simple/clinic/home/overdue/OverdueEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/OverdueEffectHandlerTest.kt
@@ -39,7 +39,7 @@ class OverdueEffectHandlerTest {
   private val effectHandler = OverdueEffectHandler(
       schedulers = TestSchedulersProvider.trampoline(),
       appointmentRepository = mock(),
-      currentFacility = { facility },
+      currentFacilityStream = Observable.just(facility),
       pagerFactory = pagerFactory,
       overdueAppointmentsConfig = overdueAppointmentsConfig,
       uiActions = uiActions

--- a/app/src/test/java/org/simple/clinic/home/overdue/OverdueLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/OverdueLogicTest.kt
@@ -91,7 +91,7 @@ class OverdueLogicTest {
     val effectHandler = OverdueEffectHandler(
         schedulers = TestSchedulersProvider.trampoline(),
         appointmentRepository = repository,
-        currentFacility = { facility },
+        currentFacilityStream = Observable.just(facility),
         pagerFactory = pagerFactory,
         overdueAppointmentsConfig = OverdueAppointmentsConfig(
             overdueAppointmentsLoadSize = 10


### PR DESCRIPTION
- Inject current facility stream in `OverdueEffectHandler`
- Subscribe to `currentFacilityStream` for getting current facility
- Rename `isLoading` to `isLoadingInitialData` in `overdueListAdapterLoadStateListener`
- Update `overdueListAdapterLoadStateListener` to display progress when loading data after switching facility
- Update CHANGELOG

**Story:** https://app.clubhouse.io/simpledotorg/story/4108/overdue-list-not-changing-when-switching-facility-from-the-overdue-screen
