### PR TITLE
Migrate `PatientEntryScreen` to a fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Bump AppCompat to v1.3.1
 - Bump RecyclerView to v1.2.1
 - Unify the patient age details into a single model
+- Migrate `PatientEntryScreen` to a fragment
 
 ### Changes
 - Don't load search results if search query is not changed from previous search query

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchScreen.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchScreen.kt
@@ -41,7 +41,7 @@ import org.simple.clinic.instantsearch.InstantSearchProgressState.NO_RESULTS
 import org.simple.clinic.navigation.v2.Router
 import org.simple.clinic.navigation.v2.Succeeded
 import org.simple.clinic.navigation.v2.fragments.BaseScreen
-import org.simple.clinic.newentry.PatientEntryScreenKey
+import org.simple.clinic.newentry.PatientEntryScreen
 import org.simple.clinic.patient.PatientSearchResult
 import org.simple.clinic.patient.businessid.Identifier
 import org.simple.clinic.router.ScreenResultBus
@@ -260,7 +260,7 @@ class InstantSearchScreen :
   override fun openPatientEntryScreen(facility: Facility) {
     router.push(AlertFacilityChangeSheet.Key(
         currentFacilityName = facility.name,
-        continuation = Continuation.ContinueToScreen_Old(PatientEntryScreenKey())
+        continuation = Continuation.ContinueToScreen(PatientEntryScreen.Key())
     ))
   }
 

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
@@ -223,7 +223,7 @@ class PatientEntryScreen : BaseScreen<
 
   private val villageTypeAheadAdapter by unsafeLazy {
     ArrayAdapter<String>(
-        context,
+        requireContext(),
         R.layout.village_typeahead_list_item,
         R.id.villageTypeAheadItemTextView,
         mutableListOf()
@@ -374,7 +374,7 @@ class PatientEntryScreen : BaseScreen<
     )
 
     inputFields.fields.forEach {
-      allTextInputFields[it::class.java]?.hint = context.getString(it.labelResId)
+      allTextInputFields[it::class.java]?.hint = getString(it.labelResId)
     }
   }
 
