### PR TITLE
Bump Fragment to v1.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - Bump AppCompat to v1.3.0
 - Move online patient lookup behind a feature flag
 - Cache build dependencies and intermediates in CI workflows
+- Bump Fragment to v1.3.6
+- Disable new `FragmentStateManager`
 - [In Progress: 21 Jul 2021] Use `MobiusLoopViewModel` for sending view effects that are lifecycle aware
   - Replace `MobiusLoop.Controller` with `MobiusLoopViewModel` in base screens
   - Add new interface for handling received view effects

--- a/app/src/main/java/org/simple/clinic/ClinicApp.kt
+++ b/app/src/main/java/org/simple/clinic/ClinicApp.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Application
 import androidx.camera.camera2.Camera2Config
 import androidx.camera.core.CameraXConfig
+import androidx.fragment.app.FragmentManager
 import io.reactivex.exceptions.UndeliverableException
 import io.reactivex.plugins.RxJavaPlugins
 import org.simple.clinic.activity.CloseActivitiesWhenUserIsUnauthorized
@@ -43,12 +44,14 @@ abstract class ClinicApp : Application(), CameraXConfig.Provider {
 
   protected open val crashReporterSinks = emptyList<CrashReporter.Sink>()
 
-  @SuppressLint("RestrictedApi")
+  @SuppressLint("RestrictedApi", "UnsafeOptInUsageWarning")
   override fun onCreate() {
     super.onCreate()
 
     appComponent = buildDaggerGraph()
     appComponent.inject(this)
+
+    FragmentManager.enableNewStateManager(false)
 
     crashReporterSinks.forEach(CrashReporter::addSink)
     Timber.plant(CrashBreadcrumbsTimberTree())

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -77,7 +77,7 @@ object Versions {
   const val lint = "27.1.1"
   const val rootbeer = "0.0.9"
   const val mlKitBarcode = "16.1.4"
-  const val fragment = "1.2.5"
+  const val fragment = "1.3.6"
   const val androidXCoreKtx = "1.3.2"
   const val threetenExtra = "1.6.0"
   const val spotless = "5.6.1"


### PR DESCRIPTION
- Bump Fragment to v1.3.6
- Disable new `FragmentStateManager`
- Update CHANGELOG
