### PR TITLE
Don't load search results if search query is not changed from previous search query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - Increase the search and scan button height in patients screen
 - Show new video illustration in patients screen
 - After language is changed app will go back to home screen
+- Don't load search results if search query is not changed from previous search query
   
 ### Fixes
 - Fix `ContactPatientBottomSheet` UI spacing and styling

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchUpdate.kt
@@ -41,12 +41,23 @@ class InstantSearchUpdate @Inject constructor(
       is SearchResultClicked -> searchResultClicked(model, event)
       is PatientAlreadyHasAnExistingNHID -> dispatch(ShowNHIDErrorDialog)
       is PatientDoesNotHaveAnExistingNHID -> dispatch(OpenLinkIdWithPatientScreen(event.patientId, model.additionalIdentifier!!))
-      is SearchQueryChanged -> next(model.searchQueryChanged(event.searchQuery), ValidateSearchQuery(event.searchQuery))
+      is SearchQueryChanged -> searchQueryChanged(model, event)
       SavedNewOngoingPatientEntry -> dispatch(OpenPatientEntryScreen(model.facility!!))
       RegisterNewPatientClicked -> registerNewPatient(model)
       is BlankScannedQrCodeResultReceived -> blankScannedQrCodeResult(model, event)
       is OpenQrCodeScannerClicked -> dispatch(OpenQrCodeScanner)
       is SearchResultsLoadStateChanged -> searchResultsLoadStateChanged(model, event)
+    }
+  }
+
+  private fun searchQueryChanged(
+      model: InstantSearchModel,
+      event: SearchQueryChanged
+  ): Next<InstantSearchModel, InstantSearchEffect> {
+    return if (event.searchQuery != model.searchQuery) {
+      next(model.searchQueryChanged(event.searchQuery), ValidateSearchQuery(event.searchQuery))
+    } else {
+      noChange()
     }
   }
 

--- a/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchUpdateTest.kt
@@ -5,6 +5,7 @@ import com.spotify.mobius.test.NextMatchers.hasEffects
 import com.spotify.mobius.test.NextMatchers.hasModel
 import com.spotify.mobius.test.NextMatchers.hasNoEffects
 import com.spotify.mobius.test.NextMatchers.hasNoModel
+import com.spotify.mobius.test.NextMatchers.hasNothing
 import com.spotify.mobius.test.UpdateSpec
 import com.spotify.mobius.test.UpdateSpec.assertThatNext
 import org.junit.Test
@@ -247,6 +248,24 @@ class InstantSearchUpdateTest {
         .then(assertThatNext(
             hasModel(facilityLoadedModel.searchQueryChanged("Pat")),
             hasEffects(ValidateSearchQuery("Pat"))
+        ))
+  }
+
+  @Test
+  fun `when search query is changed and is same as search query in model, then do nothing`() {
+    val facility = TestData.facility(
+        uuid = UUID.fromString("76b89c39-1bc4-4560-9a44-0381c59b58d0"),
+        name = "PHC Obvious"
+    )
+    val facilityLoadedModel = defaultModel
+        .facilityLoaded(facility)
+        .searchQueryChanged("Pat")
+
+    updateSpec
+        .given(facilityLoadedModel)
+        .whenEvent(SearchQueryChanged("Pat"))
+        .then(assertThatNext(
+            hasNothing()
         ))
   }
 


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/4404/don-t-load-search-results-if-search-query-is-not-changed-from-previous-search-query