### PR TITLE
Migrate to Fragment results API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Change Sri Lanka iso country code to `LK`
 - Bump asm to v9.2
 - Set Sri Lanka display name in country selection screen
+- Migrate to Fragment results API
 - [In Progress: 06 Aug 2021] Unify the patient age details into a single model
 
 ### Changes

--- a/app/src/main/java/org/simple/clinic/facility/alertchange/AlertFacilityChangeSheet.kt
+++ b/app/src/main/java/org/simple/clinic/facility/alertchange/AlertFacilityChangeSheet.kt
@@ -18,16 +18,15 @@ import org.simple.clinic.facility.alertchange.Continuation.ContinueToScreen_Old
 import org.simple.clinic.facility.change.FacilityChangeScreen
 import org.simple.clinic.feature.Features
 import org.simple.clinic.mobius.ViewRenderer
-import org.simple.clinic.navigation.v2.ExpectsResult
 import org.simple.clinic.navigation.v2.Router
 import org.simple.clinic.navigation.v2.ScreenKey
-import org.simple.clinic.navigation.v2.ScreenResult
 import org.simple.clinic.navigation.v2.Succeeded
 import org.simple.clinic.navigation.v2.compat.wrap
 import org.simple.clinic.navigation.v2.fragments.BaseBottomSheet
 import org.simple.clinic.router.ScreenResultBus
 import org.simple.clinic.router.screen.FullScreenKey
 import org.simple.clinic.router.util.resolveFloat
+import org.simple.clinic.util.setFragmentResultListener
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
@@ -39,8 +38,7 @@ class AlertFacilityChangeSheet :
         AlertFacilityChangeModel,
         AlertFacilityChangeEvent,
         AlertFacilityChangeEffect,
-        Unit>(),
-    ExpectsResult {
+        Unit>() {
 
   @Inject
   lateinit var locale: Locale
@@ -114,18 +112,16 @@ class AlertFacilityChangeSheet :
         openFacilityChangeScreen()
       }
     }
