### PR TITLE
Bump AGP to v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@
 - Restart `TheActivity` after changing language
 - Don't push to new screen if the top screen is same as the new screen
 - Bump ML Kit Barcode to v16.2.0
+- Bump Lint to v30.0.0
+- Bump AGP to v7.0.0
 
 ### Changes
 - Redesign sync indicator view

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,7 @@
-import com.android.build.api.variant.VariantFilter
+import com.google.firebase.perf.plugin.FirebasePerfExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.simple.rmg.RoomMetadataGenerator
-import com.google.firebase.perf.plugin.FirebasePerfExtension
 
 repositories {
   maven(url = "https://jitpack.io")
@@ -75,7 +74,7 @@ tasks.withType<Test> {
 }
 
 android {
-  compileSdkVersion(versions.compileSdk)
+  compileSdk = versions.compileSdk
   // Needed to switch NDK versions on the CI server since they have different
   // NDK versions on macOS and Linux environments. Gradle plugin 3.6+ requires
   // us to pin an NDK version if we package native libs.
@@ -88,8 +87,8 @@ android {
 
   defaultConfig {
     applicationId = "org.simple.clinic"
-    minSdkVersion(versions.minSdk)
-    targetSdkVersion(versions.compileSdk)
+    minSdk = versions.minSdk
+    targetSdk = versions.compileSdk
     versionCode = 1
     versionName = "0.1"
     multiDexEnabled = true
@@ -144,7 +143,7 @@ android {
     viewBinding = true
   }
 
-  flavorDimensions("track")
+  flavorDimensions.add("track")
 
   productFlavors {
     create("qa") {
@@ -176,16 +175,21 @@ android {
     }
   }
 
-  val filteredVariants = setOf(
-      "qaRelease", "stagingDebug", "sandboxDebug", "productionDebug", "securityDebug"
-  )
-  variantFilter = Action<VariantFilter> {
-    if (name in filteredVariants) {
-      ignore = true
+  androidComponents {
+    val filteredVariants = setOf(
+        "qaRelease",
+        "stagingDebug",
+        "sandboxDebug",
+        "productionDebug",
+        "securityDebug"
+    )
+
+    beforeVariants { variant ->
+      variant.enabled = variant.name !in filteredVariants
     }
   }
 
-  lintOptions {
+  lint {
     isWarningsAsErrors = true
     isAbortOnError = true
     isCheckReleaseBuilds = false
@@ -218,9 +222,9 @@ android {
 
   packagingOptions {
     // Deprecated ABIs. See https://developer.android.com/ndk/guides/abis
-    exclude("lib/mips/libsqlite3x.so")
-    exclude("lib/mips64/libsqlite3x.so")
-    exclude("lib/armeabi/libsqlite3x.so")
+    jniLibs.excludes.add("lib/mips/libsqlite3x.so")
+    jniLibs.excludes.add("lib/mips64/libsqlite3x.so")
+    jniLibs.excludes.add("lib/armeabi/libsqlite3x.so")
   }
 
   bundle {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -193,6 +193,7 @@ android {
     isWarningsAsErrors = true
     isAbortOnError = true
     isCheckReleaseBuilds = false
+    isCheckDependencies = true
   }
 
   compileOptions {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -2,7 +2,7 @@ object Versions {
   const val minSdk = 21
   const val compileSdk = 30
   const val kotlin = "1.5.21"
-  const val agp = "4.2.2"
+  const val agp = "7.0.0"
   const val roomMetadataGenerator = "1.2.0"
   const val gradleVersions = "0.38.0"
 

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -13,6 +13,8 @@ object Versions {
   const val room = "2.3.0"
   const val androidXTestExt = "1.1.3"
   const val androidXTest = "1.4.0"
+  // Enable Lint partial analysis (android.enableParallelLint) in gradle.properties
+  // once Timber supports it.
   const val timber = "4.7.0"
   const val dagger = "2.35.1"
   const val coreTesting = "2.1.0"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -76,7 +76,7 @@ object Versions {
   const val desugarJdk = "1.0.9"
   const val signaturePad = "1.3.1"
   const val viewpager2 = "1.0.0"
-  const val lint = "27.2.2"
+  const val lint = "30.0.0"
   const val rootbeer = "0.0.9"
   const val mlKitBarcode = "16.2.0"
   const val fragment = "1.3.6"

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,7 @@ defaultProguardFile=proguard-android-optimize.txt
 # Android-specific flags
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableParallelLint=false
 # Mixpanel project tokens are declared here so they can be configured on CI
 mixpanelToken=do_not_change_here
 # Manifest URL endpoint

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/lint/build.gradle.kts
+++ b/lint/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("com.android.lint")
   kotlin("jvm")
+  id("com.android.lint")
 }
 
 dependencies {

--- a/lint/src/main/java/org/simple/clinic/lint/SimpleIssueRegistry.kt
+++ b/lint/src/main/java/org/simple/clinic/lint/SimpleIssueRegistry.kt
@@ -1,6 +1,7 @@
 package org.simple.clinic.lint
 
 import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.client.api.Vendor
 import com.android.tools.lint.detector.api.CURRENT_API
 
 @Suppress("UnstableApiUsage")
@@ -14,4 +15,9 @@ class SimpleIssueRegistry : IssueRegistry() {
 
   override val api: Int
     get() = CURRENT_API
+
+  override val vendor: Vendor = Vendor(
+      vendorName = "Simple.org",
+      feedbackUrl = "https://github.com/simpledotorg/simple-android/issues"
+  )
 }

--- a/mobius-base/build.gradle.kts
+++ b/mobius-base/build.gradle.kts
@@ -4,20 +4,18 @@ plugins {
 }
 
 android {
-  compileSdkVersion(versions.compileSdk)
+  compileSdk = versions.compileSdk
 
   defaultConfig {
-    minSdkVersion(versions.minSdk)
-    targetSdkVersion(versions.compileSdk)
-    versionCode = 1
-    versionName = "0.1"
+    minSdk = versions.minSdk
+    targetSdk = versions.compileSdk
 
     consumerProguardFiles("consumer-rules.pro")
   }
 
   buildTypes {
     getByName("release") {
-      minifyEnabled(false)
+      isMinifyEnabled = false
       proguardFiles(
           getDefaultProguardFile("proguard-android-optimize.txt"),
           "proguard-rules.pro"

--- a/router/build.gradle.kts
+++ b/router/build.gradle.kts
@@ -5,18 +5,16 @@ plugins {
 }
 
 android {
-  compileSdkVersion(versions.compileSdk)
+  compileSdk = versions.compileSdk
 
   defaultConfig {
-    minSdkVersion(versions.minSdk)
-    targetSdkVersion(versions.compileSdk)
-    versionCode = 1
-    versionName = "1.0"
+    minSdk = versions.minSdk
+    targetSdk = versions.compileSdk
   }
 
   buildTypes {
     getByName("release") {
-      minifyEnabled(false)
+      isMinifyEnabled = false
     }
   }
 }

--- a/router/src/main/res/values/strings.xml
+++ b/router/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-  <string name="app_name">Flow router</string>
-</resources>

--- a/simple-platform/build.gradle.kts
+++ b/simple-platform/build.gradle.kts
@@ -4,20 +4,18 @@ plugins {
 }
 
 android {
-  compileSdkVersion(versions.compileSdk)
+  compileSdk = versions.compileSdk
 
   defaultConfig {
-    minSdkVersion(versions.minSdk)
-    targetSdkVersion(versions.compileSdk)
-    versionCode = 1
-    versionName = "0.1"
+    minSdk = versions.minSdk
+    targetSdk = versions.compileSdk
 
     consumerProguardFiles("consumer-rules.pro")
   }
 
   buildTypes {
     getByName("release") {
-      minifyEnabled(false)
+      isMinifyEnabled = false
       proguardFiles(
           getDefaultProguardFile("proguard-android-optimize.txt"),
           "proguard-rules.pro"

--- a/simple-platform/build.gradle.kts
+++ b/simple-platform/build.gradle.kts
@@ -22,9 +22,15 @@ android {
       )
     }
   }
+
+  compileOptions {
+    isCoreLibraryDesugaringEnabled = true
+  }
 }
 
 dependencies {
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}")
   api("com.jakewharton.timber:timber:${versions.timber}")
+
+  coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${versions.desugarJdk}")
 }

--- a/simple-visuals/build.gradle.kts
+++ b/simple-visuals/build.gradle.kts
@@ -4,20 +4,18 @@ plugins {
 }
 
 android {
-  compileSdkVersion(versions.compileSdk)
+  compileSdk = versions.compileSdk
 
   defaultConfig {
-    minSdkVersion(versions.minSdk)
-    targetSdkVersion(versions.compileSdk)
-    versionCode = 1
-    versionName = "0.1"
+    minSdk = versions.minSdk
+    targetSdk = versions.compileSdk
 
     consumerProguardFiles("consumer-rules.pro")
   }
 
   buildTypes {
     getByName("release") {
-      minifyEnabled(false)
+      isMinifyEnabled = false
       proguardFiles(
           getDefaultProguardFile("proguard-android-optimize.txt"),
           "proguard-rules.pro"


### PR DESCRIPTION
- Bump AGP to v7.0.0
- Bump Gradle wrapper to v7.0.2
- Replace deprecated Gradle usages
- Disable Lint partial analysis
- Enable checking dependencies when running lint
- Enable core library desugaring in platform module
- Remove unused resources in router module
- Bump Lint to v30.0.0
- Add `Vendor` in `SimpleIssueRegistry`
- Update CHANGELOG

**Story**: https://app.clubhouse.io/simpledotorg/story/4326/bump-agp-to-v7-0-0

**Release notes**: https://developer.android.com/studio/releases/gradle-plugin#7-0-0
