### PR TITLE
Add `MobiusLoopViewModel` to `BaseDialog`

### DIFF
--- a/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
@@ -15,13 +15,13 @@ import com.spotify.mobius.android.MobiusAndroid
 import com.spotify.mobius.rx2.RxMobius
 import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
-import org.simple.clinic.mobius.ViewRenderer
+import org.simple.clinic.R
 import org.simple.clinic.mobius.eventSources
 import org.simple.clinic.mobius.first
 import org.simple.clinic.navigation.v2.ScreenKey
 import org.simple.clinic.util.unsafeLazy
 
-abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F, R : ViewRenderer<M>> : DialogFragment() {
+abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F> : DialogFragment() {
 
   companion object {
     private const val KEY_MODEL = "org.simple.clinic.navigation.v2.fragments.BaseScreen.KEY_MODEL"

--- a/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
@@ -11,10 +11,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.get
 import com.spotify.mobius.EventSource
 import com.spotify.mobius.Init
-import com.spotify.mobius.MobiusLoop
 import com.spotify.mobius.Next.noChange
 import com.spotify.mobius.Update
-import com.spotify.mobius.android.MobiusAndroid
 import com.spotify.mobius.android.MobiusLoopViewModel
 import com.spotify.mobius.functions.Consumer
 import com.spotify.mobius.rx2.RxMobius
@@ -33,16 +31,6 @@ abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F, V> : DialogFragme
   }
 
   private lateinit var viewModel: MobiusLoopViewModel<M, E, F, V>
-
-  private val loop: MobiusLoop.Builder<M, E, F> by unsafeLazy {
-    RxMobius
-        .loop(createUpdate()::update, createEffectHandler())
-        .eventSources(additionalEventSources())
-  }
-
-  private val controller: MobiusLoop.Controller<M, E> by unsafeLazy {
-    MobiusAndroid.controller(loop, defaultModel(), createInit())
-  }
 
   protected val screenKey by unsafeLazy { ScreenKey.key<K>(this) }
 
@@ -89,34 +77,10 @@ abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F, V> : DialogFragme
         ) as T
       }
     }).get()
-
-    val rxBridge = RxMobiusBridge(events(), uiRenderer())
-    controller.connect(rxBridge)
-
-    if (savedInstanceState != null) {
-      val savedModel = savedInstanceState.getParcelable<M>(KEY_MODEL)!!
-      controller.replaceModel(savedModel)
-    }
-  }
-
-  override fun onDestroyView() {
-    super.onDestroyView()
-    controller.disconnect()
-  }
-
-  override fun onResume() {
-    super.onResume()
-    controller.start()
-  }
-
-  override fun onPause() {
-    super.onPause()
-    controller.stop()
   }
 
   override fun onSaveInstanceState(outState: Bundle) {
     super.onSaveInstanceState(outState)
-    outState.putParcelable(KEY_MODEL, controller.model)
     outState.putParcelable(KEY_MODEL, viewModel.model)
   }
 

--- a/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
@@ -46,7 +46,7 @@ abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F, V> : DialogFragme
 
   open fun createInit(): Init<M, F> = Init { model -> first(model) }
 
-  open fun createEffectHandler(): ObservableTransformer<F, E> = ObservableTransformer { Observable.never() }
+  open fun createEffectHandler(viewEffectsConsumer: Consumer<V>): ObservableTransformer<F, E> = ObservableTransformer { Observable.never() }
 
   open fun additionalEventSources(): List<EventSource<E>> = emptyList()
 
@@ -65,7 +65,7 @@ abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F, V> : DialogFragme
 
     viewModel = ViewModelProvider(viewModelStore, object : ViewModelProvider.Factory {
       private fun loop(viewEffectsConsumer: Consumer<V>) = RxMobius
-          .loop(createUpdate(), createEffectHandler())
+          .loop(createUpdate(), createEffectHandler(viewEffectsConsumer))
           .eventSources(additionalEventSources())
 
       @Suppress("UNCHECKED_CAST")

--- a/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
@@ -77,6 +77,9 @@ abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F, V> : DialogFragme
         ) as T
       }
     }).get()
+
+    val uiRenderer = uiRenderer()
+    viewModel.models.observe(viewLifecycleOwner, uiRenderer::render)
   }
 
   override fun onSaveInstanceState(outState: Bundle) {

--- a/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
@@ -21,7 +21,7 @@ import org.simple.clinic.mobius.first
 import org.simple.clinic.navigation.v2.ScreenKey
 import org.simple.clinic.util.unsafeLazy
 
-abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F> : DialogFragment() {
+abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F, V> : DialogFragment() {
 
   companion object {
     private const val KEY_MODEL = "org.simple.clinic.navigation.v2.fragments.BaseScreen.KEY_MODEL"

--- a/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
@@ -18,6 +18,7 @@ import com.spotify.mobius.functions.Consumer
 import com.spotify.mobius.rx2.RxMobius
 import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
+import org.simple.clinic.mobius.ViewEffectsHandler
 import org.simple.clinic.mobius.ViewRenderer
 import org.simple.clinic.mobius.eventSources
 import org.simple.clinic.mobius.first
@@ -39,6 +40,8 @@ abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F, V> : DialogFragme
   abstract fun createDialog(savedInstanceState: Bundle?): Dialog
 
   open fun uiRenderer(): ViewRenderer<M> = NoopViewRenderer()
+
+  open fun viewEffectHandler(): ViewEffectsHandler<V> = NoopViewEffectsHandler()
 
   open fun events(): Observable<E> = Observable.never()
 
@@ -80,6 +83,13 @@ abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F, V> : DialogFragme
 
     val uiRenderer = uiRenderer()
     viewModel.models.observe(viewLifecycleOwner, uiRenderer::render)
+
+    val viewEffectHandler = viewEffectHandler()
+    viewModel.viewEffects.setObserver(
+        viewLifecycleOwner,
+        { liveViewEffect -> viewEffectHandler.handle(liveViewEffect) },
+        { pausedViewEffects -> pausedViewEffects.forEach(viewEffectHandler::handle) }
+    )
   }
 
   override fun onSaveInstanceState(outState: Bundle) {

--- a/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
@@ -15,7 +15,7 @@ import com.spotify.mobius.android.MobiusAndroid
 import com.spotify.mobius.rx2.RxMobius
 import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
-import org.simple.clinic.R
+import org.simple.clinic.mobius.ViewRenderer
 import org.simple.clinic.mobius.eventSources
 import org.simple.clinic.mobius.first
 import org.simple.clinic.navigation.v2.ScreenKey
@@ -41,9 +41,9 @@ abstract class BaseDialog<K : ScreenKey, M : Parcelable, E, F> : DialogFragment(
 
   abstract fun defaultModel(): M
 
-  abstract fun uiRenderer(): R
-
   abstract fun createDialog(savedInstanceState: Bundle?): Dialog
+
+  open fun uiRenderer(): ViewRenderer<M> = NoopViewRenderer()
 
   open fun events(): Observable<E> = Observable.never()
 


### PR DESCRIPTION
- Remove `ViewRenderer` generic property from `BaseDialog`
- Set `NoopViewRenderer` as default UI renderer in `BaseDialog`
- Add view effects generic type to `BaseDialog`
- Add `MobiusLoopViewModel` in `BaseDialog`
- Remove Mobius controller usage from `BaseDialog`
- When viewmodel model updates, then render UI
- Change `BaseDialog#createEffectHandler` signature to accept view effects consumer
- Handle view effects in `BaseDialog`
- Forward UI events to viewmodel in `BaseDialog`
