### PR TITLE
Bump Kotlin to v1.5.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Remove remote config sync worker from the regular sync resources
 - Enqueue `UpdateRemoteConfigWorker` on app cold starts
 - Use `SyncConfigType` qualifier for daily and frequent sync configs
+- Bump Kotlin to v1.5.21
 
 ### Features
 - [In Progress: 06 Jul 2021] Add support for finding a patient online from ID scan

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
   const val minSdk = 21
   const val compileSdk = 30
-  const val kotlin = "1.5.20"
+  const val kotlin = "1.5.21"
   const val agp = "4.2.2"
   const val roomMetadataGenerator = "1.2.0"
 


### PR DESCRIPTION
https://github.com/JetBrains/kotlin/releases/tag/v1.5.21