### PR TITLE
Fix race condition in `onScreenResults` in`ScheduleAppointmentSheet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
   
 ### Fixes
 - Fix `ContactPatientBottomSheet` UI spacing and styling
+- Fix race condition for screen results in `ScheduleAppointmentSheet`
   
 ## Demo
 ### Internal

--- a/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheet.kt
+++ b/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheet.kt
@@ -180,9 +180,11 @@ class ScheduleAppointmentSheet : BaseBottomSheet<
 
   override fun onScreenResult(requestType: Parcelable, result: ScreenResult) {
     if (requestType == DatePickerResult && result is Succeeded) {
-      val selectedDate = result.result as SelectedDate
-      val event = AppointmentCalendarDateSelected(selectedDate = selectedDate.date)
-      calendarDateSelectedEvents.onNext(event)
+      val selectedDate = result.result
+      if (selectedDate is SelectedDate) {
+        val event = AppointmentCalendarDateSelected(selectedDate = selectedDate.date)
+        calendarDateSelectedEvents.onNext(event)
+      }
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheet.kt
+++ b/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheet.kt
@@ -184,6 +184,8 @@ class ScheduleAppointmentSheet : BaseBottomSheet<
       if (selectedDate is SelectedDate) {
         val event = AppointmentCalendarDateSelected(selectedDate = selectedDate.date)
         calendarDateSelectedEvents.onNext(event)
+      } else {
+        closeSheet()
       }
     }
   }


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/3964/fix-race-condition-for-screen-results
This is a possible solution, since we cannot reproduce this, we'll keep it open in clubhouse for a while just in case. If we don't receive any sentry problem like this again then we can remove it.