### PR TITLE
Wire up `CustomDrugEntrySheet` mobius loop with the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [In Progress: 14 Jul 2021] Medication screen improvements
   - Search for commonly used drugs
 - [In Progress: 06 Aug 2021] Add support for Sri Lanka
-- [In Progress: 10 Aug 2021] Implement `CustomDrugEntrySheet`
+- [In Progress: 18 Aug 2021] Implement `CustomDrugEntrySheet`
 
 ## On Demo
 ### Internal

--- a/app/src/androidTest/java/org/simple/clinic/drugs/search/DrugRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/drugs/search/DrugRepositoryAndroidTest.kt
@@ -136,4 +136,30 @@ class DrugRepositoryAndroidTest {
     assertThat(expectedSearchResultsForObviousProtocol).containsExactly(amlodipine10).inOrder()
     assertThat(expectedSearchResultsForNoProtocol).containsExactly(amlodipine10, amlodipine20).inOrder()
   }
+
+  @Test
+  fun `getting_drug_immediately_should_work_correctly`() {
+    // given
+    val drugSearchUUID = UUID.fromString("0864635d-fd63-4005-9cea-ba843ea804e6")
+    val searchedDrug = TestData.drug(
+        id = drugSearchUUID,
+        name = "Amlodipine",
+        dosage = "20 mg"
+    )
+    val drugs = listOf(
+        TestData.drug(
+            id = UUID.fromString("4e64d256-ea7e-4b90-8177-1eb1485630c3"),
+            name = "Amlodipine",
+            dosage = "10 mg"
+        ),
+        searchedDrug
+    )
+
+    // when
+    drugRepository.save(drugs).blockingAwait()
+
+    // then
+    val drugImmediate = drugRepository.drugImmediate(drugSearchUUID)
+    assertThat(drugImmediate).isEqualTo(searchedDrug)
+  }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/search/Drug.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/Drug.kt
@@ -57,5 +57,8 @@ data class Drug(
       ORDER BY drugs.name COLLATE NOCASE, drugs.dosage ASC
     """)
     fun searchForNonProtocolDrugs(query: String, protocolId: UUID?): PagingSource<Int, Drug>
+
+    @Query("SELECT * FROM Drug WHERE id = :drugUuid")
+    fun getOne(drugUuid: UUID): Drug?
   }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugFrequency.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugFrequency.kt
@@ -62,13 +62,13 @@ sealed class DrugFrequency : Parcelable {
 
 
   companion object {
-    fun fromMedicineFrequency(value: MedicineFrequency?): DrugFrequency {
+    fun fromMedicineFrequency(value: MedicineFrequency?): DrugFrequency? {
       return when (value) {
         MedicineFrequency.BD -> BD
         MedicineFrequency.OD -> OD
         MedicineFrequency.QDS -> QDS
         MedicineFrequency.TDS -> TDS
-        else -> Unknown("None")
+        else -> null
       }
     }
   }

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugRepository.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugRepository.kt
@@ -48,6 +48,8 @@ class DrugRepository @Inject constructor(
     return drugDao.searchForNonProtocolDrugs(query, protocolId)
   }
 
+  fun drugImmediate(drugUuid: UUID): Drug? = drugDao.getOne(drugUuid)
+
   private fun saveRecords(records: List<Drug>) {
     drugDao.save(records)
   }

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffect.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffect.kt
@@ -1,9 +1,15 @@
 package org.simple.clinic.drugs.search
 
 import androidx.paging.PagingData
+import java.util.UUID
 
 sealed class DrugSearchEffect
 
 data class SearchDrugs(val searchQuery: String) : DrugSearchEffect()
 
 data class SetDrugsSearchResults(val searchResults: PagingData<Drug>) : DrugSearchEffect()
+
+data class OpenCustomDrugEntrySheetFromDrugList(
+    val drugUuid: UUID,
+    val patientUuid: UUID
+) : DrugSearchEffect()

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffect.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffect.kt
@@ -13,3 +13,8 @@ data class OpenCustomDrugEntrySheetFromDrugList(
     val drugUuid: UUID,
     val patientUuid: UUID
 ) : DrugSearchEffect()
+
+data class OpenCustomDrugEntrySheetFromDrugName(
+    val drugName: String,
+    val patientUuid: UUID
+) : DrugSearchEffect()

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffectHandler.kt
@@ -31,6 +31,7 @@ class DrugSearchEffectHandler @AssistedInject constructor(
         .subtypeEffectHandler<DrugSearchEffect, DrugSearchEvent>()
         .addTransformer(SearchDrugs::class.java, searchDrugs())
         .addConsumer(SetDrugsSearchResults::class.java, ::setDrugsSearchResults, schedulersProvider.ui())
+        .addConsumer(OpenCustomDrugEntrySheetFromDrugList::class.java, { uiActions.openCustomDrugEntrySheetFromDrugList(it.drugUuid, it.patientUuid) }, schedulersProvider.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEffectHandler.kt
@@ -32,6 +32,7 @@ class DrugSearchEffectHandler @AssistedInject constructor(
         .addTransformer(SearchDrugs::class.java, searchDrugs())
         .addConsumer(SetDrugsSearchResults::class.java, ::setDrugsSearchResults, schedulersProvider.ui())
         .addConsumer(OpenCustomDrugEntrySheetFromDrugList::class.java, { uiActions.openCustomDrugEntrySheetFromDrugList(it.drugUuid, it.patientUuid) }, schedulersProvider.ui())
+        .addConsumer(OpenCustomDrugEntrySheetFromDrugName::class.java, { uiActions.openCustomDrugEntrySheetFromDrugName(it.drugName, it.patientUuid) }, schedulersProvider.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEvent.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEvent.kt
@@ -11,3 +11,5 @@ data class DrugsSearchResultsLoaded(val searchResults: PagingData<Drug>) : DrugS
 data class SearchQueryChanged(val searchQuery: String) : DrugSearchEvent()
 
 data class DrugListItemClicked(val drugId: UUID, val patientUuid: UUID) : DrugSearchEvent()
+
+data class NewCustomDrugClicked(val drugName: String, val patientUuid: UUID) : DrugSearchEvent()

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEvent.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchEvent.kt
@@ -2,9 +2,12 @@ package org.simple.clinic.drugs.search
 
 import androidx.paging.PagingData
 import org.simple.clinic.widgets.UiEvent
+import java.util.UUID
 
 sealed class DrugSearchEvent : UiEvent
 
 data class DrugsSearchResultsLoaded(val searchResults: PagingData<Drug>) : DrugSearchEvent()
 
 data class SearchQueryChanged(val searchQuery: String) : DrugSearchEvent()
+
+data class DrugListItemClicked(val drugId: UUID, val patientUuid: UUID) : DrugSearchEvent()

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUpdate.kt
@@ -14,6 +14,7 @@ class DrugSearchUpdate : Update<DrugSearchModel, DrugSearchEvent, DrugSearchEffe
     return when (event) {
       is DrugsSearchResultsLoaded -> dispatch(SetDrugsSearchResults(event.searchResults))
       is SearchQueryChanged -> searchDrugs(model, event)
+      is DrugListItemClicked -> dispatch(OpenCustomDrugEntrySheetFromDrugList(event.drugId, event.patientUuid))
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugSearchUpdate.kt
@@ -15,6 +15,7 @@ class DrugSearchUpdate : Update<DrugSearchModel, DrugSearchEvent, DrugSearchEffe
       is DrugsSearchResultsLoaded -> dispatch(SetDrugsSearchResults(event.searchResults))
       is SearchQueryChanged -> searchDrugs(model, event)
       is DrugListItemClicked -> dispatch(OpenCustomDrugEntrySheetFromDrugList(event.drugId, event.patientUuid))
+      is NewCustomDrugClicked -> dispatch(OpenCustomDrugEntrySheetFromDrugName(event.drugName, event.patientUuid))
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugsSearchScreen.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugsSearchScreen.kt
@@ -88,7 +88,8 @@ class DrugsSearchScreen : BaseScreen<
   override fun events() = Observable
       .mergeArray(
           searchQueryChanges(),
-          drugListItemClicks())
+          drugListItemClicks(),
+          newCustomDrugItemClicks())
       .compose(ReportAnalyticsEvents())
       .cast<DrugSearchEvent>()
 
@@ -159,6 +160,13 @@ class DrugsSearchScreen : BaseScreen<
         .itemEvents
         .ofType<DrugSearchListItem.Event.DrugClicked>()
         .map { DrugListItemClicked(it.drug.id, screenKey.patientId) }
+  }
+
+  private fun newCustomDrugItemClicks(): Observable<UiEvent> {
+    return adapter
+        .itemEvents
+        .ofType<DrugSearchListItem.Event.NewCustomDrugClicked>()
+        .map { NewCustomDrugClicked(it.name, screenKey.patientId) }
   }
 
   interface Injector {

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugsSearchScreen.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugsSearchScreen.kt
@@ -129,6 +129,10 @@ class DrugsSearchScreen : BaseScreen<
     router.push(CustomDrugEntrySheet.Key(OpenAs.New.FromDrugList(drugUuid), patientUuid))
   }
 
+  override fun openCustomDrugEntrySheetFromDrugName(drugName: String, patientUuid: UUID) {
+    router.push(CustomDrugEntrySheet.Key(OpenAs.New.FromDrugName(drugName), patientUuid))
+  }
+
   private fun drugSearchLoadStateListener(combinedLoadStates: CombinedLoadStates) {
     val isLoading = combinedLoadStates.refresh is LoadState.Loading
     progressIndicator.visibleOrGone(isLoading)

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugsSearchScreen.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugsSearchScreen.kt
@@ -1,6 +1,7 @@
 package org.simple.clinic.drugs.search
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -12,6 +13,7 @@ import com.jakewharton.rxbinding3.widget.textChanges
 import com.spotify.mobius.functions.Consumer
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.cast
+import io.reactivex.rxkotlin.ofType
 import kotlinx.parcelize.Parcelize
 import org.simple.clinic.R
 import org.simple.clinic.ReportAnalyticsEvents
@@ -83,7 +85,10 @@ class DrugsSearchScreen : BaseScreen<
 
   override fun uiRenderer() = DrugSearchUiRenderer(this)
 
-  override fun events() = searchQueryChanges()
+  override fun events() = Observable
+      .mergeArray(
+          searchQueryChanges(),
+          drugListItemClicks())
       .compose(ReportAnalyticsEvents())
       .cast<DrugSearchEvent>()
 
@@ -147,6 +152,13 @@ class DrugsSearchScreen : BaseScreen<
         .map { searchQuery ->
           SearchQueryChanged(searchQuery.toString())
         }
+  }
+
+  private fun drugListItemClicks(): Observable<UiEvent> {
+    return adapter
+        .itemEvents
+        .ofType<DrugSearchListItem.Event.DrugClicked>()
+        .map { DrugListItemClicked(it.drug.id, screenKey.patientId) }
   }
 
   interface Injector {

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugsSearchScreen.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugsSearchScreen.kt
@@ -20,6 +20,8 @@ import org.simple.clinic.databinding.ListItemDrugSearchCornerCapBinding
 import org.simple.clinic.databinding.ListItemDrugSearchDividerBinding
 import org.simple.clinic.databinding.ScreenDrugsSearchBinding
 import org.simple.clinic.di.injector
+import org.simple.clinic.drugs.selection.custom.CustomDrugEntrySheet
+import org.simple.clinic.drugs.selection.custom.OpenAs
 import org.simple.clinic.navigation.v2.Router
 import org.simple.clinic.navigation.v2.ScreenKey
 import org.simple.clinic.navigation.v2.fragments.BaseScreen
@@ -121,6 +123,10 @@ class DrugsSearchScreen : BaseScreen<
     val searchQuery = searchQueryEditText.text?.toString().orEmpty()
     drugSearchResultsList.scrollToPosition(0)
     adapter.submitData(lifecycle, DrugSearchListItem.from(searchResults, searchQuery))
+  }
+
+  override fun openCustomDrugEntrySheetFromDrugList(drugUuid: UUID, patientUuid: UUID) {
+    router.push(CustomDrugEntrySheet.Key(OpenAs.New.FromDrugList(drugUuid), patientUuid))
   }
 
   private fun drugSearchLoadStateListener(combinedLoadStates: CombinedLoadStates) {

--- a/app/src/main/java/org/simple/clinic/drugs/search/UiActions.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/UiActions.kt
@@ -6,4 +6,5 @@ import java.util.UUID
 interface UiActions {
   fun setDrugSearchResults(searchResults: PagingData<Drug>)
   fun openCustomDrugEntrySheetFromDrugList(drugUuid: UUID, patientUuid: UUID)
+  fun openCustomDrugEntrySheetFromDrugName(drugName: String, patientUuid: UUID)
 }

--- a/app/src/main/java/org/simple/clinic/drugs/search/UiActions.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/UiActions.kt
@@ -1,7 +1,9 @@
 package org.simple.clinic.drugs.search
 
 import androidx.paging.PagingData
+import java.util.UUID
 
 interface UiActions {
   fun setDrugSearchResults(searchResults: PagingData<Drug>)
+  fun openCustomDrugEntrySheetFromDrugList(drugUuid: UUID, patientUuid: UUID)
 }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/EditMedicinesScreen.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/EditMedicinesScreen.kt
@@ -38,6 +38,8 @@ import org.simple.clinic.drugs.PrescribedDrugsDoneClicked
 import org.simple.clinic.drugs.PresribedDrugsRefillClicked
 import org.simple.clinic.drugs.ProtocolDrugClicked
 import org.simple.clinic.drugs.search.DrugsSearchScreen
+import org.simple.clinic.drugs.selection.custom.CustomDrugEntrySheet
+import org.simple.clinic.drugs.selection.custom.OpenAs
 import org.simple.clinic.drugs.selection.dosage.DosagePickerSheet
 import org.simple.clinic.drugs.selection.entry.CustomPrescriptionEntrySheet
 import org.simple.clinic.feature.Feature
@@ -216,7 +218,11 @@ class EditMedicinesScreen :
   }
 
   override fun showUpdateCustomPrescriptionSheet(prescribedDrug: PrescribedDrug) {
-    activity.startActivity(CustomPrescriptionEntrySheet.intentForUpdatingPrescription(requireContext(), prescribedDrug.patientUuid, prescribedDrug.uuid))
+    if (features.isEnabled(Feature.CustomDrugSearchScreen)) {
+      router.push(CustomDrugEntrySheet.Key(OpenAs.Update(prescribedDrug.uuid), prescribedDrug.patientUuid))
+    } else {
+      activity.startActivity(CustomPrescriptionEntrySheet.intentForUpdatingPrescription(requireContext(), prescribedDrug.patientUuid, prescribedDrug.uuid))
+    }
   }
 
   private fun protocolDrugClicks(): Observable<UiEvent> {

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffect.kt
@@ -38,4 +38,6 @@ object CloseBottomSheet : CustomDrugEntryEffect()
 
 data class FetchPrescription(val prescriptionUuid: UUID) : CustomDrugEntryEffect()
 
+data class FetchDrug(val drugUuid: UUID) : CustomDrugEntryEffect()
+
 data class RemoveDrugFromPrescription(val drugUuid: UUID) : CustomDrugEntryEffect()

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffect.kt
@@ -34,7 +34,7 @@ data class UpdatePrescription(
     val frequency: DrugFrequency?
 ) : CustomDrugEntryEffect()
 
-object CloseBottomSheet : CustomDrugEntryEffect()
+object CloseSheetAndGoToEditMedicineScreen : CustomDrugEntryEffect()
 
 data class FetchPrescription(val prescriptionUuid: UUID) : CustomDrugEntryEffect()
 

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandler.kt
@@ -40,7 +40,7 @@ class CustomDrugEntryEffectHandler @AssistedInject constructor(
         .addConsumer(SetSheetTitle::class.java, ::setSheetTitle, schedulersProvider.ui())
         .addTransformer(SaveCustomDrugToPrescription::class.java, saveCustomDrugToPrescription())
         .addTransformer(UpdatePrescription::class.java, updatePrescription())
-        .addAction(CloseBottomSheet::class.java, uiActions::close, schedulersProvider.ui())
+        .addAction(CloseSheetAndGoToEditMedicineScreen::class.java, uiActions::closeSheetAndGoToEditMedicineScreen, schedulersProvider.ui())
         .addTransformer(FetchPrescription::class.java, fetchPrescription())
         .addTransformer(FetchDrug::class.java, fetchDrug())
         .addTransformer(RemoveDrugFromPrescription::class.java, removeDrugFromPrescription())

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandler.kt
@@ -57,7 +57,7 @@ class CustomDrugEntryEffectHandler @AssistedInject constructor(
   }
 
   private fun setSheetTitle(setSheetTitle: SetSheetTitle) {
-    val sheetTitle = constructSheetTitle(setSheetTitle.name, setSheetTitle.dosage, setSheetTitle.frequency)
+    val sheetTitle = constructSheetTitle(setSheetTitle.name, setSheetTitle.dosage.nullIfBlank(), setSheetTitle.frequency)
 
     uiActions.setSheetTitle(sheetTitle)
   }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEvent.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEvent.kt
@@ -1,6 +1,7 @@
 package org.simple.clinic.drugs.selection.custom
 
 import org.simple.clinic.drugs.PrescribedDrug
+import org.simple.clinic.drugs.search.Drug
 import org.simple.clinic.drugs.search.DrugFrequency
 
 sealed class CustomDrugEntryEvent
@@ -22,3 +23,5 @@ data class PrescribedDrugFetched(val prescription: PrescribedDrug) : CustomDrugE
 object ExistingDrugRemoved : CustomDrugEntryEvent()
 
 object RemoveDrugButtonClicked : CustomDrugEntryEvent()
+
+data class DrugFetched(val drug: Drug) : CustomDrugEntryEvent()

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEvent.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEvent.kt
@@ -3,8 +3,9 @@ package org.simple.clinic.drugs.selection.custom
 import org.simple.clinic.drugs.PrescribedDrug
 import org.simple.clinic.drugs.search.Drug
 import org.simple.clinic.drugs.search.DrugFrequency
+import org.simple.clinic.widgets.UiEvent
 
-sealed class CustomDrugEntryEvent
+sealed class CustomDrugEntryEvent : UiEvent
 
 data class DosageEdited(val dosage: String) : CustomDrugEntryEvent()
 

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEvent.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEvent.kt
@@ -4,6 +4,7 @@ import org.simple.clinic.drugs.PrescribedDrug
 import org.simple.clinic.drugs.search.Drug
 import org.simple.clinic.drugs.search.DrugFrequency
 import org.simple.clinic.widgets.UiEvent
+import java.util.UUID
 
 sealed class CustomDrugEntryEvent : UiEvent
 
@@ -15,7 +16,7 @@ data class EditFrequencyClicked(val frequency: DrugFrequency) : CustomDrugEntryE
 
 data class FrequencyEdited(val frequency: DrugFrequency) : CustomDrugEntryEvent()
 
-object AddMedicineButtonClicked : CustomDrugEntryEvent()
+data class AddMedicineButtonClicked(val patientUuid: UUID) : CustomDrugEntryEvent()
 
 object CustomDrugSaved : CustomDrugEntryEvent()
 

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryInit.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryInit.kt
@@ -3,13 +3,12 @@ package org.simple.clinic.drugs.selection.custom
 import com.spotify.mobius.First
 import com.spotify.mobius.First.first
 import com.spotify.mobius.Init
-import org.simple.clinic.drugs.search.Drug
 import org.simple.clinic.mobius.first
 
 class CustomDrugEntryInit : Init<CustomDrugEntryModel, CustomDrugEntryEffect> {
   override fun init(model: CustomDrugEntryModel): First<CustomDrugEntryModel, CustomDrugEntryEffect> {
     return when (model.openAs) {
-      is OpenAs.New.FromDrugList -> updatedModelFromDrug(model, model.openAs.drug)
+      is OpenAs.New.FromDrugList -> first(model, FetchDrug(model.openAs.drugUuid))
       is OpenAs.New.FromDrugName -> updatedModelFromDrugName(model, model.openAs.drugName)
       is OpenAs.Update -> first(model, FetchPrescription(model.openAs.prescribedDrugUuid))
     }
@@ -24,14 +23,5 @@ class CustomDrugEntryInit : Init<CustomDrugEntryModel, CustomDrugEntryEffect> {
     val effects = setOf(SetSheetTitle(drugName, null, null), SetDrugFrequency(null))
 
     return first(updatedModel, effects)
-  }
-
-  private fun updatedModelFromDrug(
-      model: CustomDrugEntryModel,
-      drug: Drug
-  ): First<CustomDrugEntryModel, CustomDrugEntryEffect> {
-    val updatedModel = model.drugNameLoaded(drug.name).dosageEdited(drug.dosage).frequencyEdited(drug.frequency)
-
-    return first(updatedModel, SetSheetTitle(drug.name, drug.dosage, drug.frequency), SetDrugFrequency(drug.frequency), SetDrugDosage(drug.dosage))
   }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryInit.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryInit.kt
@@ -20,7 +20,7 @@ class CustomDrugEntryInit : Init<CustomDrugEntryModel, CustomDrugEntryEffect> {
   ): First<CustomDrugEntryModel, CustomDrugEntryEffect> {
     val updatedModel = model.drugNameLoaded(drugName)
 
-    val effects = setOf(SetSheetTitle(drugName, null, null), SetDrugFrequency(null))
+    val effects = setOf(SetSheetTitle(drugName, null, null))
 
     return first(updatedModel, effects)
   }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryModel.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryModel.kt
@@ -41,7 +41,7 @@ data class CustomDrugEntryModel(
     return copy(drugName = drugName)
   }
 
-  fun rxNormCodeEdited(rxNormCOde: String?): CustomDrugEntryModel {
+  fun rxNormCodeEdited(rxNormCode: String?): CustomDrugEntryModel {
     return copy(rxNormCode = rxNormCode)
   }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryModel.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryModel.kt
@@ -1,7 +1,10 @@
 package org.simple.clinic.drugs.selection.custom
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import org.simple.clinic.drugs.search.DrugFrequency
 
+@Parcelize
 data class CustomDrugEntryModel(
     val openAs: OpenAs,
     val drugName: String?,
@@ -9,7 +12,7 @@ data class CustomDrugEntryModel(
     val dosageHasFocus: Boolean?,
     val frequency: DrugFrequency?,
     val rxNormCode: String?
-) {
+) : Parcelable {
   companion object {
     fun default(
         openAs: OpenAs

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryModel.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryModel.kt
@@ -37,4 +37,8 @@ data class CustomDrugEntryModel(
   fun drugNameLoaded(drugName: String): CustomDrugEntryModel {
     return copy(drugName = drugName)
   }
+
+  fun rxNormCodeEdited(rxNormCOde: String?): CustomDrugEntryModel {
+    return copy(rxNormCode = rxNormCode)
+  }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntrySheet.kt
@@ -20,6 +20,7 @@ import org.simple.clinic.databinding.SheetCustomDrugEntryBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.drugs.search.DrugFrequency
 import org.simple.clinic.drugs.search.DrugFrequency.Unknown
+import org.simple.clinic.drugs.selection.PrescribedDrugsScreenKey
 import org.simple.clinic.feature.Features
 import org.simple.clinic.navigation.v2.Router
 import org.simple.clinic.navigation.v2.ScreenKey
@@ -135,8 +136,8 @@ class CustomDrugEntrySheet : BaseBottomSheet<
     titleTextView.text = drugName
   }
 
-  override fun close() {
-    router.pop()
+  override fun closeSheetAndGoToEditMedicineScreen() {
+    router.popUntil(PrescribedDrugsScreenKey(screenKey.patientUuid))
   }
 
   override fun setDrugDosageText(dosage: String) {

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntrySheet.kt
@@ -1,0 +1,185 @@
+package org.simple.clinic.drugs.selection.custom
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View.GONE
+import android.view.View.VISIBLE
+import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import com.jakewharton.rxbinding3.view.clicks
+import com.jakewharton.rxbinding3.view.focusChanges
+import com.jakewharton.rxbinding3.widget.editorActions
+import com.spotify.mobius.functions.Consumer
+import io.reactivex.Observable
+import io.reactivex.rxkotlin.cast
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+import org.simple.clinic.R
+import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.databinding.SheetCustomDrugEntryBinding
+import org.simple.clinic.di.injector
+import org.simple.clinic.drugs.search.DrugFrequency
+import org.simple.clinic.drugs.search.DrugFrequency.Unknown
+import org.simple.clinic.feature.Features
+import org.simple.clinic.navigation.v2.Router
+import org.simple.clinic.navigation.v2.ScreenKey
+import org.simple.clinic.navigation.v2.fragments.BaseBottomSheet
+import org.simple.clinic.util.unsafeLazy
+import org.simple.clinic.widgets.UiEvent
+import org.simple.clinic.widgets.textChanges
+import java.util.Locale
+import java.util.UUID
+import javax.inject.Inject
+
+class CustomDrugEntrySheet : BaseBottomSheet<
+    CustomDrugEntrySheet.Key,
+    SheetCustomDrugEntryBinding,
+    CustomDrugEntryModel,
+    CustomDrugEntryEvent,
+    CustomDrugEntryEffect,
+    Unit>(), CustomDrugEntryUi, CustomDrugEntrySheetUiActions {
+
+  @Inject
+  lateinit var locale: Locale
+
+  @Inject
+  lateinit var features: Features
+
+  @Inject
+  lateinit var router: Router
+
+  @Inject
+  lateinit var effectHandlerFactory: CustomDrugEntryEffectHandler.Factory
+
+  private val openAs by unsafeLazy { screenKey.openAs }
+
+  private val titleTextView
+    get() = binding.titleTextView
+
+  private val removeButton
+    get() = binding.removeButton
+
+  private val drugDosageEditText
+    get() = binding.drugDosageEditText
+
+  private val drugFrequencyEditText
+    get() = binding.drugFrequencyEditText
+
+  private val saveButton
+    get() = binding.saveButton
+
+  override fun defaultModel() = CustomDrugEntryModel.default(openAs)
+
+  override fun bindView(
+      inflater: LayoutInflater,
+      container: ViewGroup?
+  ) = SheetCustomDrugEntryBinding.inflate(inflater, container, false)
+
+  override fun uiRenderer() = CustomDrugEntryUiRenderer(this, getString(R.string.custom_drug_entry_sheet_dosage_placeholder))
+
+  override fun createUpdate() = CustomDrugEntryUpdate()
+
+  override fun createInit() = CustomDrugEntryInit()
+
+  override fun createEffectHandler(viewEffectsConsumer: Consumer<Unit>) = effectHandlerFactory.create(this).build()
+
+  override fun events() = Observable
+      .mergeArray(
+          drugDosageChanges(),
+          drugDosageFocusChanges(),
+          saveClicks(),
+          removeClicks()
+      ).compose(ReportAnalyticsEvents())
+      .cast<CustomDrugEntryEvent>()
+
+  override fun onAttach(context: Context) {
+    super.onAttach(context)
+
+    context.injector<Injector>().inject(this)
+  }
+
+  private fun drugDosageChanges() = drugDosageEditText.textChanges(::DosageEdited)
+
+  private fun drugDosageFocusChanges() = drugDosageEditText.focusChanges().map(::DosageFocusChanged)
+
+  private fun saveClicks(): Observable<UiEvent> {
+    val dosageImeClicks = drugDosageEditText
+        .editorActions { it == EditorInfo.IME_ACTION_DONE }
+        .map { Unit }
+
+    return saveButton
+        .clicks()
+        .mergeWith(dosageImeClicks)
+        .map { AddMedicineButtonClicked(screenKey.patientUuid) }
+  }
+
+  private fun removeClicks(): Observable<UiEvent> =
+      removeButton
+          .clicks()
+          .map { RemoveDrugButtonClicked }
+
+  override fun showEditFrequencyDialog(frequency: DrugFrequency) {
+    // to do
+  }
+
+  override fun setDrugFrequency(frequency: DrugFrequency?) {
+    val updatedFrequencyString = when (frequency) {
+      is Unknown, null -> getString(R.string.custom_drug_entry_sheet_frequency_none)
+      else -> frequency.toString()
+    }
+
+    drugFrequencyEditText.setText(updatedFrequencyString)
+  }
+
+  override fun setSheetTitle(drugName: String) {
+    titleTextView.text = drugName
+  }
+
+  override fun close() {
+    router.pop()
+  }
+
+  override fun setDrugDosageText(dosage: String) {
+    drugDosageEditText.setText(dosage)
+  }
+
+  override fun setDrugDosage(dosage: String?) {
+    drugDosageEditText.setText(dosage)
+  }
+
+  override fun moveDrugDosageCursorToBeginning() {
+    drugDosageEditText.post { drugDosageEditText.setSelection(0) }
+  }
+
+  override fun showRemoveButton() {
+    removeButton.visibility = VISIBLE
+  }
+
+  override fun hideRemoveButton() {
+    removeButton.visibility = GONE
+  }
+
+  override fun setButtonTextAsSave() {
+    saveButton.text = getString(R.string.custom_drug_entry_sheet_save_button_text)
+  }
+
+  override fun setButtonTextAsAdd() {
+    saveButton.text = getString(R.string.custom_drug_entry_sheet_add_button_text)
+  }
+
+  @Parcelize
+  data class Key(
+      val openAs: OpenAs,
+      val patientUuid: UUID,
+      override val analyticsName: String = "Custom Drug Entry Sheet"
+  ) : ScreenKey() {
+    @IgnoredOnParcel
+    override val type = ScreenType.Modal
+
+    override fun instantiateFragment() = CustomDrugEntrySheet()
+  }
+
+  interface Injector {
+    fun inject(target: CustomDrugEntrySheet)
+  }
+}

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntrySheetUiActions.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntrySheetUiActions.kt
@@ -7,5 +7,5 @@ interface CustomDrugEntrySheetUiActions {
   fun setDrugFrequency(frequency: DrugFrequency?)
   fun setDrugDosage(dosage: String?)
   fun setSheetTitle(drugName: String)
-  fun close()
+  fun closeSheetAndGoToEditMedicineScreen()
 }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
@@ -47,7 +47,7 @@ class CustomDrugEntryUpdate : Update<CustomDrugEntryModel, CustomDrugEntryEvent,
 
     val updatedModel = model.drugNameLoaded(prescription.name).dosageEdited(prescription.dosage).frequencyEdited(frequency).rxNormCodeEdited(prescription.rxNormCode)
 
-    return next(updatedModel, SetSheetTitle(prescription.name, prescription.dosage, frequency), SetDrugFrequency(frequency))
+    return next(updatedModel, SetSheetTitle(prescription.name, prescription.dosage, frequency), SetDrugFrequency(frequency), SetDrugDosage(prescription.dosage))
   }
 
   private fun createOrUpdatePrescriptionEntry(model: CustomDrugEntryModel): Next<CustomDrugEntryModel, CustomDrugEntryEffect> {

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
@@ -45,7 +45,7 @@ class CustomDrugEntryUpdate : Update<CustomDrugEntryModel, CustomDrugEntryEvent,
   ): Next<CustomDrugEntryModel, CustomDrugEntryEffect> {
     val frequency = DrugFrequency.fromMedicineFrequency(prescription.frequency)
 
-    val updatedModel = model.drugNameLoaded(prescription.name).dosageEdited(prescription.dosage).frequencyEdited(frequency)
+    val updatedModel = model.drugNameLoaded(prescription.name).dosageEdited(prescription.dosage).frequencyEdited(frequency).rxNormCodeEdited(prescription.rxNormCode)
 
     return next(updatedModel, SetSheetTitle(prescription.name, prescription.dosage, frequency), SetDrugFrequency(frequency))
   }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
@@ -21,7 +21,7 @@ class CustomDrugEntryUpdate : Update<CustomDrugEntryModel, CustomDrugEntryEvent,
       is EditFrequencyClicked -> dispatch(ShowEditFrequencyDialog(event.frequency))
       is FrequencyEdited -> next(model.frequencyEdited(event.frequency), SetDrugFrequency(event.frequency), SetSheetTitle(model.drugName, model.dosage, event.frequency))
       is AddMedicineButtonClicked -> createOrUpdatePrescriptionEntry(model, event.patientUuid)
-      is CustomDrugSaved, ExistingDrugRemoved -> dispatch(CloseBottomSheet)
+      is CustomDrugSaved, ExistingDrugRemoved -> dispatch(CloseSheetAndGoToEditMedicineScreen)
       is PrescribedDrugFetched -> prescriptionFetched(model, event.prescription)
       is RemoveDrugButtonClicked -> {
         val update = model.openAs as OpenAs.Update

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
@@ -8,6 +8,7 @@ import org.simple.clinic.drugs.search.Drug
 import org.simple.clinic.drugs.search.DrugFrequency
 import org.simple.clinic.mobius.dispatch
 import org.simple.clinic.mobius.next
+import java.util.UUID
 
 class CustomDrugEntryUpdate : Update<CustomDrugEntryModel, CustomDrugEntryEvent, CustomDrugEntryEffect> {
   override fun update(
@@ -19,7 +20,7 @@ class CustomDrugEntryUpdate : Update<CustomDrugEntryModel, CustomDrugEntryEvent,
       is DosageFocusChanged -> next(model.dosageFocusChanged(event.hasFocus))
       is EditFrequencyClicked -> dispatch(ShowEditFrequencyDialog(event.frequency))
       is FrequencyEdited -> next(model.frequencyEdited(event.frequency), SetDrugFrequency(event.frequency), SetSheetTitle(model.drugName, model.dosage, event.frequency))
-      is AddMedicineButtonClicked -> createOrUpdatePrescriptionEntry(model)
+      is AddMedicineButtonClicked -> createOrUpdatePrescriptionEntry(model, event.patientUuid)
       is CustomDrugSaved, ExistingDrugRemoved -> dispatch(CloseBottomSheet)
       is PrescribedDrugFetched -> prescriptionFetched(model, event.prescription)
       is RemoveDrugButtonClicked -> {
@@ -50,11 +51,11 @@ class CustomDrugEntryUpdate : Update<CustomDrugEntryModel, CustomDrugEntryEvent,
     return next(updatedModel, SetSheetTitle(prescription.name, prescription.dosage, frequency), SetDrugFrequency(frequency), SetDrugDosage(prescription.dosage))
   }
 
-  private fun createOrUpdatePrescriptionEntry(model: CustomDrugEntryModel): Next<CustomDrugEntryModel, CustomDrugEntryEffect> {
+  private fun createOrUpdatePrescriptionEntry(model: CustomDrugEntryModel, patientUuid: UUID): Next<CustomDrugEntryModel, CustomDrugEntryEffect> {
     return when (model.openAs) {
-      is OpenAs.New.FromDrugList -> dispatch(SaveCustomDrugToPrescription(model.openAs.patientUuid, model.drugName!!, model.dosage, model.rxNormCode, model.frequency))
-      is OpenAs.New.FromDrugName -> dispatch(SaveCustomDrugToPrescription(model.openAs.patientUuid, model.openAs.drugName, model.dosage, null, model.frequency))
-      is OpenAs.Update -> dispatch(UpdatePrescription(model.openAs.patientUuid, model.openAs.prescribedDrugUuid, model.drugName!!, model.dosage, model.rxNormCode, model.frequency))
+      is OpenAs.New.FromDrugList -> dispatch(SaveCustomDrugToPrescription(patientUuid, model.drugName!!, model.dosage, model.rxNormCode, model.frequency))
+      is OpenAs.New.FromDrugName -> dispatch(SaveCustomDrugToPrescription(patientUuid, model.openAs.drugName, model.dosage, null, model.frequency))
+      is OpenAs.Update -> dispatch(UpdatePrescription(patientUuid, model.openAs.prescribedDrugUuid, model.drugName!!, model.dosage, model.rxNormCode, model.frequency))
     }
   }
 }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
@@ -4,6 +4,7 @@ import com.spotify.mobius.Next
 import com.spotify.mobius.Next.next
 import com.spotify.mobius.Update
 import org.simple.clinic.drugs.PrescribedDrug
+import org.simple.clinic.drugs.search.Drug
 import org.simple.clinic.drugs.search.DrugFrequency
 import org.simple.clinic.mobius.dispatch
 import org.simple.clinic.mobius.next
@@ -20,15 +21,25 @@ class CustomDrugEntryUpdate : Update<CustomDrugEntryModel, CustomDrugEntryEvent,
       is FrequencyEdited -> next(model.frequencyEdited(event.frequency), SetDrugFrequency(event.frequency), SetSheetTitle(model.drugName, model.dosage, event.frequency))
       is AddMedicineButtonClicked -> createOrUpdatePrescriptionEntry(model)
       is CustomDrugSaved, ExistingDrugRemoved -> dispatch(CloseBottomSheet)
-      is PrescribedDrugFetched -> drugFetched(model, event.prescription)
+      is PrescribedDrugFetched -> prescriptionFetched(model, event.prescription)
       is RemoveDrugButtonClicked -> {
         val update = model.openAs as OpenAs.Update
         dispatch(RemoveDrugFromPrescription(update.prescribedDrugUuid))
       }
+      is DrugFetched -> drugFetched(model, event.drug)
     }
   }
 
   private fun drugFetched(
+      model: CustomDrugEntryModel,
+      drug: Drug
+  ): Next<CustomDrugEntryModel, CustomDrugEntryEffect> {
+    val updatedModel = model.drugNameLoaded(drug.name).dosageEdited(drug.dosage).frequencyEdited(drug.frequency).rxNormCodeEdited(drug.rxNormCode)
+
+    return next(updatedModel, SetSheetTitle(drug.name, drug.dosage, drug.frequency), SetDrugFrequency(drug.frequency), SetDrugDosage(drug.dosage))
+  }
+
+  private fun prescriptionFetched(
       model: CustomDrugEntryModel,
       prescription: PrescribedDrug
   ): Next<CustomDrugEntryModel, CustomDrugEntryEffect> {
@@ -41,7 +52,7 @@ class CustomDrugEntryUpdate : Update<CustomDrugEntryModel, CustomDrugEntryEvent,
 
   private fun createOrUpdatePrescriptionEntry(model: CustomDrugEntryModel): Next<CustomDrugEntryModel, CustomDrugEntryEffect> {
     return when (model.openAs) {
-      is OpenAs.New.FromDrugList -> dispatch(SaveCustomDrugToPrescription(model.openAs.patientUuid, model.openAs.drug.name, model.dosage, model.openAs.drug.rxNormCode, model.frequency))
+      is OpenAs.New.FromDrugList -> dispatch(SaveCustomDrugToPrescription(model.openAs.patientUuid, model.drugName!!, model.dosage, model.rxNormCode, model.frequency))
       is OpenAs.New.FromDrugName -> dispatch(SaveCustomDrugToPrescription(model.openAs.patientUuid, model.openAs.drugName, model.dosage, null, model.frequency))
       is OpenAs.Update -> dispatch(UpdatePrescription(model.openAs.patientUuid, model.openAs.prescribedDrugUuid, model.drugName!!, model.dosage, model.rxNormCode, model.frequency))
     }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/OpenAs.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/OpenAs.kt
@@ -1,14 +1,18 @@
 package org.simple.clinic.drugs.selection.custom
 
-import org.simple.clinic.drugs.search.Drug
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import java.util.UUID
 
-sealed class OpenAs {
-  sealed class New : OpenAs() {
+sealed class OpenAs : Parcelable {
+  sealed class New : Parcelable, OpenAs() {
+    @Parcelize
     data class FromDrugName(val patientUuid: UUID, val drugName: String) : New()
 
-    data class FromDrugList(val patientUuid: UUID, val drug: Drug) : New()
+    @Parcelize
+    data class FromDrugList(val patientUuid: UUID, val drugUuid: UUID) : New()
   }
 
+  @Parcelize
   data class Update(val patientUuid: UUID, val prescribedDrugUuid: UUID) : OpenAs()
 }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/OpenAs.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/OpenAs.kt
@@ -7,12 +7,12 @@ import java.util.UUID
 sealed class OpenAs : Parcelable {
   sealed class New : Parcelable, OpenAs() {
     @Parcelize
-    data class FromDrugName(val patientUuid: UUID, val drugName: String) : New()
+    data class FromDrugName(val drugName: String) : New()
 
     @Parcelize
-    data class FromDrugList(val patientUuid: UUID, val drugUuid: UUID) : New()
+    data class FromDrugList(val drugUuid: UUID) : New()
   }
 
   @Parcelize
-  data class Update(val patientUuid: UUID, val prescribedDrugUuid: UUID) : OpenAs()
+  data class Update(val prescribedDrugUuid: UUID) : OpenAs()
 }

--- a/app/src/main/java/org/simple/clinic/main/TheActivityComponent.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityComponent.kt
@@ -18,6 +18,7 @@ import org.simple.clinic.deniedaccess.AccessDeniedScreenInjector
 import org.simple.clinic.di.PagingModule
 import org.simple.clinic.drugs.search.DrugsSearchScreen
 import org.simple.clinic.drugs.selection.EditMedicinesScreen
+import org.simple.clinic.drugs.selection.custom.CustomDrugEntrySheet
 import org.simple.clinic.editpatient.ConfirmDiscardChangesDialog
 import org.simple.clinic.editpatient.EditPatientScreen
 import org.simple.clinic.editpatient.deletepatient.DeletePatientScreenInjector
@@ -133,7 +134,8 @@ interface TheActivityComponent :
     TextInputDatePickerSheet.Injector,
     RemoveOverdueAppointmentScreen.Injector,
     DrugsSearchScreen.Injector,
-    SyncIndicatorView.Injector {
+    SyncIndicatorView.Injector,
+    CustomDrugEntrySheet.Injector {
   fun inject(target: TheActivity)
 
   @Subcomponent.Factory

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/medicinefrequency/MedicineFrequency.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/medicinefrequency/MedicineFrequency.kt
@@ -69,13 +69,13 @@ sealed class MedicineFrequency : Parcelable {
   }
 
   companion object {
-    fun fromDrugFrequency(value: DrugFrequency?): MedicineFrequency {
+    fun fromDrugFrequency(value: DrugFrequency?): MedicineFrequency? {
       return when (value) {
         DrugFrequency.BD -> BD
         DrugFrequency.OD -> OD
         DrugFrequency.QDS -> QDS
         DrugFrequency.TDS -> TDS
-        else -> Unknown("None")
+        else -> null
       }
     }
   }

--- a/app/src/main/res/layout/sheet_custom_drug_entry.xml
+++ b/app/src/main/res/layout/sheet_custom_drug_entry.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/rootLayout"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:background="?attr/colorSurface">
+
+  <TextView
+    android:id="@+id/titleTextView"
+    android:layout_width="@dimen/spacing_0"
+    android:layout_height="wrap_content"
+    android:layout_alignParentStart="true"
+    android:layout_centerVertical="true"
+    android:layout_marginStart="@dimen/spacing_24"
+    android:layout_marginTop="@dimen/spacing_24"
+    android:layout_marginEnd="@dimen/spacing_16"
+    android:layout_toStartOf="@+id/removeButton"
+    android:ellipsize="end"
+    android:maxLines="2"
+    android:textAppearance="?attr/textAppearanceHeadline6"
+    android:textColor="?attr/colorOnSurface"
+    app:layout_constraintEnd_toStartOf="@+id/removeButton"
+    app:layout_constraintHorizontal_bias="0.0"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:text="Procardia XL" />
+
+  <com.google.android.material.button.MaterialButton
+    android:id="@+id/removeButton"
+    style="@style/Widget.Simple.Button.TextButton.Red1"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_alignParentEnd="true"
+    android:layout_gravity="center_vertical"
+    android:layout_marginTop="@dimen/spacing_24"
+    android:layout_marginEnd="@dimen/spacing_24"
+    android:minWidth="@dimen/spacing_0"
+    android:minHeight="@dimen/spacing_0"
+    android:text="@string/custom_drug_entry_sheet_remove"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:visibility="visible" />
+
+  <LinearLayout
+    android:id="@+id/textFieldsLinearLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/spacing_16"
+    android:layout_marginStart="@dimen/spacing_24"
+    android:layout_marginTop="@dimen/spacing_16"
+    android:layout_marginEnd="@dimen/spacing_24"
+    android:layout_marginBottom="@dimen/spacing_16"
+    android:baselineAligned="true"
+    android:orientation="horizontal"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@+id/titleTextView">
+
+    <com.google.android.material.textfield.TextInputLayout
+      android:layout_width="@dimen/spacing_0"
+      android:layout_height="wrap_content"
+      android:layout_weight="1"
+      app:hintTextAppearance="?attr/textAppearanceBody2">
+
+      <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/drugDosageEditText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/custom_drug_entry_sheet_dosage"
+        android:imeOptions="actionNext"
+        android:inputType="textCapWords"
+        android:textColor="@color/color_on_surface_67" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+      android:layout_width="@dimen/spacing_0"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="@dimen/spacing_8"
+      android:layout_weight="1"
+      app:hintTextAppearance="?attr/textAppearanceBody2"
+      app:hintTextColor="?attr/colorPrimary"
+      app:hintEnabled="true"
+      android:textColorHint="?attr/colorPrimary">
+
+      <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/drugFrequencyEditText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/custom_drug_entry_sheet_frequency"
+        android:imeOptions="actionDone"
+        android:textColor="@color/color_on_surface_67" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+  </LinearLayout>
+
+  <FrameLayout
+    style="@style/Widget.Simple.Button.Frame"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/spacing_24"
+    app:layout_constraintTop_toBottomOf="@+id/textFieldsLinearLayout">
+
+    <com.google.android.material.button.MaterialButton
+      android:id="@+id/saveButton"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:text="@string/custom_drug_entry_sheet_save_button_text" />
+  </FrameLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/sheet_custom_drug_entry.xml
+++ b/app/src/main/res/layout/sheet_custom_drug_entry.xml
@@ -91,7 +91,8 @@
         android:layout_height="wrap_content"
         android:hint="@string/custom_drug_entry_sheet_frequency"
         android:imeOptions="actionDone"
-        android:textColor="@color/color_on_surface_67" />
+        android:textColor="@color/color_on_surface_67"
+        android:text="@string/custom_drug_entry_sheet_frequency_none"/>
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -842,6 +842,9 @@
   <string name="custom_drug_entry_sheet_remove">Remove</string>
   <string name="custom_drug_entry_sheet_dosage">Dosage</string>
   <string name="custom_drug_entry_sheet_frequency">Frequency</string>
+  <string name="custom_drug_entry_sheet_dosage_placeholder">mg</string>
   <string name="custom_drug_entry_sheet_save_button_text">Save</string>
+  <string name="custom_drug_entry_sheet_add_button_text">Add</string>
+  <string name="custom_drug_entry_sheet_frequency_none">None</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -837,5 +837,11 @@
   <string name="warning_add_blood_sugar_message">If possible, add a current blood sugar reading for this patient.</string>
   <string name="warning_add_blood_sugar_positive_button">Add blood sugar</string>
   <string name="warning_add_blood_sugar_negative_button">Not now</string>
+  
+  <!-- Custom drug entry sheet -->
+  <string name="custom_drug_entry_sheet_remove">Remove</string>
+  <string name="custom_drug_entry_sheet_dosage">Dosage</string>
+  <string name="custom_drug_entry_sheet_frequency">Frequency</string>
+  <string name="custom_drug_entry_sheet_save_button_text">Save</string>
 
 </resources>

--- a/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchEffectHandlerTest.kt
@@ -91,4 +91,19 @@ class DrugSearchEffectHandlerTest {
 
     testCase.assertNoOutgoingEvents()
   }
+
+  @Test
+  fun `when open custom drug entry screen from drug list effect is received, then open custom drug entry screen from drug list`() {
+    // given
+    val drugId = UUID.fromString("05ca8019-0514-4c6b-aa8e-657701229cd5")
+    val patientId = UUID.fromString("3d4105bb-8447-42ab-b769-2da2dcd4ba22")
+
+    // when
+    testCase.dispatch(OpenCustomDrugEntrySheetFromDrugList(drugId, patientId))
+
+    // then
+    verify(uiActions).openCustomDrugEntrySheetFromDrugList(drugId, patientId)
+    verifyNoMoreInteractions(uiActions)
+    testCase.assertNoOutgoingEvents()
+  }
 }

--- a/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchEffectHandlerTest.kt
@@ -106,4 +106,19 @@ class DrugSearchEffectHandlerTest {
     verifyNoMoreInteractions(uiActions)
     testCase.assertNoOutgoingEvents()
   }
+
+  @Test
+  fun `when open custom drug entry screen from drug name effect is received, then open custom drug entry screen from drug name`() {
+    // given
+    val drugName = "Amlodipine"
+    val patientId = UUID.fromString("3d4105bb-8447-42ab-b769-2da2dcd4ba22")
+
+    // when
+    testCase.dispatch(OpenCustomDrugEntrySheetFromDrugName(drugName, patientId))
+
+    // then
+    verify(uiActions).openCustomDrugEntrySheetFromDrugName(drugName, patientId)
+    verifyNoMoreInteractions(uiActions)
+    testCase.assertNoOutgoingEvents()
+  }
 }

--- a/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchUpdateTest.kt
@@ -61,4 +61,20 @@ class DrugSearchUpdateTest {
             hasNoEffects()
         ))
   }
+
+  @Test
+  fun `when drug list item is clicked, then open custom drug entry sheet from drug list`() {
+    val drugId = UUID.fromString("05ca8019-0514-4c6b-aa8e-657701229cd5")
+    val patientId = UUID.fromString("3d4105bb-8447-42ab-b769-2da2dcd4ba22")
+
+    updateSpec
+        .given(defaultModel)
+        .whenEvent(DrugListItemClicked(drugId, patientId))
+        .then(
+            assertThatNext(
+                hasNoModel(),
+                hasEffects(OpenCustomDrugEntrySheetFromDrugList(drugId, patientId))
+            )
+        )
+  }
 }

--- a/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/search/DrugSearchUpdateTest.kt
@@ -77,4 +77,20 @@ class DrugSearchUpdateTest {
             )
         )
   }
+
+  @Test
+  fun `when custom drug list item is clicked, then open custom drug entry sheet from drug name`() {
+    val drugName = "Amlodipine"
+    val patientId = UUID.fromString("3d4105bb-8447-42ab-b769-2da2dcd4ba22")
+
+    updateSpec
+        .given(defaultModel)
+        .whenEvent(NewCustomDrugClicked(drugName, patientId))
+        .then(
+            assertThatNext(
+                hasNoModel(),
+                hasEffects(OpenCustomDrugEntrySheetFromDrugName(drugName, patientId))
+            )
+        )
+  }
 }

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandlerTest.kt
@@ -188,10 +188,10 @@ class CustomDrugEntryEffectHandlerTest {
   @Test
   fun `when close custom drug entry sheet effect is received, then close the sheet`() {
     // when
-    testCase.dispatch(CloseBottomSheet)
+    testCase.dispatch(CloseSheetAndGoToEditMedicineScreen)
 
     // then
-    verify(uiActions).close()
+    verify(uiActions).closeSheetAndGoToEditMedicineScreen()
     verifyNoMoreInteractions(uiActions)
     testCase.assertNoOutgoingEvents()
   }

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryInitTest.kt
@@ -14,7 +14,7 @@ class CustomDrugEntryInitTest {
   @Test
   fun `when sheet is created in create mode from the drug list, fetch drug from the drugUuid`() {
     val drugUuid = UUID.fromString("6106544f-2b18-410d-992b-81860a08f02a")
-    val model = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugList(patientUuid = UUID.fromString("13008153-beda-475a-909c-793d03e654fb"), drugUuid))
+    val model = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugList(drugUuid))
 
     initSpec
         .whenInit(model)
@@ -28,7 +28,7 @@ class CustomDrugEntryInitTest {
 
   @Test
   fun `when sheet is created in create mode from a drug name, then set the drug name, frequency and sheet title`() {
-    val model = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugName(patientUuid = UUID.fromString("13008153-beda-475a-909c-793d03e654fb"), drugName))
+    val model = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugName(drugName))
 
     initSpec
         .whenInit(model)
@@ -43,9 +43,7 @@ class CustomDrugEntryInitTest {
   @Test
   fun `when sheet is created in update mode, then fetch prescription`() {
     val prescribedDrugUuid = UUID.fromString("e046a649-dfc0-45b5-89d4-7a4b0af1c282")
-    val model = CustomDrugEntryModel.default(openAs = OpenAs.Update(
-        patientUuid = UUID.fromString("13008153-beda-475a-909c-793d03e654fb"),
-        prescribedDrugUuid = prescribedDrugUuid))
+    val model = CustomDrugEntryModel.default(openAs = OpenAs.Update(prescribedDrugUuid = prescribedDrugUuid))
 
     initSpec
         .whenInit(model)

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryInitTest.kt
@@ -35,7 +35,7 @@ class CustomDrugEntryInitTest {
         .then(
             assertThatFirst(
                 hasModel(model.drugNameLoaded(drugName)),
-                hasEffects(SetSheetTitle(name = drugName, dosage = null, frequency = null), SetDrugFrequency(null))
+                hasEffects(SetSheetTitle(name = drugName, dosage = null, frequency = null))
             )
         )
   }

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryInitTest.kt
@@ -5,8 +5,6 @@ import com.spotify.mobius.test.FirstMatchers.hasModel
 import com.spotify.mobius.test.InitSpec
 import com.spotify.mobius.test.InitSpec.assertThatFirst
 import org.junit.Test
-import org.simple.clinic.TestData
-import org.simple.clinic.drugs.search.DrugFrequency
 import java.util.UUID
 
 class CustomDrugEntryInitTest {
@@ -14,17 +12,16 @@ class CustomDrugEntryInitTest {
   private val drugName = "Amlodipine"
 
   @Test
-  fun `when sheet is created in create mode from a drug list, then set the dosage, frequency and sheet title from the drug object`() {
-    val frequency = DrugFrequency.OD
-    val drug = TestData.drug(id = UUID.fromString("6106544f-2b18-410d-992b-81860a08f02a"), name = drugName, frequency = frequency)
-    val model = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugList(patientUuid = UUID.fromString("13008153-beda-475a-909c-793d03e654fb"), drug))
+  fun `when sheet is created in create mode from the drug list, fetch drug from the drugUuid`() {
+    val drugUuid = UUID.fromString("6106544f-2b18-410d-992b-81860a08f02a")
+    val model = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugList(patientUuid = UUID.fromString("13008153-beda-475a-909c-793d03e654fb"), drugUuid))
 
     initSpec
         .whenInit(model)
         .then(
             assertThatFirst(
-                hasModel(model.drugNameLoaded(drugName).dosageEdited(drug.dosage).frequencyEdited(frequency)),
-                hasEffects(SetSheetTitle(name = drugName, dosage = drug.dosage, frequency = frequency), SetDrugFrequency(frequency), SetDrugDosage(drug.dosage))
+                hasModel(model),
+                hasEffects(FetchDrug(drugUuid))
             )
         )
   }

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUiRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUiRendererTest.kt
@@ -11,8 +11,7 @@ class CustomDrugEntryUiRendererTest {
   private val ui = mock<CustomDrugEntryUi>()
   private val uiRenderer = CustomDrugEntryUiRenderer(ui, dosagePlaceholder = "mg")
   private val drugName = "Amlodipine"
-  private val patientUuid = UUID.fromString("77f1d870-5c60-49f7-a4e2-2f1d60e4218c")
-  private val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugName(patientUuid, drugName))
+  private val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugName(drugName))
 
   @Test
   fun `when drug dosage focus is changed and dosage is null, then set drug dosage text with the placeholder and move the cursor to the beginning`() {
@@ -51,7 +50,7 @@ class CustomDrugEntryUiRendererTest {
   fun `when the screen is loaded in update mode, then render the drug name and setup ui for updating drug entry`() {
     // given
     val prescribedDrugUuid = UUID.fromString("96633994-6e4d-4528-b796-f03ae016553a")
-    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.Update(patientUuid, prescribedDrugUuid))
+    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.Update(prescribedDrugUuid))
 
     // when
     uiRenderer.render(defaultModel)

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
@@ -177,4 +177,19 @@ class CustomDrugEntryUpdateTest {
             hasEffects(CloseBottomSheet)
         ))
   }
+
+  @Test
+  fun `when drug is fetched, then update the model with drug values and set sheet title, drug frequency and dosage`() {
+    val drugUuid = UUID.fromString("6bbc5bbe-863c-472a-b962-1fd3198e20d1")
+    val drug = TestData.drug(id = drugUuid)
+    updateSpec
+        .given(defaultModel)
+        .whenEvent(DrugFetched(drug))
+        .then(
+            assertThatNext(
+                hasModel(defaultModel.drugNameLoaded(drug.name).dosageEdited(drug.dosage).frequencyEdited(drug.frequency).rxNormCodeEdited(drug.rxNormCode)),
+                hasEffects(SetSheetTitle(drug.name, drug.dosage, drug.frequency), SetDrugFrequency(drug.frequency), SetDrugDosage(drug.dosage))
+            )
+        )
+  }
 }

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
@@ -17,7 +17,7 @@ class CustomDrugEntryUpdateTest {
   private val updateSpec = UpdateSpec(CustomDrugEntryUpdate())
   private val drugName = "Amlodipine"
   private val patientUuid = UUID.fromString("77f1d870-5c60-49f7-a4e2-2f1d60e4218c")
-  private val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugName(patientUuid, drugName))
+  private val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugName(drugName))
 
   @Test
   fun `when dosage is edited, then update the model with the new dosage and update the sheet title`() {
@@ -77,11 +77,11 @@ class CustomDrugEntryUpdateTest {
     val frequency = DrugFrequency.OD
     val drugUuid = UUID.fromString("6106544f-2b18-410d-992b-81860a08f02a")
     val drug = TestData.drug(id = drugUuid, name = drugName)
-    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugList(patientUuid, drugUuid)).drugNameLoaded(drugName).rxNormCodeEdited(drug.rxNormCode)
+    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugList(drugUuid)).drugNameLoaded(drugName).rxNormCodeEdited(drug.rxNormCode)
 
     updateSpec
         .given(defaultModel.dosageEdited(dosage).frequencyEdited(frequency))
-        .whenEvent(AddMedicineButtonClicked)
+        .whenEvent(AddMedicineButtonClicked(patientUuid))
         .then(assertThatNext(
             hasNoModel(),
             hasEffects(SaveCustomDrugToPrescription(patientUuid, drugName, dosage, drug.rxNormCode, frequency))
@@ -93,11 +93,11 @@ class CustomDrugEntryUpdateTest {
   fun `when add button is clicked and the sheet is opened in create mode from drug name with edited dosage and frequency values, then add the drug to the custom drug list`() {
     val dosage = "200 mg"
     val frequency = DrugFrequency.OD
-    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugName(patientUuid, drugName)).drugNameLoaded(drugName)
+    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugName(drugName)).drugNameLoaded(drugName)
 
     updateSpec
         .given(defaultModel.dosageEdited(dosage).frequencyEdited(frequency))
-        .whenEvent(AddMedicineButtonClicked)
+        .whenEvent(AddMedicineButtonClicked(patientUuid))
         .then(assertThatNext(
             hasNoModel(),
             hasEffects(SaveCustomDrugToPrescription(patientUuid, drugName, dosage, null, frequency))
@@ -109,11 +109,11 @@ class CustomDrugEntryUpdateTest {
     val dosage = "200 mg"
     val frequency = DrugFrequency.OD
     val prescribedDrugUuid = UUID.fromString("96633994-6e4d-4528-b796-f03ae016553a")
-    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.Update(patientUuid, prescribedDrugUuid))
+    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.Update(prescribedDrugUuid))
 
     updateSpec
         .given(defaultModel.drugNameLoaded(drugName).dosageEdited(dosage).frequencyEdited(frequency))
-        .whenEvent(AddMedicineButtonClicked)
+        .whenEvent(AddMedicineButtonClicked(patientUuid))
         .then(
             assertThatNext(
                 hasNoModel(),
@@ -139,7 +139,7 @@ class CustomDrugEntryUpdateTest {
     val drugFrequency = DrugFrequency.OD
     val dosage = "12mg"
     val prescribedDrug = TestData.prescription(uuid = prescribedDrugUuid, name = drugName, isDeleted = false, frequency = MedicineFrequency.OD, dosage = dosage)
-    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.Update(patientUuid, prescribedDrugUuid))
+    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.Update(prescribedDrugUuid))
 
     updateSpec
         .given(defaultModel)
@@ -158,7 +158,7 @@ class CustomDrugEntryUpdateTest {
   @Test
   fun `when remove button is clicked, then remove the drug from the custom drug list`() {
     val prescribedDrugId = UUID.fromString("59842701-d7dd-4206-88a9-9f6f2460e496")
-    val model = CustomDrugEntryModel.default(openAs = OpenAs.Update(patientUuid, prescribedDrugId))
+    val model = CustomDrugEntryModel.default(openAs = OpenAs.Update(prescribedDrugId))
 
     updateSpec
         .given(model)

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
@@ -148,7 +148,8 @@ class CustomDrugEntryUpdateTest {
                 hasModel(defaultModel
                     .drugNameLoaded(drugName)
                     .dosageEdited(dosage = dosage)
-                    .frequencyEdited(frequency = drugFrequency)),
+                    .frequencyEdited(frequency = drugFrequency)
+                    .rxNormCodeEdited(prescribedDrug.rxNormCode)),
                 hasEffects(SetSheetTitle(drugName, dosage, drugFrequency), SetDrugFrequency(drugFrequency)))
         )
   }

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
@@ -151,7 +151,7 @@ class CustomDrugEntryUpdateTest {
                     .dosageEdited(dosage = dosage)
                     .frequencyEdited(frequency = drugFrequency)
                     .rxNormCodeEdited(prescribedDrug.rxNormCode)),
-                hasEffects(SetSheetTitle(drugName, dosage, drugFrequency), SetDrugFrequency(drugFrequency)))
+                hasEffects(SetSheetTitle(drugName, dosage, drugFrequency), SetDrugFrequency(drugFrequency), SetDrugDosage(dosage)))
         )
   }
 

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
@@ -75,8 +75,9 @@ class CustomDrugEntryUpdateTest {
   fun `when add button is clicked and the sheet is opened in create mode from drug list with edited dosage and frequency values, then add the drug to the custom drug list`() {
     val dosage = "200 mg"
     val frequency = DrugFrequency.OD
-    val drug = TestData.drug(id = UUID.fromString("6106544f-2b18-410d-992b-81860a08f02a"), name = drugName)
-    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugList(patientUuid, drug)).drugNameLoaded(drugName)
+    val drugUuid = UUID.fromString("6106544f-2b18-410d-992b-81860a08f02a")
+    val drug = TestData.drug(id = drugUuid, name = drugName)
+    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugList(patientUuid, drugUuid)).drugNameLoaded(drugName).rxNormCodeEdited(drug.rxNormCode)
 
     updateSpec
         .given(defaultModel.dosageEdited(dosage).frequencyEdited(frequency))

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
@@ -123,13 +123,13 @@ class CustomDrugEntryUpdateTest {
   }
 
   @Test
-  fun `when the new drug is added to the list, then close the bottom sheet`() {
+  fun `when the new drug is added to the list, then close the bottom sheet and go to edit medicine screen`() {
     updateSpec
         .given(defaultModel)
         .whenEvent(CustomDrugSaved)
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(CloseBottomSheet)
+            hasEffects(CloseSheetAndGoToEditMedicineScreen)
         ))
   }
 
@@ -170,13 +170,13 @@ class CustomDrugEntryUpdateTest {
   }
 
   @Test
-  fun `when the drug is removed from the custom drug list, then close the bottom sheet`() {
+  fun `when the drug is removed from the custom drug list, then close the bottom sheet and go to edit medicine screen`() {
     updateSpec
         .given(defaultModel)
         .whenEvent(ExistingDrugRemoved)
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(CloseBottomSheet)
+            hasEffects(CloseSheetAndGoToEditMedicineScreen)
         ))
   }
 


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/2905/implement-customdrugentrysheet

In this PR - 
- Added `FetchDrug` effect in the mobius loop as we can only pass parcelables through keys. So changed the `OpenAs.New.FromDrugList` parameter from `Drug` to `drugUuid`
- Made some corrections in the mobius loop
- Removed the implementation of passing `Unknown("None")` when converting `DrugFrequency` to `MedicineFrequency` as  in the list of frequencies we will not have an option of Unknown. Unknown is only for cases when there is a new addition to the latest version in `DrugFrequency` and if we have to load it in the older version then we use it. Although in case of `Unknown("None")` this only means that user has not selected any frequency in which case we will just set it to null.
- Added `sheet_custom_drug_entry`
- Implemented the UI layer, mobius delegate and intents.

What's not implemented yet 
- Drug Frequency dialog is still not implemented. Will be raising another PR for that.
- If the user edits the dosage and removes the entire dosage text. The placeholder value stays there and if the user saves after it the placeholder value is saved instead of null in dosage. I will resolve this in the next PR.