### PR TITLE
Bump Flipper to v0.98.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
   - Support multiple modals
   - Fix crash when using new `FragmentStateManager`
 - Migrate `ChangeLanguageScreen` to a fragment
+- Bump Flipper to v0.98.0
 
 ### Changes
 - Redesign sync indicator view

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -54,7 +54,7 @@ object Versions {
   const val mobius = "1.5.3"
   const val guava = "28.1-jre" // Used by the "mobius-migration" library ONLY in tests
   const val uuidGenerator = "3.2.0"
-  const val flipper = "0.96.0"
+  const val flipper = "0.98.0"
   const val soloader = "0.10.1"
   const val asm = "7.2"
   const val ktlint = "0.36.0"


### PR DESCRIPTION
- Bump Flipper to v0.98.0
- Update CHANGELOG
