### PR TITLE
Fix searching by short code from the scan BP Passport screen does not load results initially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - [In Progress: 06 Aug 2021] Add support for Sri Lanka
 - [In Progress: 10 Aug 2021] Implement `CustomDrugEntrySheet`
 
+### Fixes
+- Fix searching by short code from the scan BP Passport screen does not load results initially
+
 ## On Demo
 ### Internal
 - Set Simple video and duration based on locale

--- a/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/instantsearch/InstantSearchUpdate.kt
@@ -66,7 +66,10 @@ class InstantSearchUpdate @Inject constructor(
   private fun instantSearchScreenShown(model: InstantSearchModel): Next<InstantSearchModel, InstantSearchEffect> {
     val effects = mutableSetOf<InstantSearchEffect>()
 
-    if (model.hasFacility) effects.add(PrefillSearchQuery(model.searchQuery.orEmpty()))
+    if (model.hasFacility && model.hasSearchQuery) {
+      effects.add(PrefillSearchQuery(model.searchQuery!!))
+      effects.add(ValidateSearchQuery(model.searchQuery))
+    }
 
     // When a scanned BP Passport does not result in a match, we bring up a bottom sheet which asks
     // whether this is a new registration or an existing patient. If we show the keyboard in these

--- a/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/instantsearch/InstantSearchUpdateTest.kt
@@ -462,7 +462,7 @@ class InstantSearchUpdateTest {
   }
 
   @Test
-  fun `when instant search screen is shown, then prefill search query if facility is loaded and show keyboard if there is no additional identifier`() {
+  fun `when instant search screen is shown, then prefill and validate search query if facility is loaded and has search query and show keyboard if there is no additional identifier`() {
     val facility = TestData.facility(
         uuid = UUID.fromString("1c3c133a-47f4-4616-9cc9-5c00b0115bd1"),
         name = "PHC Obvious"
@@ -478,7 +478,7 @@ class InstantSearchUpdateTest {
         .whenEvent(InstantSearchScreenShown)
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowKeyboard, PrefillSearchQuery("Ram"))
+            hasEffects(ShowKeyboard, PrefillSearchQuery("Ram"), ValidateSearchQuery("Ram"))
         ))
   }
 }


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/4583/searching-by-short-code-from-the-scan-bp-passport-screen-does-not-load-results-initially