@@ -531,7 +531,7 @@ class PatientEntryScreen : BaseScreen<
   }
 
   private fun inflateAlternateIdView(identifier: String) {
-    val layoutInflater = LayoutInflater.from(context)
+    val layoutInflater = LayoutInflater.from(requireContext())
     val alternateIdView = PatientEntryAlternateIdViewBinding.inflate(layoutInflater, this, false)
     alternateIdView.alternateIdentifier.text = identifier
     alternateIdContainer.addView(alternateIdView.root)
@@ -607,7 +607,7 @@ class PatientEntryScreen : BaseScreen<
 
   override fun showLengthTooShortPhoneNumberError(show: Boolean, requiredNumberLength: Int) {
     if (show) {
-      phoneNumberInputLayout.error = context.getString(R.string.patiententry_error_phonenumber_length_less, requiredNumberLength.toString())
+      phoneNumberInputLayout.error = getString(R.string.patiententry_error_phonenumber_length_less, requiredNumberLength.toString())
     } else {
       phoneNumberInputLayout.error = null
     }
@@ -615,7 +615,7 @@ class PatientEntryScreen : BaseScreen<
 
   override fun showLengthTooLongPhoneNumberError(show: Boolean, requiredNumberLength: Int) {
     if (show) {
-      phoneNumberInputLayout.error = context.getString(R.string.patiententry_error_phonenumber_length_more, requiredNumberLength.toString())
+      phoneNumberInputLayout.error = getString(R.string.patiententry_error_phonenumber_length_more, requiredNumberLength.toString())
     } else {
       phoneNumberInputLayout.error = null
     }

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
@@ -1,7 +1,9 @@
 package org.simple.clinic.newentry
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.graphics.Typeface.BOLD
+import android.os.Bundle
 import android.os.Parcelable
 import android.text.style.StyleSpan
 import android.view.LayoutInflater
@@ -295,6 +297,20 @@ class PatientEntryScreen : BaseScreen<
       layoutInflater: LayoutInflater,
       container: ViewGroup?
   ) = ScreenManualPatientEntryBinding.inflate(layoutInflater, container, false)
+
+  override fun onAttach(context: Context) {
+    super.onAttach(context)
+    context.injector<Injector>().inject(this)
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    backButton.setOnClickListener { router.pop() }
+
+    if (features.isEnabled(Feature.VillageTypeAhead)) {
+      colonyOrVillageEditText.setAdapter(villageTypeAheadAdapter)
+    }
+  }
 
   @SuppressLint("CheckResult")
   override fun onFinishInflate() {

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
@@ -1,10 +1,8 @@
 package org.simple.clinic.newentry
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Typeface.BOLD
 import android.os.Bundle
-import android.os.Parcelable
 import android.text.style.StyleSpan
 import android.view.LayoutInflater
 import android.view.View
@@ -28,7 +26,6 @@ import com.spotify.mobius.functions.Consumer
 import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
-import io.reactivex.rxkotlin.ofType
 import kotlinx.parcelize.Parcelize
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
@@ -39,7 +36,6 @@ import org.simple.clinic.di.injector
 import org.simple.clinic.feature.Feature
 import org.simple.clinic.feature.Features
 import org.simple.clinic.medicalhistory.newentry.NewMedicalHistoryScreenKey
-import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.navigation.v2.Router
 import org.simple.clinic.navigation.v2.ScreenKey
 import org.simple.clinic.navigation.v2.compat.wrap
@@ -73,6 +69,7 @@ import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility.B
 import org.simple.clinic.widgets.ageanddateofbirth.DateOfBirthAndAgeVisibility.DATE_OF_BIRTH_VISIBLE
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputAgeValidator
 import org.simple.clinic.widgets.ageanddateofbirth.UserInputDateValidator
+import org.simple.clinic.widgets.hideKeyboard
 import org.simple.clinic.widgets.scrollToChild
 import org.simple.clinic.widgets.setTextAndCursor
 import org.simple.clinic.widgets.showKeyboard
@@ -110,118 +107,119 @@ class PatientEntryScreen : BaseScreen<
   @Inject
   lateinit var features: Features
 
-  private var binding: ScreenManualPatientEntryBinding? = null
+  private val rootView
+    get() = binding.root
 
   private val fullNameEditText
-    get() = binding!!.fullNameEditText
+    get() = binding.fullNameEditText
 
   private val ageEditText
-    get() = binding!!.ageEditText
+    get() = binding.ageEditText
 
   private val dateOfBirthEditText
-    get() = binding!!.dateOfBirthEditText
+    get() = binding.dateOfBirthEditText
 
   private val phoneNumberEditText
-    get() = binding!!.phoneNumberEditText
+    get() = binding.phoneNumberEditText
 
   private val colonyOrVillageEditText
-    get() = binding!!.colonyOrVillageEditText
+    get() = binding.colonyOrVillageEditText
 
   private val districtEditText
-    get() = binding!!.districtEditText
+    get() = binding.districtEditText
 
   private val stateEditText
-    get() = binding!!.stateEditText
+    get() = binding.stateEditText
 
   private val backButton
-    get() = binding!!.backButton
+    get() = binding.backButton
 
   private val identifierTextView
-    get() = binding!!.identifierTextView
+    get() = binding.identifierTextView
 
   private val fullNameInputLayout
-    get() = binding!!.fullNameInputLayout
+    get() = binding.fullNameInputLayout
 
   private val ageEditTextInputLayout
-    get() = binding!!.ageEditTextInputLayout
+    get() = binding.ageEditTextInputLayout
 
   private val dateOfBirthInputLayout
-    get() = binding!!.dateOfBirthInputLayout
+    get() = binding.dateOfBirthInputLayout
 
   private val phoneNumberInputLayout
-    get() = binding!!.phoneNumberInputLayout
+    get() = binding.phoneNumberInputLayout
 
   private val genderRadioGroup
-    get() = binding!!.genderRadioGroup
+    get() = binding.genderRadioGroup
 
   private val alternativeIdInputLayout
-    get() = binding!!.alternativeIdInputLayout
+    get() = binding.alternativeIdInputLayout
 
   private val streetAddressInputLayout
-    get() = binding!!.streetAddressInputLayout
+    get() = binding.streetAddressInputLayout
 
   private val colonyOrVillageInputLayout
-    get() = binding!!.colonyOrVillageInputLayout
+    get() = binding.colonyOrVillageInputLayout
 
   private val zoneInputLayout
-    get() = binding!!.zoneInputLayout
+    get() = binding.zoneInputLayout
 
   private val districtInputLayout
-    get() = binding!!.districtInputLayout
+    get() = binding.districtInputLayout
 
   private val stateInputLayout
-    get() = binding!!.stateInputLayout
+    get() = binding.stateInputLayout
 
   private val maleRadioButton
-    get() = binding!!.maleRadioButton
+    get() = binding.maleRadioButton
 
   private val femaleRadioButton
-    get() = binding!!.femaleRadioButton
+    get() = binding.femaleRadioButton
 
   private val transgenderRadioButton
-    get() = binding!!.transgenderRadioButton
+    get() = binding.transgenderRadioButton
 
   private val consentTextView
-    get() = binding!!.consentTextView
+    get() = binding.consentTextView
 
   private val consentLabel
-    get() = binding!!.consentLabel
+    get() = binding.consentLabel
 
   private val alternativeIdInputEditText
-    get() = binding!!.alternativeIdInputEditText
+    get() = binding.alternativeIdInputEditText
 
   private val zoneEditText
-    get() = binding!!.zoneEditText
+    get() = binding.zoneEditText
 
   private val streetAddressEditText
-    get() = binding!!.streetAddressEditText
+    get() = binding.streetAddressEditText
 
   private val consentSwitch
-    get() = binding!!.consentSwitch
+    get() = binding.consentSwitch
 
   private val dateOfBirthAndAgeSeparator
-    get() = binding!!.dateOfBirthAndAgeSeparator
+    get() = binding.dateOfBirthAndAgeSeparator
 
   private val genderErrorTextView
-    get() = binding!!.genderErrorTextView
+    get() = binding.genderErrorTextView
 
   private val formScrollView
-    get() = binding!!.formScrollView
+    get() = binding.formScrollView
 
   private val patientEntryRoot
-    get() = binding!!.patientEntryRoot
+    get() = binding.patientEntryRoot
 
   private val identifierContainer
-    get() = binding!!.identifierContainer
+    get() = binding.identifierContainer
 
   private val saveButton
-    get() = binding!!.saveButton
+    get() = binding.saveButton
 
   private val alternateIdLabel
-    get() = binding!!.alternateIdLabel
+    get() = binding.alternateIdLabel
 
   private val alternateIdContainer
-    get() = binding!!.alternateIdContainer
+    get() = binding.alternateIdContainer
 
   private val villageTypeAheadAdapter by unsafeLazy {
     ArrayAdapter<String>(
@@ -255,26 +253,6 @@ class PatientEntryScreen : BaseScreen<
    * to track the fact that we've already shown it.
    **/
   private var alreadyFocusedOnEmptyTextField: Boolean = false
-
-  private val uiRenderer = PatientEntryUiRenderer(this)
-
-  private val events: Observable<PatientEntryEvent> by unsafeLazy {
-    Observable
-        .merge(formChanges(), saveClicks(), consentChanges())
-        .compose(ReportAnalyticsEvents())
-        .cast<PatientEntryEvent>()
-  }
-
-  private val delegate by unsafeLazy {
-    MobiusDelegate.forView(
-        events = events.ofType(),
-        defaultModel = PatientEntryModel.DEFAULT,
-        init = PatientEntryInit(isVillageTypeAheadEnabled = features.isEnabled(Feature.VillageTypeAhead)),
-        update = PatientEntryUpdate(phoneNumberValidator, dobValidator, ageValidator),
-        effectHandler = effectHandlerFactory.create(ui = this, validationActions = this).build(),
-        modelUpdateListener = uiRenderer::render
-    )
-  }
 
   override fun defaultModel() = PatientEntryModel.DEFAULT
 
@@ -312,31 +290,13 @@ class PatientEntryScreen : BaseScreen<
     }
   }
 
-  @SuppressLint("CheckResult")
-  override fun onFinishInflate() {
-    super.onFinishInflate()
-    if (isInEditMode) {
-      return
-    }
-
-    binding = ScreenManualPatientEntryBinding.bind(this)
-
-    context.injector<Injector>().inject(this)
-
-    backButton.setOnClickListener { router.pop() }
-
-    if (features.isEnabled(Feature.VillageTypeAhead)) {
-      colonyOrVillageEditText.setAdapter(villageTypeAheadAdapter)
-    }
-  }
-
   override fun setupUi(inputFields: InputFields) {
     // Not sure why, but setting android:nextFocusDown in XML isn't working,
     // so doing this manually here.
     dateOfBirthEditText.imeOptions += EditorInfo.IME_ACTION_NEXT
     dateOfBirthEditText.setOnEditorActionListener { _, actionId, _ ->
       // When date is empty, this will move focus to age field and colony field otherwise.
-      if (!dateOfBirthEditText.text!!.isBlank() && actionId == EditorInfo.IME_ACTION_NEXT) {
+      if (dateOfBirthEditText.text!!.isNotBlank() && actionId == EditorInfo.IME_ACTION_NEXT) {
         colonyOrVillageEditText.requestFocus()
         true
       } else {
@@ -428,26 +388,6 @@ class PatientEntryScreen : BaseScreen<
     consentLabel.setText(consentLabelTextResId)
   }
 
-  override fun onAttachedToWindow() {
-    super.onAttachedToWindow()
-    delegate.start()
-  }
-
-  override fun onDetachedFromWindow() {
-    delegate.stop()
-    binding = null
-    super.onDetachedFromWindow()
-  }
-
-  override fun onSaveInstanceState(): Parcelable {
-    return delegate.onSaveInstanceState(super.onSaveInstanceState())
-  }
-
-  override fun onRestoreInstanceState(state: Parcelable?) {
-    val viewState = delegate.onRestoreInstanceState(state)
-    super.onRestoreInstanceState(viewState)
-  }
-
   private fun formChanges(): Observable<PatientEntryEvent> {
     val alternativeIdInputEditTextChanges = Maybe.fromCallable {
       country.alternativeIdentifierType
@@ -487,7 +427,7 @@ class PatientEntryScreen : BaseScreen<
 
   private fun saveClicks(): Observable<PatientEntryEvent> {
     val stateImeClicks = stateEditText
-        .editorActions() { it == EditorInfo.IME_ACTION_DONE }
+        .editorActions { it == EditorInfo.IME_ACTION_DONE }
         .map { SaveClicked }
 
     val saveButtonClicks = saveButton
@@ -548,7 +488,7 @@ class PatientEntryScreen : BaseScreen<
 
   private fun inflateAlternateIdView(identifier: String) {
     val layoutInflater = LayoutInflater.from(requireContext())
-    val alternateIdView = PatientEntryAlternateIdViewBinding.inflate(layoutInflater, this, false)
+    val alternateIdView = PatientEntryAlternateIdViewBinding.inflate(layoutInflater, rootView, false)
     alternateIdView.alternateIdentifier.text = identifier
     alternateIdContainer.addView(alternateIdView.root)
   }
@@ -576,7 +516,7 @@ class PatientEntryScreen : BaseScreen<
   }
 
   override fun openMedicalHistoryEntryScreen() {
-    hideKeyboard()
+    rootView.hideKeyboard()
     router.push(NewMedicalHistoryScreenKey().wrap())
   }
 
@@ -587,7 +527,7 @@ class PatientEntryScreen : BaseScreen<
         .setOrdering(TransitionSet.ORDERING_TOGETHER)
         .setDuration(250)
         .setInterpolator(FastOutSlowInInterpolator())
-    TransitionManager.beginDelayedTransition(this, transition)
+    TransitionManager.beginDelayedTransition(rootView, transition)
 
     dateOfBirthInputLayout.visibility = when (visibility) {
       DATE_OF_BIRTH_VISIBLE, BOTH_VISIBLE -> View.VISIBLE

--- a/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/newentry/PatientEntryScreen.kt
@@ -28,6 +28,7 @@ import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
 import io.reactivex.rxkotlin.ofType
+import kotlinx.parcelize.Parcelize
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.appconfig.Country
@@ -39,6 +40,7 @@ import org.simple.clinic.feature.Features
 import org.simple.clinic.medicalhistory.newentry.NewMedicalHistoryScreenKey
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.navigation.v2.Router
+import org.simple.clinic.navigation.v2.ScreenKey
 import org.simple.clinic.navigation.v2.compat.wrap
 import org.simple.clinic.newentry.country.InputFields
 import org.simple.clinic.newentry.form.AlternativeIdInputField
@@ -736,5 +738,13 @@ class PatientEntryScreen(
 
   interface Injector {
     fun inject(target: PatientEntryScreen)
+  }
+
+  @Parcelize
+  data class Key(
+      override val analyticsName: String = "Create Patient Entry"
+  ) : ScreenKey() {
+
+    override fun instantiateFragment() = PatientEntryScreen()
   }
 }

--- a/app/src/main/res/layout/screen_manual_patient_entry.xml
+++ b/app/src/main/res/layout/screen_manual_patient_entry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<org.simple.clinic.newentry.PatientEntryScreen xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/patientEntryRoot"
@@ -395,4 +395,4 @@
 
   </FrameLayout>
 
-</org.simple.clinic.newentry.PatientEntryScreen>
+</RelativeLayout>


### PR DESCRIPTION
- Use `RelativeLayout` as parent in `screen_manual_patient_entry`
- Add `ScreenKey` in `PatientEntryScreen`
- Use `PatientEntryScreen.Key` to open `PatientEntryScreen`
- Extend `BaseScreen` in `PatientEntryScreen`
- Replace `context` with `requireContext`
- Override lifecycle method of the fragment
- Remove unused code
- Update CHANGELOG

**Story**: https://app.clubhouse.io/simpledotorg/story/4460/migrate-patiententryscreen-to-a-fragment
