### PR TITLE
Fix incorrect test in `TheActivityControllerTest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Bump AGP to v7.0.0
 - Bump Play Services Location to v18.0.0
 - Set Simple video and duration based on locale
+- Fix incorrect test in `TheActivityControllerTest`
 - [In Progress: 30 Jul 2021] Support `ContactPatientSheet` with no appointment
 
 ### Changes

--- a/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
@@ -183,7 +183,7 @@ class TheActivityControllerTest {
     ))
     val lockAfterTimestamp = MemoryValue(
         defaultValue = Optional.empty(),
-        currentValue = Optional.of(Instant.now().minusSeconds(TimeUnit.MINUTES.toSeconds(5)))
+        currentValue = Optional.of(currentTimestamp.minusSeconds(TimeUnit.MINUTES.toSeconds(5)))
     )
 
     // when
@@ -191,6 +191,7 @@ class TheActivityControllerTest {
 
     // then
     assertThat(lockAfterTimestamp.hasValue).isTrue()
+    verify(ui).showAppLockScreen()
     verifyNoMoreInteractions(ui)
   }
 

--- a/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
@@ -176,6 +176,11 @@ class TheActivityControllerTest {
   @Test
   fun `when app is started locked and lock timer hasn't expired yet then the timer should not be unset`() {
     // given
+    whenever(userSession.loggedInUserImmediate()).thenReturn(TestData.loggedInUser(
+        uuid = UUID.fromString("049ee3e0-f5a8-4ba6-9270-b20231d3fe50"),
+        loggedInStatus = LOGGED_IN,
+        status = UserStatus.ApprovedForSyncing
+    ))
     val lockAfterTimestamp = MemoryValue(
         defaultValue = Optional.empty(),
         currentValue = Optional.of(Instant.now().minusSeconds(TimeUnit.MINUTES.toSeconds(5)))


### PR DESCRIPTION
There was a test where the setup was being done incorrectly (using the current timestamp instead of the test stub). However, the test was always passing because we were not setting up a mock for the logged in user, so the code path that works with the timestamp was never getting triggered.