### PR TITLE
Show appointment results in contact patient sheet for patient with no phone number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Update `MaterialAlertDialog` theme and style
 - Run integration tests on discrete Heroku servers instead of QA
 - Bump lottie to v4.1.0
+- Show appointment results in contact patient sheet for patient with no phone number
 
 ### Changes
 - [In Progress: 19 Aug 2021] UI improvements for medical history screen

--- a/app/src/main/java/org/simple/clinic/contactpatient/ContactPatientBottomSheet.kt
+++ b/app/src/main/java/org/simple/clinic/contactpatient/ContactPatientBottomSheet.kt
@@ -379,6 +379,10 @@ class ContactPatientBottomSheet : BaseBottomSheet<
     progressIndicator.visibility = GONE
   }
 
+  override fun showPatientWithNoPhoneNumberResults() {
+    callPatientView.showPatientWithNoPhoneNumberResults = true
+  }
+
   private fun backPressed() {
     hotEvents.onNext(BackClicked)
   }

--- a/app/src/main/java/org/simple/clinic/contactpatient/ContactPatientUi.kt
+++ b/app/src/main/java/org/simple/clinic/contactpatient/ContactPatientUi.kt
@@ -48,4 +48,6 @@ interface ContactPatientUi {
 
   fun showPatientWithCallResultUi()
   fun hidePatientWithCallResultUi()
+
+  fun showPatientWithNoPhoneNumberResults()
 }

--- a/app/src/main/java/org/simple/clinic/contactpatient/ContactPatientUiRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/contactpatient/ContactPatientUiRenderer.kt
@@ -78,6 +78,11 @@ class ContactPatientUiRenderer(
     } else if (model.patientProfileHasPhoneNumber && model.isAppointmentPresent) {
       showPatientCallResult()
       loadSecureCallingUi(model)
+    } else if (!model.patientProfileHasPhoneNumber && model.isAppointmentPresent) {
+      ui.showPatientWithNoPhoneNumberUi()
+      ui.hidePatientWithPhoneNumberUi()
+      ui.setResultLabelText()
+      ui.showPatientWithNoPhoneNumberResults()
     } else {
       ui.showPatientWithNoPhoneNumberUi()
       ui.hidePatientWithPhoneNumberUi()

--- a/app/src/main/java/org/simple/clinic/contactpatient/views/CallPatientView.kt
+++ b/app/src/main/java/org/simple/clinic/contactpatient/views/CallPatientView.kt
@@ -83,6 +83,9 @@ class CallPatientView(
   private val patientWithCallResultGroup
     get() = binding!!.patientWithCallResultGroup
 
+  private val patientWithNoPhoneNumberResultsGroup
+    get() = binding!!.patientWithNoPhoneNumberResultGroup
+
   var secureCallingSectionVisible: Boolean = false
     set(value) {
       field = value
@@ -117,6 +120,12 @@ class CallPatientView(
     set(value) {
       field = value
       patientWithCallResultGroup.visibility = if (field) View.VISIBLE else View.GONE
+    }
+
+  var showPatientWithNoPhoneNumberResults: Boolean = false
+    set(value) {
+      field = value
+      patientWithNoPhoneNumberResultsGroup.visibility = if (field) View.VISIBLE else View.GONE
     }
 
   var agreedToVisitClicked: AgreedToVisitClicked? = null

--- a/app/src/main/res/layout/contactpatient_callpatient.xml
+++ b/app/src/main/res/layout/contactpatient_callpatient.xml
@@ -346,4 +346,11 @@
     android:layout_height="wrap_content"
     android:visibility="gone"
     app:constraint_referenced_ids="resultOfCallLabel, agreedToVisitTextView, agreedToVisitSeparator, remindToCallLaterTextView, remindToCallLaterSeparator, removeFromOverdueListTextView" />
+
+  <androidx.constraintlayout.widget.Group
+    android:id="@+id/patientWithNoPhoneNumberResultGroup"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:visibility="gone"
+    app:constraint_referenced_ids="resultOfCallLabel, agreedToVisitTextView, agreedToVisitSeparator, removeFromOverdueListTextView" />
 </merge>

--- a/app/src/test/java/org/simple/clinic/contactpatient/CallPatientUiRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/contactpatient/CallPatientUiRendererTest.kt
@@ -316,7 +316,6 @@ class CallPatientUiRendererTest {
     verifyNoMoreInteractions(ui)
   }
 
-
   @Test
   fun `if the overdue list changes feature is disabled, then switch to old call patient view`() {
     // when
@@ -369,6 +368,7 @@ class CallPatientUiRendererTest {
         lastVisited = patientProfile.patientLastSeen))
     verify(ui).switchToCallPatientView()
     verify(ui).setResultLabelText()
+    verify(ui).showPatientWithNoPhoneNumberResults()
     verifyNoMoreInteractions(ui)
   }
 
@@ -445,6 +445,7 @@ class CallPatientUiRendererTest {
     verify(ui).showPatientWithNoPhoneNumberUi()
     verify(ui).hidePatientWithPhoneNumberUi()
     verify(ui).setResultLabelText()
+    verify(ui).showPatientWithNoPhoneNumberResults()
     verifyNoMoreInteractions(ui)
   }
 
@@ -479,6 +480,7 @@ class CallPatientUiRendererTest {
     verify(ui).showPatientWithNoPhoneNumberUi()
     verify(ui).hidePatientWithPhoneNumberUi()
     verify(ui).setResultLabelText()
+    verify(ui).showPatientWithNoPhoneNumberResults()
     verifyNoMoreInteractions(ui)
   }
 


### PR DESCRIPTION
Slack message: https://simpledotorg.slack.com/archives/CFK2PHJ1L/p1629447233229600

Since this UI doesn't have to be reactive, we don't have to worry about hiding the results section. Basically we are not adjusting UI based on some reactive stream, we just render the UI when creating the sheet.

This results UI is hidden by default, and only get's shown if the patient doesn't have no phone number and has appointment.
