### PR TITLE
Bump ML Kit Barcode to v16.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Bump Jackson to v2.12.4
 - Restart `TheActivity` after changing language
 - Don't push to new screen if the top screen is same as the new screen
+- Bump ML Kit Barcode to v16.2.0
 
 ### Changes
 - Redesign sync indicator view

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -76,7 +76,7 @@ object Versions {
   const val viewpager2 = "1.0.0"
   const val lint = "27.2.2"
   const val rootbeer = "0.0.9"
-  const val mlKitBarcode = "16.1.4"
+  const val mlKitBarcode = "16.2.0"
   const val fragment = "1.3.6"
   const val androidXCoreKtx = "1.6.0"
   const val threetenExtra = "1.6.0"


### PR DESCRIPTION
- Bump ML Kit Barcode to v16.2.0
- Update CHANGELOG