+
+    setFragmentResultListener(ChangeCurrentFacility) { _, result ->
+      if (result is Succeeded) proceedToNextScreen()
+    }
   }
 
   private fun showDialogUi() {
     val backgroundDimAmount = requireContext().resolveFloat(android.R.attr.backgroundDimAmount)
     requireDialog().window!!.setDimAmount(backgroundDimAmount)
     binding.root.visibility = View.VISIBLE
-  }
-
-  override fun onScreenResult(requestType: Parcelable, result: ScreenResult) {
-    if (requestType == ChangeCurrentFacility && result is Succeeded) {
-      proceedToNextScreen()
-    }
   }
 
   private fun proceedToNextScreen() {

--- a/app/src/main/java/org/simple/clinic/facility/change/FacilityChangeScreen.kt
+++ b/app/src/main/java/org/simple/clinic/facility/change/FacilityChangeScreen.kt
@@ -16,13 +16,12 @@ import org.simple.clinic.di.injector
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.facility.change.confirm.ConfirmFacilityChangeSheet
 import org.simple.clinic.feature.Features
-import org.simple.clinic.navigation.v2.ExpectsResult
 import org.simple.clinic.navigation.v2.Router
 import org.simple.clinic.navigation.v2.ScreenKey
-import org.simple.clinic.navigation.v2.ScreenResult
 import org.simple.clinic.navigation.v2.Succeeded
 import org.simple.clinic.navigation.v2.fragments.BaseScreen
 import org.simple.clinic.util.RuntimePermissions
+import org.simple.clinic.util.setFragmentResultListener
 import org.simple.clinic.widgets.UiEvent
 import java.util.Locale
 import javax.inject.Inject
@@ -36,8 +35,7 @@ class FacilityChangeScreen :
         FacilityChangeEffect,
         Unit>(),
     FacilityChangeUi,
-    FacilityChangeUiActions,
-    ExpectsResult {
+    FacilityChangeUiActions {
 
   @Inject
   lateinit var locale: Locale
@@ -82,13 +80,13 @@ class FacilityChangeScreen :
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
     setupUiComponents()
-  }
 
-  override fun onScreenResult(requestType: Parcelable, result: ScreenResult) {
-    if (requestType == ConfirmFacility && result is Succeeded) {
-      val facilityChangeConfirmed = ConfirmFacilityChangeSheet.wasFacilityChanged(result)
+    setFragmentResultListener(ConfirmFacility) { _, result ->
+      if (result is Succeeded) {
+        val facilityChangeConfirmed = ConfirmFacilityChangeSheet.wasFacilityChanged(result)
 
-      handleFacilityChangeConfirmed(facilityChangeConfirmed)
+        handleFacilityChangeConfirmed(facilityChangeConfirmed)
+      }
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/home/HomeScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomeScreen.kt
@@ -23,9 +23,7 @@ import org.simple.clinic.home.HomeTab.OVERDUE
 import org.simple.clinic.home.HomeTab.PATIENTS
 import org.simple.clinic.home.HomeTab.REPORTS
 import org.simple.clinic.home.help.HelpScreenKey
-import org.simple.clinic.navigation.v2.ExpectsResult
 import org.simple.clinic.navigation.v2.Router
-import org.simple.clinic.navigation.v2.ScreenResult
 import org.simple.clinic.navigation.v2.compat.wrap
 import org.simple.clinic.navigation.v2.fragments.BaseScreen
 import org.simple.clinic.router.ScreenResultBus
@@ -43,8 +41,7 @@ class HomeScreen :
         HomeScreenEffect,
         Unit>(),
     HomeScreenUi,
-    HomeScreenUiActions,
-    ExpectsResult {
+    HomeScreenUiActions {
 
   @Inject
   lateinit var router: Router
@@ -132,10 +129,6 @@ class HomeScreen :
   override fun onDestroyView() {
     viewPager.adapter = null
     super.onDestroyView()
-  }
-
-  override fun onScreenResult(requestType: Parcelable, result: ScreenResult) {
-
   }
 
   private fun setupToolBar() {

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchScreen.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchScreen.kt
@@ -38,9 +38,7 @@ import org.simple.clinic.feature.Features
 import org.simple.clinic.instantsearch.InstantSearchProgressState.DONE
 import org.simple.clinic.instantsearch.InstantSearchProgressState.IN_PROGRESS
 import org.simple.clinic.instantsearch.InstantSearchProgressState.NO_RESULTS
-import org.simple.clinic.navigation.v2.ExpectsResult
 import org.simple.clinic.navigation.v2.Router
-import org.simple.clinic.navigation.v2.ScreenResult
 import org.simple.clinic.navigation.v2.Succeeded
 import org.simple.clinic.navigation.v2.fragments.BaseScreen
 import org.simple.clinic.newentry.PatientEntryScreenKey
@@ -56,6 +54,7 @@ import org.simple.clinic.summary.PatientSummaryScreenKey
 import org.simple.clinic.util.RequestPermissions
 import org.simple.clinic.util.RuntimePermissions
 import org.simple.clinic.util.UtcClock
+import org.simple.clinic.util.setFragmentResultListener
 import org.simple.clinic.widgets.PagingItemAdapter
 import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.hideKeyboard
@@ -78,8 +77,7 @@ class InstantSearchScreen :
         InstantSearchEffect,
         Unit>(),
     InstantSearchUi,
-    InstantSearchUiActions,
-    ExpectsResult {
+    InstantSearchUiActions {
 
   @Inject
   lateinit var effectHandlerFactory: InstantSearchEffectHandler.Factory
@@ -199,6 +197,13 @@ class InstantSearchScreen :
 
     searchResultsView.adapter = searchResultsAdapter
     searchResultsAdapter.addLoadStateListener(::searchResultsAdapterLoadStateListener)
+
+    setFragmentResultListener(BlankScannedQrCode) { _, result ->
+      if (result is Succeeded) {
+        val scannedQrCodeResult = ScannedQrCodeSheet.blankScannedQrCodeResult(result)
+        blankScannedQrCodeResults.onNext(BlankScannedQrCodeResultReceived(scannedQrCodeResult))
+      }
+    }
   }
 
   override fun onStart() {
@@ -306,13 +311,6 @@ class InstantSearchScreen :
 
   override fun hideResults() {
     searchResultsView.visibility = View.GONE
-  }
-
-  override fun onScreenResult(requestType: Parcelable, result: ScreenResult) {
-    if (requestType == BlankScannedQrCode && result is Succeeded) {
-      val scannedQrCodeResult = ScannedQrCodeSheet.blankScannedQrCodeResult(result)
-      blankScannedQrCodeResults.onNext(BlankScannedQrCodeResultReceived(scannedQrCodeResult))
-    }
   }
 
   private fun searchResultsAdapterLoadStateListener(loadStates: CombinedLoadStates) {

--- a/app/src/main/java/org/simple/clinic/navigation/v2/ExpectsResult.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/ExpectsResult.kt
@@ -1,7 +1,0 @@
-package org.simple.clinic.navigation.v2
-
-import android.os.Parcelable
-
-interface ExpectsResult {
-  fun onScreenResult(requestType: Parcelable, result: ScreenResult)
-}

--- a/app/src/main/java/org/simple/clinic/navigation/v2/Router.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/Router.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import org.simple.clinic.platform.analytics.Analytics
+import org.simple.clinic.util.setFragmentResult
 
 /**
  * Class that maintains a history of screens and is used to perform
@@ -413,14 +414,10 @@ class Router(
       currentTopScreen: NavRequest,
       screenResult: ScreenResult?
   ) {
-    val newTopNavRequest = history.top()
     if (currentTopScreen is ExpectingResult && screenResult != null) {
-      val targetFragment = fragmentManager.findFragmentByTag(newTopNavRequest.key.fragmentTag)
+      val requestType = currentTopScreen.requestType
 
-      require(targetFragment != null) { "Could not find fragment for key: [${newTopNavRequest.key}]" }
-      require(targetFragment is ExpectsResult) { "Key [${newTopNavRequest.key}] was pushed expecting results, but fragment [${targetFragment.javaClass.name}] does not implement [${ExpectsResult::class.java.name}]!" }
-
-      handler.post { targetFragment.onScreenResult(currentTopScreen.requestType, screenResult) }
+      fragmentManager.setFragmentResult(requestType, screenResult)
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheet.kt
+++ b/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentSheet.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.View.GONE
@@ -26,10 +25,8 @@ import org.simple.clinic.datepicker.SelectedDate
 import org.simple.clinic.di.injector
 import org.simple.clinic.feature.Features
 import org.simple.clinic.mobius.DeferredEventSource
-import org.simple.clinic.navigation.v2.ExpectsResult
 import org.simple.clinic.navigation.v2.Router
 import org.simple.clinic.navigation.v2.ScreenKey
-import org.simple.clinic.navigation.v2.ScreenResult
 import org.simple.clinic.navigation.v2.Succeeded
 import org.simple.clinic.navigation.v2.fragments.BaseBottomSheet
 import org.simple.clinic.newentry.ButtonState
@@ -39,6 +36,7 @@ import org.simple.clinic.scheduleappointment.facilityselection.FacilitySelection
 import org.simple.clinic.summary.AppointmentSheetOpenedFrom
 import org.simple.clinic.summary.teleconsultation.status.TeleconsultStatusSheet
 import org.simple.clinic.util.UserClock
+import org.simple.clinic.util.setFragmentResultListener
 import org.simple.clinic.widgets.ProgressMaterialButton.ButtonState.Enabled
 import org.simple.clinic.widgets.ProgressMaterialButton.ButtonState.InProgress
 import java.time.LocalDate
@@ -55,7 +53,7 @@ class ScheduleAppointmentSheet : BaseBottomSheet<
     ScheduleAppointmentModel,
     ScheduleAppointmentEvent,
     ScheduleAppointmentEffect,
-    Unit>(), ScheduleAppointmentUi, ScheduleAppointmentUiActions, ExpectsResult {
+    Unit>(), ScheduleAppointmentUi, ScheduleAppointmentUiActions {
 
   companion object {
     private const val REQCODE_FACILITY_SELECT = 100
@@ -171,20 +169,20 @@ class ScheduleAppointmentSheet : BaseBottomSheet<
     changeFacilityButton.setOnClickListener {
       openFacilitySelection()
     }
+
+    setFragmentResultListener(DatePickerResult) { _, result ->
+      if (result is Succeeded) {
+        val selectedDate = result.result as SelectedDate
+        val event = AppointmentCalendarDateSelected(selectedDate = selectedDate.date)
+        calendarDateSelectedEvents.onNext(event)
+      }
+    }
   }
 
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     super.onActivityResult(requestCode, resultCode, data)
     if (resultCode == Activity.RESULT_OK) {
       manageRequestCodes(requestCode, data)
-    }
-  }
-
-  override fun onScreenResult(requestType: Parcelable, result: ScreenResult) {
-    if (requestType == DatePickerResult && result is Succeeded) {
-      val selectedDate = result.result as SelectedDate
-      val event = AppointmentCalendarDateSelected(selectedDate = selectedDate.date)
-      calendarDateSelectedEvents.onNext(event)
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -38,10 +38,8 @@ import org.simple.clinic.facility.alertchange.Continuation.ContinueToScreen_Old
 import org.simple.clinic.home.HomeScreenKey
 import org.simple.clinic.mobius.DeferredEventSource
 import org.simple.clinic.mobius.ViewRenderer
-import org.simple.clinic.navigation.v2.ExpectsResult
 import org.simple.clinic.navigation.v2.HandlesBack
 import org.simple.clinic.navigation.v2.Router
-import org.simple.clinic.navigation.v2.ScreenResult
 import org.simple.clinic.navigation.v2.Succeeded
 import org.simple.clinic.navigation.v2.fragments.BaseScreen
 import org.simple.clinic.patient.DateOfBirth
@@ -61,6 +59,7 @@ import org.simple.clinic.summary.updatephone.UpdatePhoneNumberDialog
 import org.simple.clinic.teleconsultlog.teleconsultrecord.screen.TeleconsultRecordScreenKey
 import org.simple.clinic.util.UserClock
 import org.simple.clinic.util.messagesender.WhatsAppMessageSender
+import org.simple.clinic.util.setFragmentResultListener
 import org.simple.clinic.util.toLocalDateAtZone
 import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.hideKeyboard
@@ -82,8 +81,7 @@ class PatientSummaryScreen :
     PatientSummaryScreenUi,
     PatientSummaryUiActions,
     PatientSummaryChildView,
-    HandlesBack,
-    ExpectsResult {
+    HandlesBack {
 
   private val rootLayout
     get() = binding.rootLayout
@@ -250,12 +248,12 @@ class PatientSummaryScreen :
     rootLayout.hideKeyboard()
 
     subscriptions.add(setupChildViewVisibility())
-  }
 
-  override fun onScreenResult(requestType: Parcelable, result: ScreenResult) {
-    if (requestType == ScreenRequest.ScheduleAppointmentSheet && result is Succeeded) {
-      val sheetOpenedFrom = ScheduleAppointmentSheet.sheetOpenedFrom(result)
-      appointmentScheduleSheetClosed.notify(ScheduledAppointment(sheetOpenedFrom))
+    setFragmentResultListener(ScreenRequest.ScheduleAppointmentSheet) { _, result ->
+      if (result is Succeeded) {
+        val sheetOpenedFrom = ScheduleAppointmentSheet.sheetOpenedFrom(result)
+        appointmentScheduleSheetClosed.notify(ScheduledAppointment(sheetOpenedFrom))
+      }
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/util/FragmentExt.kt
+++ b/app/src/main/java/org/simple/clinic/util/FragmentExt.kt
@@ -1,0 +1,41 @@
+package org.simple.clinic.util
+
+import android.os.Parcelable
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.setFragmentResultListener
+import org.simple.clinic.navigation.v2.ScreenResult
+
+fun Fragment.setFragmentResultListener(
+    vararg requestKeys: Parcelable,
+    listener: (requestKey: Parcelable, result: ScreenResult) -> Unit
+) {
+  requestKeys.forEach { requestKey ->
+    val requestKeyName = requestKey::class.java.name
+    setFragmentResultListener(requestKeyName, requestKeys, listener)
+  }
+}
+
+private fun Fragment.setFragmentResultListener(
+    requestKeyName: String,
+    requestKeys: Array<out Parcelable>,
+    listener: (requestKey: Parcelable, result: ScreenResult) -> Unit
+) {
+  setFragmentResultListener(requestKeyName) { requestKey, bundle ->
+    val key = requestKeys.firstOrNull { key -> key::class.java.name == requestKey }
+
+    if (key != null)
+      listener(key, bundle.getParcelable(requestKey)!!)
+    else
+      throw IllegalArgumentException("Unknown request key: $key, in fragment: $tag")
+  }
+}
+
+fun FragmentManager.setFragmentResult(requestKey: Parcelable, result: ScreenResult) {
+  val requestKeyName = requestKey::class.java.name
+
+  setFragmentResult(requestKeyName, bundleOf(
+      requestKeyName to result
+  ))
+}


### PR DESCRIPTION
- Add fragment extensions for fragment results
- Set fragment result when dispatching screen results in `Router`
- Migrate `AlertFacilityChangeSheet` to use fragment results listener
- Migrate `ContactPatientBottomSheet` to use fragment results listener
- Migrate `FacilityChangeScreen` to use fragment results listener
- Migrate `InstantSearchScreen` to use fragment results listener
- Migrate `PatientSummaryScreen` to use fragment results listener
- Migrate `ScheduleAppointmentSheet` to use fragment results listener
- Removed unused code
- Update CHANGELOG
