### PR TITLE
Add `.idea/gradle.properties` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ proguard/
 .idea/$CACHE_FILE$
 .idea/*.xml
 .idea/codeStyles
+.idea/gradle.properties
 .navigation/
 captures/
 *.iml


### PR DESCRIPTION
The latest version of Android Studio/AGP has started adding this as an empty file during the build. Ignoring this.