### PR TITLE
Bump AppCompat to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   - Bump `camera-lifecycle` to v1.0.0
   - Bump `camera-view` to v1.0.0-alpha26
 - Fix UI inconsistencies in overdue list and contact patient sheet
+- Add gradle-versions-plugin for checking dependency updates
+- Bump AppCompat to v1.3.0
 - [In Progress: 16 Jul 2021] Remove the daily and frequent sync separation
 
 ### Changes

--- a/app/src/main/res/layout/contactpatient_appointmentreminder.xml
+++ b/app/src/main/res/layout/contactpatient_appointmentreminder.xml
@@ -35,12 +35,12 @@
     android:layout_marginEnd="9dp"
     android:background="?attr/selectableItemBackgroundBorderless"
     android:padding="@dimen/spacing_12"
-    android:tint="@color/appointment_date_stepper"
     android:tintMode="src_in"
     app:layout_constraintEnd_toStartOf="@+id/selectedAppointmentRelativeDate"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toBottomOf="@+id/calLaterInLabel"
     app:srcCompat="@drawable/ic_remove_circle_outline_32dp"
+    app:tint="@color/appointment_date_stepper"
     tools:ignore="ContentDescription" />
 
   <TextView
@@ -77,12 +77,12 @@
     android:layout_marginEnd="44dp"
     android:background="?attr/selectableItemBackgroundBorderless"
     android:padding="@dimen/spacing_12"
-    android:tint="@color/appointment_date_stepper"
     android:tintMode="src_in"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toEndOf="@+id/selectedAppointmentRelativeDate"
     app:layout_constraintTop_toBottomOf="@+id/calLaterInLabel"
     app:srcCompat="@drawable/ic_add_circle_outline_32dp"
+    app:tint="@color/appointment_date_stepper"
     tools:ignore="ContentDescription" />
 
   <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/item_overdue_list_patient_old.xml
+++ b/app/src/main/res/layout/item_overdue_list_patient_old.xml
@@ -163,8 +163,8 @@
       android:background="@drawable/overdue_call_button_background"
       android:foreground="?selectableItemBackground"
       android:padding="@dimen/spacing_16"
-      android:tint="?attr/colorOnPrimary"
       app:srcCompat="@drawable/ic_call_24dp"
+      app:tint="?attr/colorOnPrimary"
       tools:ignore="ContentDescription,UnusedAttribute" />
 
   </LinearLayout>

--- a/app/src/main/res/layout/screen_edit_patient.xml
+++ b/app/src/main/res/layout/screen_edit_patient.xml
@@ -13,9 +13,9 @@
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackgroundBorderless"
     android:padding="@dimen/spacing_16"
-    android:tint="@color/color_on_surface_67"
     android:tintMode="src_in"
     app:srcCompat="@drawable/ic_close_24dp"
+    app:tint="@color/color_on_surface_67"
     tools:ignore="ContentDescription" />
 
   <ScrollView

--- a/app/src/main/res/layout/screen_manual_patient_entry.xml
+++ b/app/src/main/res/layout/screen_manual_patient_entry.xml
@@ -13,8 +13,8 @@
     android:background="?attr/selectableItemBackgroundBorderless"
     android:contentDescription="@string/patiententry_contentdescription_up_button"
     android:padding="@dimen/spacing_12"
-    android:tint="@color/color_on_surface_67"
-    app:srcCompat="@drawable/ic_arrow_back_24dp" />
+    app:srcCompat="@drawable/ic_arrow_back_24dp"
+    app:tint="@color/color_on_surface_67" />
 
   <ScrollView
     android:id="@+id/formScrollView"

--- a/app/src/main/res/layout/screen_patient_summary.xml
+++ b/app/src/main/res/layout/screen_patient_summary.xml
@@ -27,8 +27,8 @@
       android:background="?selectableItemBackgroundBorderless"
       android:contentDescription="@string/patientsummary_contentdescription_up_button"
       android:padding="@dimen/spacing_12"
-      android:tint="?attr/colorOnToolbarPrimary"
-      app:srcCompat="@drawable/ic_arrow_back_24dp" />
+      app:srcCompat="@drawable/ic_arrow_back_24dp"
+      app:tint="?attr/colorOnToolbarPrimary" />
 
     <com.google.android.material.button.MaterialButton
       android:id="@+id/editPatientButton"

--- a/app/src/main/res/layout/sheet_schedule_appointment.xml
+++ b/app/src/main/res/layout/sheet_schedule_appointment.xml
@@ -39,9 +39,9 @@
       android:layout_height="wrap_content"
       android:background="?selectableItemBackgroundBorderless"
       android:padding="@dimen/spacing_12"
-      android:tint="@color/appointment_date_stepper"
       android:tintMode="src_in"
       app:srcCompat="@drawable/ic_remove_circle_outline_32dp"
+      app:tint="@color/appointment_date_stepper"
       tools:ignore="ContentDescription" />
 
     <TextView
@@ -62,9 +62,9 @@
       android:layout_height="wrap_content"
       android:background="?selectableItemBackgroundBorderless"
       android:padding="@dimen/spacing_12"
-      android:tint="@color/appointment_date_stepper"
       android:tintMode="src_in"
       app:srcCompat="@drawable/ic_add_circle_outline_32dp"
+      app:tint="@color/appointment_date_stepper"
       tools:ignore="ContentDescription" />
 
   </LinearLayout>

--- a/app/src/main/res/layout/sheet_text_input_date_picker.xml
+++ b/app/src/main/res/layout/sheet_text_input_date_picker.xml
@@ -29,11 +29,11 @@
     android:layout_height="wrap_content"
     android:background="?selectableItemBackgroundBorderless"
     android:padding="@dimen/spacing_16"
-    android:tint="?attr/colorPrimary"
     app:layout_constraintBottom_toBottomOf="@id/enterDateTextView"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="@id/enterDateTextView"
     app:srcCompat="@drawable/ic_close_24dp"
+    app:tint="?attr/colorPrimary"
     tools:ignore="ContentDescription" />
 
   <androidx.constraintlayout.widget.Barrier

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -69,7 +69,7 @@ object Versions {
 
   // When bumping this dependency verify whether `org.simple.clinic.feature.Feature.ChangeLanguage`
   // can be enabled again.
-  const val appcompat = "1.2.0"
+  const val appcompat = "1.3.0"
   const val lottie = "3.4.0"
   const val desugarJdk = "1.0.9"
   const val signaturePad = "1.3.1"

--- a/router/build.gradle.kts
+++ b/router/build.gradle.kts
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-  implementation("androidx.appcompat:appcompat:${versions.supportLib}")
+  implementation("androidx.appcompat:appcompat:${versions.appcompat}")
   implementation("com.squareup.flow:flow:${versions.flow}")
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}")
   implementation("io.reactivex.rxjava2:rxjava:${versions.rxJava}")


### PR DESCRIPTION
- Bump AppCompat version to v1.3.0
- Use `app:tint` instead of platform tint
- Update CHANGELOG
