### PR TITLE
Restricting login OTP entries to 5 attempts #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Search for commonly used drugs
 - [In Progress: 06 Aug 2021] Add support for Sri Lanka
 - [In Progress: 25 Aug 2021] Implement providing drug frequencies label depending on the country
+- [In-progress: 27 Aug 2021] Restrict OTP entries to 5 attempts
 
 ## On Demo
 ### Internal

--- a/app/src/main/java/org/simple/clinic/di/AppModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/AppModule.kt
@@ -18,6 +18,7 @@ import org.simple.clinic.appupdate.AppUpdateModule
 import org.simple.clinic.di.network.HttpInterceptorsModule
 import org.simple.clinic.di.network.NetworkModule
 import org.simple.clinic.di.network.RetrofitModule
+import org.simple.clinic.enterotp.BruteForceOtpEntryProtectionModule
 import org.simple.clinic.facility.change.FacilityChangeModule
 import org.simple.clinic.home.overdue.OverdueAppointmentsConfigModule
 import org.simple.clinic.instantsearch.InstantSearchConfigModule
@@ -88,7 +89,8 @@ import javax.inject.Named
   TeleconsultPrescriptionModule::class,
   InstantSearchConfigModule::class,
   CountryModule::class,
-  OverdueAppointmentsConfigModule::class
+  OverdueAppointmentsConfigModule::class,
+  BruteForceOtpEntryProtectionModule::class
 ])
 class AppModule(private val appContext: Application) {
 

--- a/app/src/main/java/org/simple/clinic/enterotp/BruteForceOtpEntryProtection.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/BruteForceOtpEntryProtection.kt
@@ -1,0 +1,29 @@
+package org.simple.clinic.enterotp
+
+import com.f2prateek.rx.preferences2.Preference
+import org.simple.clinic.util.UtcClock
+import javax.inject.Inject
+
+class BruteForceOtpEntryProtection @Inject constructor(
+    private val utcClock: UtcClock,
+    private val config: BruteForceOtpEntryProtectionConfig,
+    private val otpStatePreference: Preference<BruteForceOtpProtectionState>
+) {
+
+  fun incrementFailedOtpAttempt() {
+    val updatedBruteForceOtpProtectionState = updateFailedOtpAttemptLimitReached(config.limitOfFailedAttempts)
+    otpStatePreference.set(updatedBruteForceOtpProtectionState)
+  }
+
+  private fun updateFailedOtpAttemptLimitReached(
+      maxAllowedFailedOtpAttempts: Int
+  ): BruteForceOtpProtectionState {
+    val otpState = otpStatePreference.get()
+    val isOtpAttemptLimitReached = otpState.failedLoginOtpAttempt >= maxAllowedFailedOtpAttempts
+    return if (isOtpAttemptLimitReached && !otpState.limitReachedAt.isPresent) {
+      otpState.failedAttemptLimitReached(utcClock)
+    } else {
+      otpState.loginAttemptFailed()
+    }
+  }
+}

--- a/app/src/main/java/org/simple/clinic/enterotp/BruteForceOtpEntryProtectionConfig.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/BruteForceOtpEntryProtectionConfig.kt
@@ -1,0 +1,8 @@
+package org.simple.clinic.enterotp
+
+import java.time.Duration
+
+data class BruteForceOtpEntryProtectionConfig(
+  val limitOfFailedAttempts: Int,
+  val blockDuration: Duration
+)

--- a/app/src/main/java/org/simple/clinic/enterotp/BruteForceOtpEntryProtectionConfigModule.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/BruteForceOtpEntryProtectionConfigModule.kt
@@ -1,0 +1,13 @@
+package org.simple.clinic.enterotp
+
+import dagger.Module
+import dagger.Provides
+import java.time.Duration
+
+@Module
+class BruteForceOtpEntryProtectionConfigModule {
+  @Provides
+  fun config(): BruteForceOtpEntryProtectionConfig {
+    return BruteForceOtpEntryProtectionConfig(limitOfFailedAttempts = 4, blockDuration = Duration.ofMinutes(20))
+  }
+}

--- a/app/src/main/java/org/simple/clinic/enterotp/BruteForceOtpEntryProtectionModule.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/BruteForceOtpEntryProtectionModule.kt
@@ -1,0 +1,21 @@
+package org.simple.clinic.enterotp
+
+import com.f2prateek.rx.preferences2.Preference
+import com.f2prateek.rx.preferences2.RxSharedPreferences
+import com.squareup.moshi.Moshi
+import dagger.Module
+import dagger.Provides
+import org.simple.clinic.util.preference.MoshiObjectPreferenceConverter
+
+@Module(includes = [BruteForceOtpEntryProtectionConfigModule::class])
+class BruteForceOtpEntryProtectionModule {
+
+  @Provides
+  fun otpAttempts(
+      rxSharedPrefs: RxSharedPreferences,
+      moshi: Moshi
+  ): Preference<BruteForceOtpProtectionState> {
+    val typeConverter = MoshiObjectPreferenceConverter(moshi, BruteForceOtpProtectionState::class.java)
+    return rxSharedPrefs.getObject("login_otp_attempt_limit", BruteForceOtpProtectionState(), typeConverter)
+  }
+}

--- a/app/src/main/java/org/simple/clinic/enterotp/BruteForceOtpProtectionState.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/BruteForceOtpProtectionState.kt
@@ -1,0 +1,22 @@
+package org.simple.clinic.enterotp
+
+import com.squareup.moshi.JsonClass
+import org.simple.clinic.util.UtcClock
+import org.simple.clinic.util.toOptional
+import java.time.Instant
+import java.util.Optional
+
+@JsonClass(generateAdapter = true)
+data class BruteForceOtpProtectionState(
+    val limitReachedAt: Optional<Instant> = Optional.empty(),
+    val failedLoginOtpAttempt: Int = 0
+) {
+
+  fun failedAttemptLimitReached(utcClock: UtcClock): BruteForceOtpProtectionState {
+    return this.copy(limitReachedAt = Instant.now(utcClock).toOptional())
+  }
+
+  fun loginAttemptFailed(): BruteForceOtpProtectionState {
+    return this.copy(failedLoginOtpAttempt = failedLoginOtpAttempt + 1)
+  }
+}

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpEffect.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpEffect.kt
@@ -1,5 +1,7 @@
 package org.simple.clinic.enterotp
 
+import org.simple.clinic.login.LoginResult
+
 sealed class EnterOtpEffect
 
 object LoadUser : EnterOtpEffect()
@@ -19,3 +21,5 @@ object ListenForUserBackgroundVerification : EnterOtpEffect()
 object RequestLoginOtp : EnterOtpEffect()
 
 object ShowSmsSentMessage : EnterOtpEffect()
+
+data class FailedLoginOtpAttempt(val result: LoginResult) : EnterOtpEffect()

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpEffectHandler.kt
@@ -20,6 +20,7 @@ class EnterOtpEffectHandler @AssistedInject constructor(
     private val ongoingLoginEntryRepository: OngoingLoginEntryRepository,
     private val loginUserWithOtp: LoginUserWithOtp,
     private val activateUser: ActivateUser,
+    private val bruteForceProtection: BruteForceOtpEntryProtection,
     @Assisted private val uiActions: EnterOtpUiActions
 ) {
 
@@ -40,6 +41,7 @@ class EnterOtpEffectHandler @AssistedInject constructor(
         .addTransformer(ListenForUserBackgroundVerification::class.java, waitForUserBackgroundVerifications())
         .addTransformer(RequestLoginOtp::class.java, activateUser())
         .addAction(ShowSmsSentMessage::class.java, uiActions::showSmsSentMessage, schedulers.ui())
+        .addConsumer(FailedLoginOtpAttempt::class.java, { bruteForceProtection.incrementFailedOtpAttempt() }, schedulers.io())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUpdate.kt
@@ -44,8 +44,17 @@ class EnterOtpUpdate(
     val updatedModel = model.loginFinished()
     return when (val result = event.result) {
       LoginResult.Success -> next(updatedModel, ClearLoginEntry, TriggerSync)
+      is LoginResult.ServerError -> showLoginFailedAttemptIfIncorrectOtp(result, updatedModel)
       else -> next(updatedModel.loginFailed(AsyncOpError.from(result)), ClearPin as EnterOtpEffect)
     }
+  }
+
+  private fun showLoginFailedAttemptIfIncorrectOtp(
+      result: LoginResult.ServerError,
+      updatedModel: EnterOtpModel
+  ): Next<EnterOtpModel, EnterOtpEffect> {
+    val model = updatedModel.loginFailed(AsyncOpError.from(result))
+    return next(model, FailedLoginOtpAttempt(result), ClearPin)
   }
 
   private fun otpSubmitted(

--- a/app/src/test/java/org/simple/clinic/enterotp/BruteForceOtpEntryProtectionTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/BruteForceOtpEntryProtectionTest.kt
@@ -1,0 +1,33 @@
+package org.simple.clinic.enterotp
+
+import com.f2prateek.rx.preferences2.Preference
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Rule
+import org.junit.Test
+import org.simple.clinic.util.RxErrorsRule
+import org.simple.clinic.util.TestUtcClock
+import java.time.Duration
+
+class BruteForceOtpEntryProtectionTest {
+
+  @get:Rule
+  val rxErrorsRule = RxErrorsRule()
+
+  private val preferenceState = mock<Preference<BruteForceOtpProtectionState>>()
+  private val clock = TestUtcClock()
+  private val config = BruteForceOtpEntryProtectionConfig(limitOfFailedAttempts = 4, blockDuration = Duration.ofMinutes(20))
+
+  private val bruteForceOtpEntryProtection = BruteForceOtpEntryProtection(clock, config, preferenceState)
+
+  @Test
+  fun `when incrementing the count of failed otp attempts, then the count should be updated`() {
+    val state = BruteForceOtpProtectionState(failedLoginOtpAttempt = 2)
+    whenever(preferenceState.get()).thenReturn(state)
+
+    bruteForceOtpEntryProtection.incrementFailedOtpAttempt()
+
+    verify(preferenceState).set(BruteForceOtpProtectionState(failedLoginOtpAttempt = 3))
+  }
+}

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpEffectHandlerTest.kt
@@ -1,0 +1,51 @@
+package org.simple.clinic.enterotp
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import io.reactivex.Completable
+import org.junit.After
+import org.junit.Test
+import org.simple.clinic.login.LoginResult
+import org.simple.clinic.mobius.EffectHandlerTestCase
+import org.simple.clinic.util.scheduler.TestSchedulersProvider
+
+class EnterOtpEffectHandlerTest {
+
+  private val uiActions = mock<EnterOtpUiActions>()
+  private val bruteForceOtpEntryProtection = mock<BruteForceOtpEntryProtection>()
+  private val effectHandler = EnterOtpEffectHandler(
+      schedulers = TestSchedulersProvider.trampoline(),
+      userSession = mock(),
+      dataSync = mock(),
+      ongoingLoginEntryRepository = mock(),
+      loginUserWithOtp = mock(),
+      activateUser = mock(),
+      bruteForceProtection = bruteForceOtpEntryProtection,
+      uiActions = uiActions
+  )
+
+  private val testCase = EffectHandlerTestCase(effectHandler.build())
+
+  @After
+  fun tearDown() {
+    testCase.dispose()
+  }
+
+  @Test
+  fun `when the failed login otp entry attempt effect is received, then increment the otp failed value in preferences`() {
+    // given
+    val errorMessage = "Your OTP does not match. Try again?"
+
+    // when
+    testCase.dispatch(FailedLoginOtpAttempt(LoginResult.ServerError(errorMessage)))
+
+    // then
+    verify(bruteForceOtpEntryProtection).incrementFailedOtpAttempt()
+    verifyNoMoreInteractions(bruteForceOtpEntryProtection)
+    verifyZeroInteractions(uiActions)
+  }
+}

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpLogicTest.kt
@@ -919,7 +919,8 @@ class EnterOtpLogicTest {
         ongoingLoginEntryRepository = ongoingLoginEntryRepository,
         loginUserWithOtp = loginUserWithOtp,
         activateUser = activateUser,
-        uiActions = uiActions
+        uiActions = uiActions,
+        bruteForceProtection = mock()
     )
     val uiRenderer = EnterOtpUiRenderer(ui)
 

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpUpdateTest.kt
@@ -1,24 +1,25 @@
 package org.simple.clinic.enterotp
 
-import com.spotify.mobius.test.NextMatchers.hasModel
 import com.spotify.mobius.test.NextMatchers.hasEffects
+import com.spotify.mobius.test.NextMatchers.hasModel
 import com.spotify.mobius.test.UpdateSpec
 import com.spotify.mobius.test.UpdateSpec.assertThatNext
 import org.junit.Test
 import org.simple.clinic.TestData
 import org.simple.clinic.login.LoginResult.NetworkError
+import org.simple.clinic.login.LoginResult.ServerError
 import java.util.UUID
 
 class EnterOtpUpdateTest {
+  private val updateSpec = UpdateSpec(EnterOtpUpdate(loginOtpRequiredLength = 6))
+  private val user = TestData.loggedInUser(uuid = UUID.fromString("6fc16e72-39a5-4568-86db-1f8b1c0c08d3"))
+  private val loginStartedModel = EnterOtpModel.create()
+      .userLoaded(user)
+      .enteredOtpValid()
+      .loginStarted()
+
   @Test
   fun `when the login request is completed and is unsuccessful, then finish logging in and show error`() {
-    val updateSpec = UpdateSpec(EnterOtpUpdate(loginOtpRequiredLength = 6))
-    val user = TestData.loggedInUser(uuid = UUID.fromString("6fc16e72-39a5-4568-86db-1f8b1c0c08d3"))
-    val loginStartedModel = EnterOtpModel.create()
-        .userLoaded(user)
-        .enteredOtpValid()
-        .loginStarted()
-
     updateSpec
         .given(loginStartedModel)
         .whenEvent(LoginUserCompleted(NetworkError))
@@ -28,6 +29,20 @@ class EnterOtpUpdateTest {
                 hasEffects(ClearPin)
             )
         )
+  }
 
+  @Test
+  fun `when the login request is completed and has returned server error saying incorrect otp, then show failed attempt and clear pin`() {
+    val incorrectOtp = "Your entered Otp is incorrect, please try again"
+    val result = ServerError(incorrectOtp)
+    updateSpec
+        .given(loginStartedModel)
+        .whenEvent(LoginUserCompleted(result))
+        .then(
+            assertThatNext(
+                hasModel(loginStartedModel.loginFinished().loginFailed(AsyncOpError.Companion.from(result))),
+                hasEffects(FailedLoginOtpAttempt(result), ClearPin)
+            )
+        )
   }
 }


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/4514/limit-incorrect-otp-entries