### PR TITLE
Implement `DrugsSearchScreen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Updated `ContactPatientBottomSheet` behaviour for supporting patients with and without phone number
 - Change `SyncInterval` from an enum to a data class
 - [In Progress: 13 Jul 2021] Load online lookup API if patient not found locally
+- [In Progress: 14 Jul 2021] Implement `DrugsSearchScreen`
 
 ### Features
 - [In Progress: 06 Jul 2021] Add support for finding a patient online from ID scan
@@ -35,6 +36,8 @@
   - Load overdue patients without phone number
   - Add option to download & share overdue list
   - Updated contact patient bottom sheet UI
+- [In Progress: 14 Jul 2021] Medical screen improvements
+  - Search for commonly used drugs
   
 ### Fixes
 - Fix `ContactPatientBottomSheet` not going back to call patient view on back click in call later mode

--- a/app/src/androidTest/java/org/simple/clinic/drugs/search/DrugRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/drugs/search/DrugRepositoryAndroidTest.kt
@@ -8,6 +8,8 @@ import org.simple.clinic.AppDatabase
 import org.simple.clinic.PagingTestCase
 import org.simple.clinic.TestClinicApp
 import org.simple.clinic.TestData
+import org.simple.clinic.protocol.ProtocolAndProtocolDrugs
+import org.simple.clinic.protocol.ProtocolRepository
 import java.util.UUID
 import javax.inject.Inject
 
@@ -18,6 +20,9 @@ class DrugRepositoryAndroidTest {
 
   @Inject
   lateinit var drugRepository: DrugRepository
+
+  @Inject
+  lateinit var protocolRepository: ProtocolRepository
 
   @Before
   fun setUp() {
@@ -55,34 +60,80 @@ class DrugRepositoryAndroidTest {
   }
 
   @Test
-  fun search_drugs_should_work_correctly() {
+  fun searching_for_drugs_should_return_drugs_that_are_not_in_protocol() {
     // given
     val amlodipine10 = TestData.drug(
         id = UUID.fromString("fd422777-d6dd-4afc-9fd1-8147e8578ca4"),
         name = "Amlodipine",
-        dosage = "10mg"
+        dosage = "10mg",
+        rxNormCode = "329528"
     )
     val amlodipine20 = TestData.drug(
         id = UUID.fromString("d48fd21f-41fd-4e37-9616-fa989964b945"),
         name = "Amlodipine",
-        dosage = "20mg"
+        dosage = "20mg",
+        rxNormCode = "329526"
     )
     val losartan25 = TestData.drug(
         id = UUID.fromString("5db739bb-1fa6-470c-b230-4fead4e92543"),
         name = "Losartan",
-        dosage = "25mg"
+        dosage = "25mg",
+        rxNormCode = "979484"
     )
     val drugs = listOf(amlodipine10, amlodipine20, losartan25)
 
+    val obviousProtocol = TestData.protocol(uuid = UUID.fromString("7d26ecc1-707c-475e-b476-d7da6c4ad263"),
+        name = "Protocol Obvious")
+
+    val obviousProtocolDrugs = listOf(
+        TestData.protocolDrug(
+            uuid = UUID.fromString("19dfa8b3-9295-415d-9661-787b2a13ec99"),
+            name = "Amlodipine",
+            dosage = "20mg",
+            rxNormCode = "329526",
+            protocolUuid = obviousProtocol.uuid
+        ),
+        TestData.protocolDrug(
+            uuid = UUID.fromString("eaf9b5e8-ecd1-4c11-af5d-4f6b54671d32"),
+            name = "Metoprolol",
+            dosage = "25mg",
+            rxNormCode = "866426",
+            protocolUuid = obviousProtocol.uuid
+        )
+    )
+
+    val notObviousProtocol = TestData.protocol(uuid = UUID.fromString("6515a4cd-3b2f-40f2-abf0-be30285a461c"),
+        name = "Protocol Not Obvious")
+
+    val notObviousProtocolDrugs = listOf(
+        TestData.protocolDrug(
+            uuid = UUID.fromString("4b9a48f2-456a-4fcf-994d-f9bb90529ea0"),
+            name = "Amlodipine",
+            dosage = "10mg",
+            rxNormCode = "329528",
+            protocolUuid = notObviousProtocol.uuid
+        ),
+    )
+
+    protocolRepository.save(listOf(
+        ProtocolAndProtocolDrugs(obviousProtocol, obviousProtocolDrugs),
+        ProtocolAndProtocolDrugs(notObviousProtocol, notObviousProtocolDrugs)
+    )).blockingAwait()
     drugRepository.save(drugs).blockingAwait()
 
     // when
-    val expectedSearchResults = PagingTestCase(pagingSource = drugRepository.search(query = "amlo"),
+    val expectedSearchResultsForObviousProtocol = PagingTestCase(pagingSource = drugRepository.searchForNonProtocolDrugs(query = "amlo", protocolId = obviousProtocol.uuid),
+        loadSize = 10)
+        .data
+        .blockingFirst()
+
+    val expectedSearchResultsForNoProtocol = PagingTestCase(pagingSource = drugRepository.searchForNonProtocolDrugs(query = "amlo", protocolId = null),
         loadSize = 10)
         .data
         .blockingFirst()
 
     // then
-    assertThat(expectedSearchResults).containsExactly(amlodipine10, amlodipine20).inOrder()
+    assertThat(expectedSearchResultsForObviousProtocol).containsExactly(amlodipine10).inOrder()
+    assertThat(expectedSearchResultsForNoProtocol).containsExactly(amlodipine10, amlodipine20).inOrder()
   }
 }

--- a/app/src/androidTest/java/org/simple/clinic/drugs/search/DrugRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/drugs/search/DrugRepositoryAndroidTest.kt
@@ -5,6 +5,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.simple.clinic.AppDatabase
+import org.simple.clinic.PagingTestCase
 import org.simple.clinic.TestClinicApp
 import org.simple.clinic.TestData
 import java.util.UUID
@@ -51,5 +52,37 @@ class DrugRepositoryAndroidTest {
     val savedDrugs = drugRepository.drugs()
 
     assertThat(savedDrugs).isEqualTo(drugs)
+  }
+
+  @Test
+  fun search_drugs_should_work_correctly() {
+    // given
+    val amlodipine10 = TestData.drug(
+        id = UUID.fromString("fd422777-d6dd-4afc-9fd1-8147e8578ca4"),
+        name = "Amlodipine",
+        dosage = "10mg"
+    )
+    val amlodipine20 = TestData.drug(
+        id = UUID.fromString("d48fd21f-41fd-4e37-9616-fa989964b945"),
+        name = "Amlodipine",
+        dosage = "20mg"
+    )
+    val losartan25 = TestData.drug(
+        id = UUID.fromString("5db739bb-1fa6-470c-b230-4fead4e92543"),
+        name = "Losartan",
+        dosage = "25mg"
+    )
+    val drugs = listOf(amlodipine10, amlodipine20, losartan25)
+
+    drugRepository.save(drugs).blockingAwait()
+
+    // when
+    val expectedSearchResults = PagingTestCase(pagingSource = drugRepository.search(query = "amlo"),
+        loadSize = 10)
+        .data
+        .blockingFirst()
+
+    // then
+    assertThat(expectedSearchResults).containsExactly(amlodipine10, amlodipine20).inOrder()
   }
 }

--- a/app/src/main/java/org/simple/clinic/di/PagingModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/PagingModule.kt
@@ -5,6 +5,8 @@ import androidx.paging.PagedList
 import dagger.Module
 import dagger.Provides
 import org.simple.clinic.di.PagingSize.Page.AllRecentPatients
+import org.simple.clinic.di.PagingSize.Page.DrugsSearchResults
+import org.simple.clinic.remoteconfig.ConfigReader
 import javax.inject.Named
 
 @Module
@@ -25,5 +27,11 @@ class PagingModule {
   @PagingSize(AllRecentPatients)
   fun providesAllRecentPatientsPageSize(): Int {
     return 25
+  }
+
+  @Provides
+  @PagingSize(DrugsSearchResults)
+  fun providesDrugSearchResultsPageSize(configReader: ConfigReader): Int {
+    return configReader.long("custom_drugs_search_results_page_size", 25).toInt()
   }
 }

--- a/app/src/main/java/org/simple/clinic/di/PagingSize.kt
+++ b/app/src/main/java/org/simple/clinic/di/PagingSize.kt
@@ -6,7 +6,8 @@ import javax.inject.Qualifier
 annotation class PagingSize(val value: Page) {
 
   enum class Page {
-    AllRecentPatients
+    AllRecentPatients,
+    DrugsSearchResults
   }
 }
 

--- a/app/src/main/java/org/simple/clinic/drugs/search/Drug.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/Drug.kt
@@ -52,8 +52,11 @@ data class Drug(
 
     @Query("""
       SELECT drugs.* FROM Drug drugs
-      WHERE drugs.name LIKE '%' || :query || '%' COLLATE NOCASE
+      LEFT JOIN ProtocolDrug PD ON PD.protocolUuid == :protocolId AND PD.rxNormCode == drugs.rxNormCode
+      WHERE drugs.name LIKE '%' || :query || '%' COLLATE NOCASE AND PD.uuid IS NULL
+      GROUP BY drugs.id
+      ORDER BY drugs.name COLLATE NOCASE, drugs.dosage ASC
     """)
-    fun search(query: String): PagingSource<Int, Drug>
+    fun searchForNonProtocolDrugs(query: String, protocolId: UUID?): PagingSource<Int, Drug>
   }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/search/Drug.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/Drug.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.drugs.search
 
+import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Embedded
 import androidx.room.Entity
@@ -48,5 +49,11 @@ data class Drug(
 
     @Query("SELECT COUNT(uuid) FROM Protocol")
     fun count(): Observable<Int>
+
+    @Query("""
+      SELECT drugs.* FROM Drug drugs
+      WHERE drugs.name LIKE '%' || :query || '%' COLLATE NOCASE
+    """)
+    fun search(query: String): PagingSource<Int, Drug>
   }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugRepository.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugRepository.kt
@@ -44,8 +44,8 @@ class DrugRepository @Inject constructor(
     return drugDao.getAll()
   }
 
-  fun search(query: String): PagingSource<Int, Drug> {
-    return drugDao.search(query)
+  fun searchForNonProtocolDrugs(query: String, protocolId: UUID?): PagingSource<Int, Drug> {
+    return drugDao.searchForNonProtocolDrugs(query, protocolId)
   }
 
   private fun saveRecords(records: List<Drug>) {

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugRepository.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugRepository.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.drugs.search
 
+import androidx.paging.PagingSource
 import io.reactivex.Completable
 import io.reactivex.Observable
 import org.simple.clinic.drugs.search.sync.DrugPayload
@@ -41,6 +42,10 @@ class DrugRepository @Inject constructor(
 
   fun drugs(): List<Drug> {
     return drugDao.getAll()
+  }
+
+  fun search(query: String): PagingSource<Int, Drug> {
+    return drugDao.search(query)
   }
 
   private fun saveRecords(records: List<Drug>) {

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffect.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffect.kt
@@ -1,0 +1,5 @@
+package org.simple.clinic.drugs.search
+
+sealed class DrugSearchEffect
+
+data class SearchDrugs(val searchQuery: String) : DrugSearchEffect()

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffect.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffect.kt
@@ -1,5 +1,9 @@
 package org.simple.clinic.drugs.search
 
+import androidx.paging.PagingData
+
 sealed class DrugSearchEffect
 
 data class SearchDrugs(val searchQuery: String) : DrugSearchEffect()
+
+data class SetDrugsSearchResults(val searchResults: PagingData<Drug>) : DrugSearchEffect()

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffectHandler.kt
@@ -1,12 +1,14 @@
 package org.simple.clinic.drugs.search
 
 import com.spotify.mobius.rx2.RxMobius
+import dagger.Lazy
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import io.reactivex.ObservableTransformer
 import org.simple.clinic.di.PagingSize
 import org.simple.clinic.di.PagingSize.Page.DrugsSearchResults
+import org.simple.clinic.facility.Facility
 import org.simple.clinic.util.PagerFactory
 import org.simple.clinic.util.scheduler.SchedulersProvider
 
@@ -14,6 +16,7 @@ class DrugSearchEffectHandler @AssistedInject constructor(
     private val schedulersProvider: SchedulersProvider,
     private val drugsRepository: DrugRepository,
     private val pagerFactory: PagerFactory,
+    private val currentFacility: Lazy<Facility>,
     @PagingSize(DrugsSearchResults) private val drugsSearchResultsPageSize: Int,
     @Assisted private val uiActions: UiActions
 ) {
@@ -40,8 +43,9 @@ class DrugSearchEffectHandler @AssistedInject constructor(
       effects
           .observeOn(schedulersProvider.io())
           .switchMap {
+            val currentFacilityProtocolId = currentFacility.get().protocolUuid
             pagerFactory.createPager(
-                sourceFactory = { drugsRepository.search(it.searchQuery) },
+                sourceFactory = { drugsRepository.searchForNonProtocolDrugs(it.searchQuery, currentFacilityProtocolId) },
                 pageSize = drugsSearchResultsPageSize
             )
           }

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffectHandler.kt
@@ -1,0 +1,38 @@
+package org.simple.clinic.drugs.search
+
+import com.spotify.mobius.rx2.RxMobius
+import io.reactivex.ObservableTransformer
+import org.simple.clinic.di.PagingSize
+import org.simple.clinic.di.PagingSize.Page.DrugsSearchResults
+import org.simple.clinic.util.PagerFactory
+import org.simple.clinic.util.scheduler.SchedulersProvider
+import javax.inject.Inject
+
+class DrugSearchEffectHandler @Inject constructor(
+    private val schedulersProvider: SchedulersProvider,
+    private val drugsRepository: DrugRepository,
+    private val pagerFactory: PagerFactory,
+    @PagingSize(DrugsSearchResults) private val drugsSearchResultsPageSize: Int
+) {
+
+  fun build(): ObservableTransformer<DrugSearchEffect, DrugSearchEvent> {
+    return RxMobius
+        .subtypeEffectHandler<DrugSearchEffect, DrugSearchEvent>()
+        .addTransformer(SearchDrugs::class.java, searchDrugs())
+        .build()
+  }
+
+  private fun searchDrugs(): ObservableTransformer<SearchDrugs, DrugSearchEvent> {
+    return ObservableTransformer { effects ->
+      effects
+          .observeOn(schedulersProvider.io())
+          .switchMap {
+            pagerFactory.createPager(
+                sourceFactory = { drugsRepository.search(it.searchQuery) },
+                pageSize = drugsSearchResultsPageSize
+            )
+          }
+          .map(::DrugsSearchResultsLoaded)
+    }
+  }
+}

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffectHandler.kt
@@ -1,25 +1,38 @@
 package org.simple.clinic.drugs.search
 
 import com.spotify.mobius.rx2.RxMobius
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import io.reactivex.ObservableTransformer
 import org.simple.clinic.di.PagingSize
 import org.simple.clinic.di.PagingSize.Page.DrugsSearchResults
 import org.simple.clinic.util.PagerFactory
 import org.simple.clinic.util.scheduler.SchedulersProvider
-import javax.inject.Inject
 
-class DrugSearchEffectHandler @Inject constructor(
+class DrugSearchEffectHandler @AssistedInject constructor(
     private val schedulersProvider: SchedulersProvider,
     private val drugsRepository: DrugRepository,
     private val pagerFactory: PagerFactory,
-    @PagingSize(DrugsSearchResults) private val drugsSearchResultsPageSize: Int
+    @PagingSize(DrugsSearchResults) private val drugsSearchResultsPageSize: Int,
+    @Assisted private val uiActions: UiActions
 ) {
+
+  @AssistedFactory
+  interface Factory {
+    fun create(uiActions: UiActions): DrugSearchEffectHandler
+  }
 
   fun build(): ObservableTransformer<DrugSearchEffect, DrugSearchEvent> {
     return RxMobius
         .subtypeEffectHandler<DrugSearchEffect, DrugSearchEvent>()
         .addTransformer(SearchDrugs::class.java, searchDrugs())
+        .addConsumer(SetDrugsSearchResults::class.java, ::setDrugsSearchResults, schedulersProvider.ui())
         .build()
+  }
+
+  private fun setDrugsSearchResults(effect: SetDrugsSearchResults) {
+    uiActions.setDrugSearchResults(effect.searchResults)
   }
 
   private fun searchDrugs(): ObservableTransformer<SearchDrugs, DrugSearchEvent> {

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEvent.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEvent.kt
@@ -5,3 +5,5 @@ import androidx.paging.PagingData
 sealed class DrugSearchEvent
 
 data class DrugsSearchResultsLoaded(val searchResults: PagingData<Drug>) : DrugSearchEvent()
+
+data class SearchQueryChanged(val searchQuery: String) : DrugSearchEvent()

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEvent.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEvent.kt
@@ -1,0 +1,7 @@
+package org.simple.clinic.drugs.search
+
+import androidx.paging.PagingData
+
+sealed class DrugSearchEvent
+
+data class DrugsSearchResultsLoaded(val searchResults: PagingData<Drug>) : DrugSearchEvent()

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchModel.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchModel.kt
@@ -1,0 +1,9 @@
+package org.simple.clinic.drugs.search
+
+class DrugSearchModel {
+
+  companion object {
+
+    fun create() = DrugSearchModel()
+  }
+}

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchModel.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchModel.kt
@@ -1,9 +1,17 @@
 package org.simple.clinic.drugs.search
 
-class DrugSearchModel {
+data class DrugSearchModel(
+    val searchQuery: String
+) {
 
   companion object {
 
-    fun create() = DrugSearchModel()
+    fun create() = DrugSearchModel(
+        searchQuery = ""
+    )
+  }
+
+  fun searchQueryChanged(searchQuery: String): DrugSearchModel {
+    return copy(searchQuery = searchQuery)
   }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchModel.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchModel.kt
@@ -11,6 +11,9 @@ data class DrugSearchModel(
     )
   }
 
+  val hasSearchQuery
+    get() = searchQuery.isNotBlank()
+
   fun searchQueryChanged(searchQuery: String): DrugSearchModel {
     return copy(searchQuery = searchQuery)
   }

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUi.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUi.kt
@@ -2,4 +2,5 @@ package org.simple.clinic.drugs.search
 
 interface DrugSearchUi {
   fun hideSearchResults()
+  fun showSearchResults()
 }

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUi.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUi.kt
@@ -1,0 +1,5 @@
+package org.simple.clinic.drugs.search
+
+interface DrugSearchUi {
+  fun hideSearchResults()
+}

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUiRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUiRenderer.kt
@@ -7,6 +7,8 @@ class DrugSearchUiRenderer(private val ui: DrugSearchUi) : ViewRenderer<DrugSear
   override fun render(model: DrugSearchModel) {
     if (!model.hasSearchQuery) {
       ui.hideSearchResults()
+    } else {
+      ui.showSearchResults()
     }
   }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUiRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUiRenderer.kt
@@ -1,0 +1,12 @@
+package org.simple.clinic.drugs.search
+
+import org.simple.clinic.mobius.ViewRenderer
+
+class DrugSearchUiRenderer(private val ui: DrugSearchUi) : ViewRenderer<DrugSearchModel> {
+
+  override fun render(model: DrugSearchModel) {
+    if (!model.hasSearchQuery) {
+      ui.hideSearchResults()
+    }
+  }
+}

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUpdate.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.drugs.search
 import com.spotify.mobius.Next
 import com.spotify.mobius.Update
 import org.simple.clinic.mobius.dispatch
+import org.simple.clinic.mobius.next
 
 class DrugSearchUpdate : Update<DrugSearchModel, DrugSearchEvent, DrugSearchEffect> {
 
@@ -12,6 +13,15 @@ class DrugSearchUpdate : Update<DrugSearchModel, DrugSearchEvent, DrugSearchEffe
   ): Next<DrugSearchModel, DrugSearchEffect> {
     return when (event) {
       is DrugsSearchResultsLoaded -> dispatch(SetDrugsSearchResults(event.searchResults))
+      is SearchQueryChanged -> searchDrugs(model, event)
     }
+  }
+
+  private fun searchDrugs(
+      model: DrugSearchModel,
+      event: SearchQueryChanged
+  ): Next<DrugSearchModel, DrugSearchEffect> {
+    val searchQuery = event.searchQuery
+    return next(model.searchQueryChanged(searchQuery), SearchDrugs(searchQuery))
   }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUpdate.kt
@@ -22,6 +22,12 @@ class DrugSearchUpdate : Update<DrugSearchModel, DrugSearchEvent, DrugSearchEffe
       event: SearchQueryChanged
   ): Next<DrugSearchModel, DrugSearchEffect> {
     val searchQuery = event.searchQuery
-    return next(model.searchQueryChanged(searchQuery), SearchDrugs(searchQuery))
+    val searchQueryChangedModel = model.searchQueryChanged(searchQuery)
+
+    return if (searchQuery.isNotBlank()) {
+      next(searchQueryChangedModel, SearchDrugs(searchQuery))
+    } else {
+      next(searchQueryChangedModel)
+    }
   }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUpdate.kt
@@ -1,0 +1,17 @@
+package org.simple.clinic.drugs.search
+
+import com.spotify.mobius.Next
+import com.spotify.mobius.Update
+import org.simple.clinic.mobius.dispatch
+
+class DrugSearchUpdate : Update<DrugSearchModel, DrugSearchEvent, DrugSearchEffect> {
+
+  override fun update(
+      model: DrugSearchModel,
+      event: DrugSearchEvent
+  ): Next<DrugSearchModel, DrugSearchEffect> {
+    return when (event) {
+      is DrugsSearchResultsLoaded -> dispatch(SetDrugsSearchResults(event.searchResults))
+    }
+  }
+}

--- a/app/src/main/java/org/simple/clinic/drugs/search/UiActions.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/UiActions.kt
@@ -1,0 +1,7 @@
+package org.simple.clinic.drugs.search
+
+import androidx.paging.PagingData
+
+interface UiActions {
+  fun setDrugSearchResults(searchResults: PagingData<Drug>)
+}

--- a/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchEffectHandlerTest.kt
@@ -1,0 +1,61 @@
+package org.simple.clinic.drugs.search
+
+import androidx.paging.PagingData
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import io.reactivex.Observable
+import org.junit.After
+import org.junit.Test
+import org.simple.clinic.TestData
+import org.simple.clinic.mobius.EffectHandlerTestCase
+import org.simple.clinic.util.PagerFactory
+import org.simple.clinic.util.PagingSourceFactory
+import org.simple.clinic.util.scheduler.TestSchedulersProvider
+import java.util.UUID
+
+class DrugSearchEffectHandlerTest {
+
+  private val repository = mock<DrugRepository>()
+  private val pagerFactory = mock<PagerFactory>()
+  private val drugsSearchResultsPageSize = 10
+  private val testCase = EffectHandlerTestCase(DrugSearchEffectHandler(
+      schedulersProvider = TestSchedulersProvider.trampoline(),
+      drugsRepository = repository,
+      pagerFactory = pagerFactory,
+      drugsSearchResultsPageSize = drugsSearchResultsPageSize
+  ).build())
+
+  @After
+  fun tearDown() {
+    testCase.dispose()
+  }
+
+  @Test
+  fun `when search drugs effect is received, then search drugs`() {
+    // given
+    val searchQuery = "Amlodip"
+    val searchResults = PagingData.from(listOf(
+        TestData.drug(id = UUID.fromString("d9af2d06-0c52-430a-9dc4-64aef8d35a5b"),
+            name = "Amlodipine",
+            dosage = "10 mg"),
+        TestData.drug(id = UUID.fromString("ed1062da-05f1-4125-bee5-ee8606620020"),
+            name = "Amlodipine",
+            dosage = "20 mg")
+    ))
+
+    whenever(pagerFactory.createPager(
+        sourceFactory = any<PagingSourceFactory<Int, Drug>>(),
+        pageSize = eq(drugsSearchResultsPageSize),
+        initialKey = eq(null)
+    )) doReturn Observable.just(searchResults)
+
+    // when
+    testCase.dispatch(SearchDrugs(searchQuery))
+
+    // then
+    testCase.assertOutgoingEvents(DrugsSearchResultsLoaded(searchResults))
+  }
+}

--- a/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchEffectHandlerTest.kt
@@ -25,12 +25,15 @@ class DrugSearchEffectHandlerTest {
   private val pagerFactory = mock<PagerFactory>()
   private val uiActions = mock<UiActions>()
   private val drugsSearchResultsPageSize = 10
+  private val facility = TestData.facility(uuid = UUID.fromString("6718d30a-a755-4422-b0a1-802c989c56ce"),
+      name = "PHC Obvious")
 
   private val testCase = EffectHandlerTestCase(DrugSearchEffectHandler(
       schedulersProvider = TestSchedulersProvider.trampoline(),
       drugsRepository = repository,
       pagerFactory = pagerFactory,
       drugsSearchResultsPageSize = drugsSearchResultsPageSize,
+      currentFacility = { facility },
       uiActions = uiActions
   ).build())
 

--- a/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchUiRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchUiRendererTest.kt
@@ -1,0 +1,28 @@
+package org.simple.clinic.drugs.search
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import org.junit.Test
+
+class DrugSearchUiRendererTest {
+
+  private val ui = mock<DrugSearchUi>()
+  private val uiRenderer = DrugSearchUiRenderer(ui)
+
+  private val defaultModel = DrugSearchModel.create()
+
+  @Test
+  fun `when search query is empty, then hide search results`() {
+    // given
+    val emptySearchQueryModel = defaultModel
+        .searchQueryChanged(searchQuery = "")
+
+    // when
+    uiRenderer.render(emptySearchQueryModel)
+
+    // then
+    verify(ui).hideSearchResults()
+    verifyNoMoreInteractions(ui)
+  }
+}

--- a/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchUiRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchUiRendererTest.kt
@@ -25,4 +25,18 @@ class DrugSearchUiRendererTest {
     verify(ui).hideSearchResults()
     verifyNoMoreInteractions(ui)
   }
+
+  @Test
+  fun `when search query is not empty, then show search results`() {
+    // given
+    val searchQueryModel = defaultModel
+        .searchQueryChanged(searchQuery = "Amlodipine")
+
+    // when
+    uiRenderer.render(searchQueryModel)
+
+    // then
+    verify(ui).showSearchResults()
+    verifyNoMoreInteractions(ui)
+  }
 }

--- a/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchUpdateTest.kt
@@ -2,6 +2,7 @@ package org.simple.clinic.drugs.search
 
 import androidx.paging.PagingData
 import com.spotify.mobius.test.NextMatchers.hasEffects
+import com.spotify.mobius.test.NextMatchers.hasModel
 import com.spotify.mobius.test.NextMatchers.hasNoModel
 import com.spotify.mobius.test.UpdateSpec
 import com.spotify.mobius.test.UpdateSpec.assertThatNext
@@ -11,9 +12,11 @@ import java.util.UUID
 
 class DrugSearchUpdateTest {
 
+  private val defaultModel = DrugSearchModel.create()
+  private val updateSpec = UpdateSpec(DrugSearchUpdate())
+
   @Test
   fun `when drugs search results are loaded, then show drug search results`() {
-    val defaultModel = DrugSearchModel.create()
     val searchResults = PagingData.from(listOf(
         TestData.drug(id = UUID.fromString("6604240d-c83d-4476-978f-06af96750719"),
             name = "Amlodipine",
@@ -23,12 +26,25 @@ class DrugSearchUpdateTest {
             dosage = "20mg")
     ))
 
-    UpdateSpec(DrugSearchUpdate())
+    updateSpec
         .given(defaultModel)
         .whenEvent(DrugsSearchResultsLoaded(searchResults))
         .then(assertThatNext(
             hasNoModel(),
             hasEffects(SetDrugsSearchResults(searchResults))
+        ))
+  }
+
+  @Test
+  fun `when search query is changed, then update model and search drugs`() {
+    val searchQuery = "Amlodipine"
+
+    updateSpec
+        .given(defaultModel)
+        .whenEvent(SearchQueryChanged(searchQuery))
+        .then(assertThatNext(
+            hasModel(defaultModel.searchQueryChanged(searchQuery)),
+            hasEffects(SearchDrugs(searchQuery))
         ))
   }
 }

--- a/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchUpdateTest.kt
@@ -1,0 +1,34 @@
+package org.simple.clinic.drugs.search
+
+import androidx.paging.PagingData
+import com.spotify.mobius.test.NextMatchers.hasEffects
+import com.spotify.mobius.test.NextMatchers.hasNoModel
+import com.spotify.mobius.test.UpdateSpec
+import com.spotify.mobius.test.UpdateSpec.assertThatNext
+import org.junit.Test
+import org.simple.clinic.TestData
+import java.util.UUID
+
+class DrugSearchUpdateTest {
+
+  @Test
+  fun `when drugs search results are loaded, then show drug search results`() {
+    val defaultModel = DrugSearchModel.create()
+    val searchResults = PagingData.from(listOf(
+        TestData.drug(id = UUID.fromString("6604240d-c83d-4476-978f-06af96750719"),
+            name = "Amlodipine",
+            dosage = "10mg"),
+        TestData.drug(id = UUID.fromString("e700ab22-e5fa-4037-a139-8bd678bbf035"),
+            name = "Amlodipine",
+            dosage = "20mg")
+    ))
+
+    UpdateSpec(DrugSearchUpdate())
+        .given(defaultModel)
+        .whenEvent(DrugsSearchResultsLoaded(searchResults))
+        .then(assertThatNext(
+            hasNoModel(),
+            hasEffects(SetDrugsSearchResults(searchResults))
+        ))
+  }
+}

--- a/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchUpdateTest.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.drugs.search
 import androidx.paging.PagingData
 import com.spotify.mobius.test.NextMatchers.hasEffects
 import com.spotify.mobius.test.NextMatchers.hasModel
+import com.spotify.mobius.test.NextMatchers.hasNoEffects
 import com.spotify.mobius.test.NextMatchers.hasNoModel
 import com.spotify.mobius.test.UpdateSpec
 import com.spotify.mobius.test.UpdateSpec.assertThatNext
@@ -45,6 +46,19 @@ class DrugSearchUpdateTest {
         .then(assertThatNext(
             hasModel(defaultModel.searchQueryChanged(searchQuery)),
             hasEffects(SearchDrugs(searchQuery))
+        ))
+  }
+
+  @Test
+  fun `when search query is empty, then update model`() {
+    val searchQuery = ""
+
+    updateSpec
+        .given(defaultModel)
+        .whenEvent(SearchQueryChanged(searchQuery))
+        .then(assertThatNext(
+            hasModel(defaultModel.searchQueryChanged(searchQuery)),
+            hasNoEffects()
         ))
   }
 }


### PR DESCRIPTION
**Story**: https://app.clubhouse.io/simpledotorg/story/2899/implement-drugssearchscreen

- Add query to search for drugs
- Add page size for drug search results
- Add effect to search drugs
- Handle `SetDrugsSearchResults` effect
- When drug search results are loaded then show search results
- When search query is changed, then update model and search drugs
- When search query is empty, then update model
- When search query is empty, then hide search results
- When search query is not empty, then show search results
