### PR TITLE
Fix `ContactPatientBottomSheet` UI spacing and styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 ### Fixes
 - Fix `ContactPatientBottomSheet` not going back to call patient view on back click in call later mode
 - Fix overdue list not changing when switching facility from overdue screen
+- Fix `ContactPatientBottomSheet` UI spacing and styling
 
 ## 2021-07-15-7866
 ### Internal

--- a/app/src/main/java/org/simple/clinic/contactpatient/ContactPatientBottomSheet.kt
+++ b/app/src/main/java/org/simple/clinic/contactpatient/ContactPatientBottomSheet.kt
@@ -44,7 +44,6 @@ import org.simple.clinic.util.RequestPermissions
 import org.simple.clinic.util.RuntimePermissions
 import org.simple.clinic.util.UserClock
 import org.simple.clinic.util.onBackPressed
-import org.simple.clinic.util.toLocalDateAtZone
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.util.valueOrEmpty
 import java.time.LocalDate
@@ -274,7 +273,7 @@ class ContactPatientBottomSheet : BaseBottomSheet<
   }
 
   override fun setTransferredFromLabelText() {
-    callPatientView.setRegisteredFacilityLabelText = getString(R.string.contactpatient_patient_transferred_from)
+    callPatientView.setRegisteredFacilityLabelText = getString(R.string.contactpatient_patient_transfer_from)
   }
 
   override fun directlyCallPatient(patientPhoneNumber: String, dialer: Dialer) {

--- a/app/src/main/res/layout/contactpatient_callpatient.xml
+++ b/app/src/main/res/layout/contactpatient_callpatient.xml
@@ -190,7 +190,7 @@
 
   <TextView
     android:id="@+id/agreedToVisitTextView"
-    style="@style/Widget.Simple.PatientContactCallResultItem"
+    style="@style/Widget.Simple.PatientContactCallResultItem_Old"
     android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/spacing_16"
@@ -213,7 +213,7 @@
 
   <TextView
     android:id="@+id/remindToCallLaterTextView"
-    style="@style/Widget.Simple.PatientContactCallResultItem"
+    style="@style/Widget.Simple.PatientContactCallResultItem_Old"
     android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
     android:text="@string/contactpatient_remind_call_later"
@@ -236,7 +236,7 @@
 
   <TextView
     android:id="@+id/removeFromOverdueListTextView"
-    style="@style/Widget.Simple.PatientContactCallResultItem"
+    style="@style/Widget.Simple.PatientContactCallResultItem_Old"
     android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
     android:text="@string/contactpatient_remove_from_list"

--- a/app/src/main/res/layout/contactpatient_callpatient.xml
+++ b/app/src/main/res/layout/contactpatient_callpatient.xml
@@ -14,11 +14,12 @@
     android:id="@+id/nameTextView"
     android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/spacing_24"
+    android:layout_marginHorizontal="@dimen/spacing_24"
     android:layout_marginTop="@dimen/spacing_24"
     android:gravity="start"
     android:textAppearance="?attr/textAppearanceHeadline6"
     android:textColor="?attr/colorOnSurface"
+    app:layout_constraintBottom_toTopOf="@id/patientAddressTextView"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"
@@ -28,7 +29,7 @@
     android:id="@+id/patientAddressTextView"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/spacing_24"
+    android:layout_marginHorizontal="@dimen/spacing_24"
     android:layout_marginTop="@dimen/spacing_16"
     android:maxLines="2"
     android:textAppearance="?attr/textAppearanceBody2"
@@ -54,25 +55,25 @@
 
   <TextView
     android:id="@+id/registeredFacilityTextView"
-    android:layout_width="wrap_content"
+    android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/spacing_8"
     android:layout_marginTop="@dimen/spacing_10"
+    android:layout_marginEnd="@dimen/spacing_24"
     android:maxLines="1"
     android:textAppearance="?attr/textAppearanceBody2"
     android:textColor="@color/color_on_surface_67"
+    app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toEndOf="@id/registeredFacilityLabel"
     app:layout_constraintTop_toBottomOf="@id/patientAddressTextView"
     tools:text="CHC Bhatinda" />
 
   <View
-    android:id="@+id/divider"
+    android:id="@+id/patientInfoSeparator"
     android:layout_width="@dimen/spacing_0"
     android:layout_height="@dimen/spacing_1"
-    android:layout_marginStart="@dimen/spacing_16"
-    android:layout_marginTop="@dimen/spacing_16"
-    android:layout_marginEnd="@dimen/spacing_16"
-    android:layout_marginBottom="@dimen/spacing_16"
+    android:layout_marginHorizontal="@dimen/spacing_24"
+    android:layout_marginVertical="@dimen/spacing_16"
     android:background="@drawable/divider"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
@@ -83,27 +84,29 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/spacing_24"
-    android:layout_marginTop="@dimen/spacing_8"
+    android:layout_marginTop="@dimen/spacing_16"
     android:maxLines="1"
     android:text="@string/contactpatient_phone"
     android:textAppearance="?attr/textAppearanceBody2Bold"
     android:textColor="@color/color_on_surface_67"
     android:visibility="visible"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/divider" />
+    app:layout_constraintTop_toBottomOf="@+id/patientInfoSeparator" />
 
   <TextView
     android:id="@+id/phoneNumberTextView"
-    android:layout_width="wrap_content"
+    android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/spacing_8"
-    android:layout_marginTop="@dimen/spacing_8"
+    android:layout_marginEnd="@dimen/spacing_24"
     android:maxLines="1"
     android:textAppearance="?attr/textAppearanceBody2"
     android:textColor="@color/color_on_surface_67"
     android:visibility="visible"
+    app:layout_constraintBottom_toBottomOf="@id/phoneNumberLabel"
+    app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toEndOf="@id/phoneNumberLabel"
-    app:layout_constraintTop_toBottomOf="@id/divider"
+    app:layout_constraintTop_toTopOf="@id/phoneNumberLabel"
     tools:text="9898989898" />
 
   <TextView
@@ -118,19 +121,22 @@
     android:textColor="@color/color_on_surface_67"
     app:layout_constraintBottom_toTopOf="@id/lastVisitedLabel"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@+id/phoneNumberLabel" />
+    app:layout_constraintTop_toBottomOf="@+id/phoneNumberLabel"
+    app:layout_goneMarginTop="@dimen/spacing_16" />
 
   <TextView
     android:id="@+id/diagnosisTextView"
-    android:layout_width="wrap_content"
+    android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/spacing_8"
-    android:layout_marginTop="@dimen/spacing_8"
+    android:layout_marginEnd="@dimen/spacing_24"
     android:maxLines="1"
     android:textAppearance="?attr/textAppearanceBody2"
     android:textColor="@color/color_on_surface_67"
+    app:layout_constraintBottom_toBottomOf="@id/diagnosisLabel"
+    app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toEndOf="@id/diagnosisLabel"
-    app:layout_constraintTop_toBottomOf="@id/phoneNumberLabel"
+    app:layout_constraintTop_toTopOf="@id/diagnosisLabel"
     tools:text="Hypertension, Diabetes" />
 
   <TextView
@@ -143,31 +149,31 @@
     android:text="@string/contactpatient_visited"
     android:textAppearance="?attr/textAppearanceBody2Bold"
     android:textColor="@color/color_on_surface_67"
-    app:layout_constraintBottom_toTopOf="@id/divider2"
+    app:layout_constraintBottom_toTopOf="@id/diagnosisSeparator"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toBottomOf="@+id/diagnosisLabel" />
 
   <TextView
     android:id="@+id/lastVisitedTextView"
-    android:layout_width="wrap_content"
+    android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/spacing_8"
-    android:layout_marginTop="@dimen/spacing_8"
+    android:layout_marginEnd="@dimen/spacing_24"
     android:maxLines="1"
     android:textAppearance="?attr/textAppearanceBody2"
     android:textColor="@color/color_on_surface_67"
+    app:layout_constraintBottom_toBottomOf="@id/lastVisitedLabel"
+    app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toEndOf="@id/lastVisitedLabel"
-    app:layout_constraintTop_toBottomOf="@id/diagnosisLabel"
+    app:layout_constraintTop_toTopOf="@id/lastVisitedLabel"
     tools:text="15-May-2021" />
 
   <View
-    android:id="@+id/divider2"
+    android:id="@+id/diagnosisSeparator"
     android:layout_width="@dimen/spacing_0"
     android:layout_height="@dimen/spacing_1"
-    android:layout_marginStart="@dimen/spacing_16"
+    android:layout_marginHorizontal="@dimen/spacing_24"
     android:layout_marginTop="@dimen/spacing_16"
-    android:layout_marginEnd="@dimen/spacing_16"
-    android:layout_marginBottom="@dimen/spacing_24"
     android:background="@drawable/divider"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
@@ -178,7 +184,7 @@
     android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/spacing_24"
-    android:layout_marginTop="@dimen/spacing_24"
+    android:layout_marginTop="@dimen/spacing_16"
     android:layout_marginEnd="@dimen/spacing_24"
     android:text="@string/contactpatient_result_of_call"
     android:textAllCaps="true"
@@ -186,11 +192,11 @@
     android:textColor="@color/color_on_surface_67"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/divider2" />
+    app:layout_constraintTop_toBottomOf="@id/diagnosisSeparator" />
 
   <TextView
     android:id="@+id/agreedToVisitTextView"
-    style="@style/Widget.Simple.PatientContactCallResultItem_Old"
+    style="@style/Widget.Simple.PatientContactCallResultItem"
     android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/spacing_16"
@@ -204,8 +210,7 @@
     android:id="@+id/agreedToVisitSeparator"
     android:layout_width="@dimen/spacing_0"
     android:layout_height="@dimen/spacing_1"
-    android:layout_marginStart="@dimen/spacing_16"
-    android:layout_marginEnd="@dimen/spacing_16"
+    android:layout_marginHorizontal="@dimen/spacing_24"
     android:background="@drawable/divider"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
@@ -213,7 +218,7 @@
 
   <TextView
     android:id="@+id/remindToCallLaterTextView"
-    style="@style/Widget.Simple.PatientContactCallResultItem_Old"
+    style="@style/Widget.Simple.PatientContactCallResultItem"
     android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
     android:text="@string/contactpatient_remind_call_later"
@@ -227,8 +232,7 @@
     android:id="@+id/remindToCallLaterSeparator"
     android:layout_width="@dimen/spacing_0"
     android:layout_height="@dimen/spacing_1"
-    android:layout_marginStart="@dimen/spacing_16"
-    android:layout_marginEnd="@dimen/spacing_16"
+    android:layout_marginHorizontal="@dimen/spacing_24"
     android:background="@drawable/divider"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
@@ -236,7 +240,7 @@
 
   <TextView
     android:id="@+id/removeFromOverdueListTextView"
-    style="@style/Widget.Simple.PatientContactCallResultItem_Old"
+    style="@style/Widget.Simple.PatientContactCallResultItem"
     android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
     android:text="@string/contactpatient_remove_from_list"
@@ -250,11 +254,10 @@
     android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/spacing_16"
-    android:layout_marginTop="@dimen/spacing_32"
+    android:layout_marginTop="@dimen/spacing_24"
     android:layout_marginEnd="@dimen/spacing_16"
-    android:layout_marginBottom="@dimen/spacing_8"
-    android:gravity="center|center_horizontal"
     android:text="@string/contactpatient_help_text"
+    android:textAlignment="center"
     android:textAppearance="?attr/textAppearanceBody2"
     android:textColor="@color/color_on_surface_67"
     app:layout_constraintEnd_toEndOf="parent"
@@ -267,13 +270,13 @@
     android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/spacing_16"
-    android:layout_marginEnd="@dimen/spacing_16"
     android:layout_marginTop="@dimen/spacing_8"
-    android:paddingStart="@dimen/spacing_8"
-    android:paddingEnd="@dimen/spacing_24"
+    android:layout_marginEnd="@dimen/spacing_16"
+    android:layout_marginBottom="@dimen/spacing_12"
     android:text="@string/contactpatient_call_normal"
     android:theme="@style/ThemeOverlay.Simple.Blue2Primary"
     app:icon="@drawable/ic_call_16dp"
+    app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toStartOf="@+id/secureCallButton"
     app:layout_constraintHorizontal_chainStyle="spread"
     app:layout_constraintStart_toStartOf="parent"
@@ -285,8 +288,6 @@
     android:layout_width="@dimen/spacing_0"
     android:layout_height="wrap_content"
     android:layout_marginEnd="@dimen/spacing_16"
-    android:paddingStart="@dimen/spacing_8"
-    android:paddingEnd="@dimen/spacing_24"
     android:text="@string/contactpatient_call_secure"
     app:icon="@drawable/ic_call_16dp"
     app:layout_constraintEnd_toEndOf="parent"
@@ -294,18 +295,12 @@
     app:layout_constraintTop_toTopOf="@id/normalCallButton"
     tools:visibility="visible" />
 
-  <Space
-    android:id="@+id/spaceAboveNormalCallButton"
-    android:layout_width="match_parent"
-    android:layout_height="@dimen/spacing_12"
-    app:layout_constraintTop_toBottomOf="@id/normalCallButton" />
-
-  <RelativeLayout
+  <FrameLayout
     android:id="@+id/noPhoneNumberBottomTextViewLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_marginTop="@dimen/spacing_32"
-    android:background="@color/simple_light_grey"
+    android:layout_height="@dimen/spacing_60"
+    android:layout_marginTop="@dimen/spacing_24"
+    android:background="?android:attr/colorBackground"
     android:visibility="gone"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
@@ -315,15 +310,14 @@
       android:id="@+id/noPhoneNumberBottomTextView"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:layout_centerHorizontal="true"
-      android:drawablePadding="@dimen/spacing_12"
-      android:gravity="center|center_horizontal"
-      android:paddingVertical="@dimen/spacing_24"
+      android:layout_gravity="center"
+      android:drawablePadding="@dimen/spacing_8"
       android:text="@string/contactpatient_no_phone_number"
       android:textAppearance="?attr/textAppearanceButtonBig"
       android:textColor="@color/color_on_surface_67"
       app:drawableStartCompat="@drawable/ic_contact_patient_bottom_sheet_no_phone_number" />
-  </RelativeLayout>
+
+  </FrameLayout>
 
   <androidx.constraintlayout.widget.Group
     android:id="@+id/secureCallingGroup"
@@ -337,7 +331,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:visibility="gone"
-    app:constraint_referenced_ids="phoneNumberLabel, phoneNumberTextView, remindToCallLaterTextView, remindToCallLaterSeparator, helpTextView, normalCallButton, secureCallButton, spaceAboveNormalCallButton" />
+    app:constraint_referenced_ids="phoneNumberLabel, phoneNumberTextView, remindToCallLaterTextView, remindToCallLaterSeparator, helpTextView, normalCallButton, secureCallButton" />
 
   <androidx.constraintlayout.widget.Group
     android:id="@+id/patientWithNoPhoneNumberGroup"
@@ -345,4 +339,5 @@
     android:layout_height="wrap_content"
     android:visibility="gone"
     app:constraint_referenced_ids="patientAddressTextView, noPhoneNumberBottomTextViewLayout" />
+
 </merge>

--- a/app/src/main/res/layout/contactpatient_callpatient_old.xml
+++ b/app/src/main/res/layout/contactpatient_callpatient_old.xml
@@ -71,7 +71,7 @@
 
   <TextView
     android:id="@+id/agreedToVisitTextView"
-    style="@style/Widget.Simple.PatientContactCallResultItem"
+    style="@style/Widget.Simple.PatientContactCallResultItem_Old"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/spacing_16"
@@ -94,7 +94,7 @@
 
   <TextView
     android:id="@+id/remindToCallLaterTextView"
-    style="@style/Widget.Simple.PatientContactCallResultItem"
+    style="@style/Widget.Simple.PatientContactCallResultItem_Old"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:text="@string/contactpatient_remind_call_later"
@@ -116,7 +116,7 @@
 
   <TextView
     android:id="@+id/removeFromOverdueListTextView"
-    style="@style/Widget.Simple.PatientContactCallResultItem"
+    style="@style/Widget.Simple.PatientContactCallResultItem_Old"
     android:layout_width="0dp"
     android:layout_height="wrap_content"
     android:text="@string/contactpatient_remove_from_list"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -17,6 +17,7 @@
   <dimen name="spacing_48">48dp</dimen>
   <dimen name="spacing_52">52dp</dimen>
   <dimen name="spacing_56">56dp</dimen>
+  <dimen name="spacing_60">60dp</dimen>
   <dimen name="spacing_64">64dp</dimen>
   <dimen name="spacing_96">96dp</dimen>
   <dimen name="spacing_128">128dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -630,7 +630,7 @@
   <string name="contactpatient_patient_died">Died</string>
   <string name="contactpatient_other_reason">Other reason</string>
   <string name="contactpatient_patient_registered_at">Registered at</string>
-  <string name="contactpatient_patient_transferred_from">Transferred from</string>
+  <string name="contactpatient_patient_transfer_from">Transfer from</string>
   <string name="contactpatient_phone">Phone</string>
   <string name="contactpatient_dx">Dx</string>
   <string name="contactpatient_visited">Visited</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -161,7 +161,7 @@
   </style>
 
   <!-- Simple App Views -->
-  <style name="Widget.Simple.PatientContactCallResultItem" parent="">
+  <style name="Widget.Simple.PatientContactCallResultItem_Old" parent="">
     <item name="android:textAppearance">?attr/textAppearanceBody2</item>
     <item name="android:textColor">?attr/colorPrimary</item>
     <item name="android:paddingStart">@dimen/spacing_16</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -172,6 +172,18 @@
     <item name="android:paddingTop">@dimen/spacing_12</item>
   </style>
 
+  <style name="Widget.Simple.PatientContactCallResultItem" parent="">
+    <item name="android:textAppearance">?attr/textAppearanceBody2</item>
+    <item name="android:textColor">?attr/colorPrimary</item>
+    <item name="android:paddingStart">@dimen/spacing_24</item>
+    <item name="android:paddingEnd">@dimen/spacing_24</item>
+    <item name="android:paddingTop">@dimen/spacing_8</item>
+    <item name="android:paddingBottom">@dimen/spacing_8</item>
+    <item name="android:background">?attr/selectableItemBackground</item>
+    <item name="android:drawablePadding">@dimen/spacing_8</item>
+    <item name="android:gravity">center_vertical</item>
+  </style>
+
   <style name="Widget.Simple.ExpandedToolbar.FacilityName" parent="">
     <item name="android:textAppearance">?attr/textAppearanceBody2</item>
     <item name="android:textColor">?attr/colorOnToolbarPrimary</item>
@@ -291,7 +303,7 @@
     <item name="android:minWidth">@dimen/spacing_56</item>
     <item name="android:textAlignment">center</item>
   </style>
-  
+
   <style name="Widget.Simple.TextField.Large.DateInput">
     <item name="android:minWidth">64dp</item>
     <item name="android:minEms">1</item>

--- a/app/src/main/res/values/theme_overlay.xml
+++ b/app/src/main/res/values/theme_overlay.xml
@@ -76,6 +76,7 @@
     <item name="android:statusBarColor">@android:color/transparent</item>
     <item name="android:windowSoftInputMode">adjustResize</item>
     <item name="materialButtonStyle">@style/Widget.Simple.Button</item>
+    <item name="android:colorBackground">@color/simple_light_grey</item>
   </style>
 
   <!-- Widget Specific Theme Overlays -->


### PR DESCRIPTION
- Rename `Widget.Simple.PatientContactCallResultItem` to `Widget.Simple.PatientContactCallResultItem_Old`
- Add `Widget.Simple.PatientContactCallResultItem`
- Set `colorBackground` in `ThemeOverlay.Simple.BottomSheetDialog`
- Fix `contactpatient_callpatient` UI spacing and styling
- Update CHANGELOG
