### PR TITLE
Migrate to new Fragment results API for communication between fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Commit and push string formatting changes
 - Add `.gitattributes` for specifying eol for `strings.xml`  
 - Support `ContactPatientSheet` with no appointment
+- Migrate to use new Fragment results API for communication between fragments
 - [In Progress: 04 Aug 2021] Add support for Sri Lanka 
 
 ### Changes

--- a/app/src/main/java/org/simple/clinic/navigation/v2/Router.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/Router.kt
@@ -9,6 +9,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import org.simple.clinic.platform.analytics.Analytics
+import org.simple.clinic.util.setFragmentResult
+import org.simple.clinic.util.setFragmentResultListener
 
 /**
  * Class that maintains a history of screens and is used to perform
@@ -415,12 +417,18 @@ class Router(
   ) {
     val newTopNavRequest = history.top()
     if (currentTopScreen is ExpectingResult && screenResult != null) {
+      val requestType = currentTopScreen.requestType
       val targetFragment = fragmentManager.findFragmentByTag(newTopNavRequest.key.fragmentTag)
 
       require(targetFragment != null) { "Could not find fragment for key: [${newTopNavRequest.key}]" }
       require(targetFragment is ExpectsResult) { "Key [${newTopNavRequest.key}] was pushed expecting results, but fragment [${targetFragment.javaClass.name}] does not implement [${ExpectsResult::class.java.name}]!" }
 
-      handler.post { targetFragment.onScreenResult(currentTopScreen.requestType, screenResult) }
+      fragmentManager.setFragmentResult(requestType, screenResult)
+      with(targetFragment) {
+        setFragmentResultListener(requestType) { _, result ->
+          onScreenResult(requestType, result)
+        }
+      }
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/navigation/v2/Router.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/Router.kt
@@ -48,9 +48,6 @@ class Router(
       containerId = containerId
   )
 
-  // Used for posting screen results
-  private val handler = Handler(Looper.getMainLooper())
-
   fun onReady(savedInstanceState: Bundle?) {
     history = savedInstanceState?.getParcelable(HISTORY_STATE_KEY) ?: history
 

--- a/app/src/main/java/org/simple/clinic/util/FragmentExt.kt
+++ b/app/src/main/java/org/simple/clinic/util/FragmentExt.kt
@@ -1,0 +1,27 @@
+package org.simple.clinic.util
+
+import android.os.Parcelable
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.setFragmentResultListener
+import org.simple.clinic.navigation.v2.ScreenResult
+
+fun Fragment.setFragmentResultListener(
+    requestKey: Parcelable,
+    listener: (requestKey: Parcelable, result: ScreenResult) -> Unit
+) {
+  val requestKeyName = requestKey::class.java.name
+
+  setFragmentResultListener(requestKeyName) { _, bundle ->
+    listener(requestKey, bundle.getParcelable(requestKeyName)!!)
+  }
+}
+
+fun FragmentManager.setFragmentResult(requestKey: Parcelable, result: ScreenResult) {
+  val requestKeyName = requestKey::class.java.name
+
+  setFragmentResult(requestKeyName, bundleOf(
+      requestKeyName to result
+  ))
+}


### PR DESCRIPTION
- Add extensions for fragment results API
- Dispatch screen results using `FragmentManager#setFragmentResult` in `Router`
- Migrate `ContactPatientBottomSheet` to use new fragment results API
- Migrate `AlertFacilityChangeSheet` to use new fragment results API
- Migrate `FacilityChangeScreen` to use new fragment results API
- Migrate `InstantSearchScreen` to use new fragment results API
- Migrate `ScheduleAppointmentSheet` to use new fragment results API
- Migrate `PatientSummaryScreen` to use new fragment results API
- Stop extending `ExpectsResults` in `HomeScreen`
- Remove `ExpectsResult`
- Update CHANGELOG
