### PR TITLE
Bump CameraX dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
     - Remote config -> 21.0.0
 - Disable Firebase Performance Monitoring for development builds
 - Use full date formatter when rendering last visited date in contact patient sheet
+- Bump CameraX dependencies
+  - Bump `camera-core`, `camera-camera2` to v1.0.0
+  - Bump `camera-lifecycle` to v1.0.0
+  - Bump `camera-view` to v1.0.0-alpha26
 - [In Progress: 16 Jul 2021] Remove the daily and frequent sync separation
 
 ### Features

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -61,9 +61,9 @@ object Versions {
   const val quarantine = "0.3.0"
   const val jackson = "2.10.2"
   const val logback = "1.2.3"
-  const val camerax = "1.0.0-rc04"
-  const val cameraView = "1.0.0-alpha23"
-  const val cameraLifecycle = "1.0.0-rc04"
+  const val camerax = "1.0.0"
+  const val cameraView = "1.0.0-alpha26"
+  const val cameraLifecycle = "1.0.0"
   const val zxing = "3.3.3"
   const val paging = "3.0.0"
 


### PR DESCRIPTION
- Bump CameraX dependency to v1.0.0
- Update CHANGELOG

**Should be tested on all the test devices**
