### PR TITLE
Migrate v1 `Country` usages to v2 `Country` - 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 - Remove unused `DrugFrequencyChoiceItem` class
 - Change `ScheduleAppointmentSheet` to use Mobius view effects
 - [In Progress: 30 Aug 2021] Record call results instead of updating the same appointment record
+- [In Progress: 30 Aug 2021] Migrate v1 `Country` usages to v2 `Country`
+
+### Features
+- [In Progress: 30 Aug 2021] Add support for state selection during sign-in/sign-up
 
 ### Changes
 - Implement `CustomDrugEntrySheet`

--- a/app/src/androidTest/java/org/simple/clinic/di/TestRetrofitModule.kt
+++ b/app/src/androidTest/java/org/simple/clinic/di/TestRetrofitModule.kt
@@ -32,7 +32,7 @@ class TestRetrofitModule {
 
   @Provides
   @AppScope
-  @Named("for_country")
+  @Named("for_deployment")
   fun retrofit(
       moshi: Moshi,
       okHttpClient: OkHttpClient

--- a/app/src/main/java/org/simple/clinic/appconfig/AppConfigModule.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/AppConfigModule.kt
@@ -7,10 +7,10 @@ import dagger.Module
 import dagger.Provides
 import org.simple.clinic.appconfig.api.ManifestFetchApi
 import org.simple.clinic.appconfig.displayname.CountryDisplayNameFetcherModule
-import java.util.Optional
 import org.simple.clinic.util.preference.MoshiObjectPreferenceConverter
 import org.simple.clinic.util.preference.getOptional
 import retrofit2.Retrofit
+import java.util.Optional
 import javax.inject.Named
 
 @Module(includes = [CountryDisplayNameFetcherModule::class])
@@ -28,5 +28,14 @@ class AppConfigModule {
   ): Preference<Optional<Country>> {
     val countryPreferenceConverter = MoshiObjectPreferenceConverter(moshi, Country::class.java)
     return rxSharedPreferences.getOptional("preference_selected_country_v1", countryPreferenceConverter)
+  }
+
+  @Provides
+  fun provideSelectedCountryV2Preference(
+      rxSharedPreferences: RxSharedPreferences,
+      moshi: Moshi
+  ): Preference<Optional<CountryV2>> {
+    val countryPreferenceConverter = MoshiObjectPreferenceConverter(moshi, CountryV2::class.java)
+    return rxSharedPreferences.getOptional("preference_selected_country_v2", countryPreferenceConverter)
   }
 }

--- a/app/src/main/java/org/simple/clinic/appconfig/AppConfigModule.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/AppConfigModule.kt
@@ -38,4 +38,13 @@ class AppConfigModule {
     val countryPreferenceConverter = MoshiObjectPreferenceConverter(moshi, CountryV2::class.java)
     return rxSharedPreferences.getOptional("preference_selected_country_v2", countryPreferenceConverter)
   }
+
+  @Provides
+  fun provideSelectedDeployment(
+      rxSharedPreferences: RxSharedPreferences,
+      moshi: Moshi
+  ): Preference<Optional<Deployment>> {
+    val deploymentPreferenceConverter = MoshiObjectPreferenceConverter(moshi, Deployment::class.java)
+    return rxSharedPreferences.getOptional("preference_selected_deployment_v1", deploymentPreferenceConverter)
+  }
 }

--- a/app/src/main/java/org/simple/clinic/appconfig/AppConfigRepository.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/AppConfigRepository.kt
@@ -6,6 +6,7 @@ import io.reactivex.Observable
 import io.reactivex.Single
 import org.simple.clinic.appconfig.api.ManifestFetchApi
 import org.simple.clinic.util.ErrorResolver
+import org.simple.clinic.util.toNullable
 import java.util.Optional
 import javax.inject.Inject
 
@@ -30,6 +31,10 @@ class AppConfigRepository @Inject constructor(
 
   fun currentCountryObservable(): Observable<Optional<Country>> {
     return selectedCountryPreference.asObservable()
+  }
+
+  fun currentDeployment(): Deployment? {
+    return selectedDeployment.get().toNullable()
   }
 
   fun fetchAppManifest(): Single<ManifestFetchResult> {

--- a/app/src/main/java/org/simple/clinic/appconfig/AppConfigRepository.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/AppConfigRepository.kt
@@ -19,7 +19,8 @@ import javax.inject.Inject
  **/
 class AppConfigRepository @Inject constructor(
     private val manifestFetchApi: ManifestFetchApi,
-    private val selectedCountryPreference: Preference<Optional<Country>>
+    private val selectedCountryPreference: Preference<Optional<Country>>,
+    private val selectedCountryV2Preference: Preference<Optional<CountryV2>>
 ) {
 
   fun currentCountry(): Optional<Country> {
@@ -41,5 +42,9 @@ class AppConfigRepository @Inject constructor(
 
   fun saveCurrentCountry(country: Country): Completable {
     return Completable.fromAction { selectedCountryPreference.set(Optional.of(country)) }
+  }
+
+  fun saveCurrentCountry(country: CountryV2) {
+    selectedCountryV2Preference.set(Optional.of(country))
   }
 }

--- a/app/src/main/java/org/simple/clinic/appconfig/AppConfigRepository.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/AppConfigRepository.kt
@@ -20,7 +20,8 @@ import javax.inject.Inject
 class AppConfigRepository @Inject constructor(
     private val manifestFetchApi: ManifestFetchApi,
     private val selectedCountryPreference: Preference<Optional<Country>>,
-    private val selectedCountryV2Preference: Preference<Optional<CountryV2>>
+    private val selectedCountryV2Preference: Preference<Optional<CountryV2>>,
+    private val selectedDeployment: Preference<Optional<Deployment>>
 ) {
 
   fun currentCountry(): Optional<Country> {
@@ -46,5 +47,9 @@ class AppConfigRepository @Inject constructor(
 
   fun saveCurrentCountry(country: CountryV2) {
     selectedCountryV2Preference.set(Optional.of(country))
+  }
+
+  fun saveDeployment(deployment: Deployment) {
+    selectedDeployment.set(Optional.of(deployment))
   }
 }

--- a/app/src/main/java/org/simple/clinic/appconfig/CountryModule.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/CountryModule.kt
@@ -15,4 +15,29 @@ object CountryModule {
 
     return selectedCountry
   }
+
+  @Provides
+  fun providesDeployment(appConfigRepository: AppConfigRepository): Deployment {
+    createDeploymentIfOldCountryIsPresent(appConfigRepository)
+
+    val selectedDeployment = appConfigRepository.currentDeployment()
+
+    requireNotNull(selectedDeployment) { "There is no stored deployment available!" }
+
+    return selectedDeployment
+  }
+
+  private fun createDeploymentIfOldCountryIsPresent(appConfigRepository: AppConfigRepository) {
+    val selectedCountry = appConfigRepository.currentCountry().toNullable()
+    val selectedDeployment = appConfigRepository.currentDeployment()
+
+    if (selectedCountry != null && selectedDeployment == null) {
+      // Since V1 country doesn't have deployment names, we are going with country name
+      val deployment = Deployment(
+          displayName = selectedCountry.displayName,
+          endPoint = selectedCountry.endpoint
+      )
+      appConfigRepository.saveDeployment(deployment)
+    }
+  }
 }

--- a/app/src/main/java/org/simple/clinic/appconfig/CountryV2.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/CountryV2.kt
@@ -4,6 +4,10 @@ import android.os.Parcelable
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import kotlinx.parcelize.Parcelize
+import org.simple.clinic.patient.businessid.Identifier
+import org.threeten.extra.chrono.EthiopicChronology
+import java.time.chrono.Chronology
+import java.time.chrono.IsoChronology
 
 @Parcelize
 @JsonClass(generateAdapter = true)
@@ -20,4 +24,50 @@ data class CountryV2(
 
     @Json(name = "deployments")
     val deployments: List<Deployment>
-) : Parcelable
+) : Parcelable {
+
+  val alternativeIdentifierType: Identifier.IdentifierType?
+    get() {
+      return when (isoCountryCode) {
+        BANGLADESH -> Identifier.IdentifierType.BangladeshNationalId
+        ETHIOPIA -> Identifier.IdentifierType.EthiopiaMedicalRecordNumber
+        INDIA -> Identifier.IdentifierType.IndiaNationalHealthId
+        SRI_LANKA -> Identifier.IdentifierType.SriLankaNationalId
+        else -> null
+      }
+    }
+
+  val areWhatsAppRemindersSupported: Boolean
+    get() = isoCountryCode == INDIA
+
+  val chronology: Chronology
+    get() = when (isoCountryCode) {
+      ETHIOPIA -> EthiopicChronology.INSTANCE
+      else -> IsoChronology.INSTANCE
+    }
+
+  val fullDatePattern: String
+    get() = when (isoCountryCode) {
+      ETHIOPIA -> "dd/MM/yyyy"
+      else -> "d-MMM-yyyy"
+    }
+
+  val exactDatePattern: String
+    get() = when (isoCountryCode) {
+      ETHIOPIA -> "dd/MM/yyyy"
+      else -> "d MMMM, yyyy"
+    }
+
+  val fileDateTimePattern: String
+    get() = when (isoCountryCode) {
+      ETHIOPIA -> "dd MM yyyy h.mm.ss a"
+      else -> "d MMM yyyy h.mm.ss a"
+    }
+
+  companion object {
+    const val INDIA = "IN"
+    const val BANGLADESH = "BD"
+    const val ETHIOPIA = "ET"
+    const val SRI_LANKA = "LK"
+  }
+}

--- a/app/src/main/java/org/simple/clinic/appconfig/CountryV2.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/CountryV2.kt
@@ -1,8 +1,11 @@
 package org.simple.clinic.appconfig
 
+import android.os.Parcelable
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 @JsonClass(generateAdapter = true)
 data class CountryV2(
 
@@ -17,4 +20,4 @@ data class CountryV2(
 
     @Json(name = "deployments")
     val deployments: List<Deployment>
-)
+) : Parcelable

--- a/app/src/main/java/org/simple/clinic/appconfig/Deployment.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/Deployment.kt
@@ -1,9 +1,12 @@
 package org.simple.clinic.appconfig
 
+import android.os.Parcelable
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import kotlinx.parcelize.Parcelize
 import java.net.URI
 
+@Parcelize
 @JsonClass(generateAdapter = true)
 data class Deployment(
     @Json(name = "display_name")
@@ -11,4 +14,4 @@ data class Deployment(
 
     @Json(name = "endpoint")
     val endPoint: URI
-)
+) : Parcelable

--- a/app/src/main/java/org/simple/clinic/bloodsugar/di/BloodSugarModule.kt
+++ b/app/src/main/java/org/simple/clinic/bloodsugar/di/BloodSugarModule.kt
@@ -23,7 +23,7 @@ class BloodSugarModule {
   }
 
   @Provides
-  fun syncApi(@Named("for_country") retrofit: Retrofit): BloodSugarSyncApi {
+  fun syncApi(@Named("for_deployment") retrofit: Retrofit): BloodSugarSyncApi {
     return retrofit.create(BloodSugarSyncApi::class.java)
   }
 

--- a/app/src/main/java/org/simple/clinic/bp/di/BloodPressureModule.kt
+++ b/app/src/main/java/org/simple/clinic/bp/di/BloodPressureModule.kt
@@ -23,7 +23,7 @@ open class BloodPressureModule {
   }
 
   @Provides
-  fun syncApi(@Named("for_country") retrofit: Retrofit): BloodPressureSyncApi {
+  fun syncApi(@Named("for_deployment") retrofit: Retrofit): BloodPressureSyncApi {
     return retrofit.create(BloodPressureSyncApi::class.java)
   }
 

--- a/app/src/main/java/org/simple/clinic/di/network/RetrofitModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/network/RetrofitModule.kt
@@ -6,7 +6,6 @@ import dagger.Provides
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import org.simple.clinic.BuildConfig
-import org.simple.clinic.appconfig.Country
 import org.simple.clinic.appconfig.Deployment
 import org.simple.clinic.di.AppScope
 import retrofit2.Retrofit
@@ -40,26 +39,8 @@ class RetrofitModule {
 
   @Provides
   @AppScope
-  @Named("for_country")
-  fun retrofit(
-      country: Country,
-      commonRetrofitBuilder: Retrofit.Builder
-  ): Retrofit {
-    // Since the endpoint is not under our control, and is defined at the server level,
-    // this is a safety check that will generate the right endpoint regardless of whether the
-    // endpoint defined in the manifest has a trailing slash or not.
-    val baseUrl = country.endpoint.toString().removeSuffix("/")
-    val endpoint = "$baseUrl/".toHttpUrl()
-
-    return commonRetrofitBuilder
-        .baseUrl(endpoint)
-        .build()
-  }
-
-  @Provides
-  @AppScope
   @Named("for_deployment")
-  fun retrofitForDeployment(
+  fun retrofit(
       deployment: Deployment,
       commonRetrofitBuilder: Retrofit.Builder
   ): Retrofit {

--- a/app/src/main/java/org/simple/clinic/di/network/RetrofitModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/network/RetrofitModule.kt
@@ -7,6 +7,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import org.simple.clinic.BuildConfig
 import org.simple.clinic.appconfig.Country
+import org.simple.clinic.appconfig.Deployment
 import org.simple.clinic.di.AppScope
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
@@ -48,6 +49,24 @@ class RetrofitModule {
     // this is a safety check that will generate the right endpoint regardless of whether the
     // endpoint defined in the manifest has a trailing slash or not.
     val baseUrl = country.endpoint.toString().removeSuffix("/")
+    val endpoint = "$baseUrl/".toHttpUrl()
+
+    return commonRetrofitBuilder
+        .baseUrl(endpoint)
+        .build()
+  }
+
+  @Provides
+  @AppScope
+  @Named("for_deployment")
+  fun retrofitForDeployment(
+      deployment: Deployment,
+      commonRetrofitBuilder: Retrofit.Builder
+  ): Retrofit {
+    // Since the endpoint is not under our control, and is defined at the server level,
+    // this is a safety check that will generate the right endpoint regardless of whether the
+    // endpoint defined in the manifest has a trailing slash or not.
+    val baseUrl = deployment.endPoint.toString().removeSuffix("/")
     val endpoint = "$baseUrl/".toHttpUrl()
 
     return commonRetrofitBuilder

--- a/app/src/main/java/org/simple/clinic/drugs/PrescriptionModule.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/PrescriptionModule.kt
@@ -21,7 +21,7 @@ class PrescriptionModule {
   }
 
   @Provides
-  fun syncApi(@Named("for_country") retrofit: Retrofit): PrescriptionSyncApi {
+  fun syncApi(@Named("for_deployment") retrofit: Retrofit): PrescriptionSyncApi {
     return retrofit.create(PrescriptionSyncApi::class.java)
   }
 

--- a/app/src/main/java/org/simple/clinic/drugs/search/DrugModule.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/search/DrugModule.kt
@@ -23,7 +23,7 @@ object DrugModule {
   }
 
   @Provides
-  fun drugSyncApi(@Named("for_country") retrofit: Retrofit): DrugSyncApi {
+  fun drugSyncApi(@Named("for_deployment") retrofit: Retrofit): DrugSyncApi {
     return retrofit.create(DrugSyncApi::class.java)
   }
 

--- a/app/src/main/java/org/simple/clinic/facility/FacilityModule.kt
+++ b/app/src/main/java/org/simple/clinic/facility/FacilityModule.kt
@@ -20,7 +20,7 @@ class FacilityModule {
   }
 
   @Provides
-  fun syncApi(@Named("for_country") retrofit: Retrofit): FacilitySyncApi {
+  fun syncApi(@Named("for_deployment") retrofit: Retrofit): FacilitySyncApi {
     return retrofit.create(FacilitySyncApi::class.java)
   }
 

--- a/app/src/main/java/org/simple/clinic/help/HelpModule.kt
+++ b/app/src/main/java/org/simple/clinic/help/HelpModule.kt
@@ -9,7 +9,7 @@ import javax.inject.Named
 class HelpModule {
 
   @Provides
-  fun helpApi(@Named("for_country") retrofit: Retrofit): HelpApi = retrofit.create(HelpApi::class.java)
+  fun helpApi(@Named("for_deployment") retrofit: Retrofit): HelpApi = retrofit.create(HelpApi::class.java)
 
   @Provides
   @Named("help_file_path")

--- a/app/src/main/java/org/simple/clinic/login/LoginModule.kt
+++ b/app/src/main/java/org/simple/clinic/login/LoginModule.kt
@@ -18,7 +18,7 @@ import javax.inject.Named
 class LoginModule {
 
   @Provides
-  fun loginApi(@Named("for_country") retrofit: Retrofit): UsersApi {
+  fun loginApi(@Named("for_deployment") retrofit: Retrofit): UsersApi {
     return retrofit.create(UsersApi::class.java)
   }
 

--- a/app/src/main/java/org/simple/clinic/medicalhistory/MedicalHistoryModule.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/MedicalHistoryModule.kt
@@ -21,7 +21,7 @@ class MedicalHistoryModule {
   }
 
   @Provides
-  fun syncApi(@Named("for_country") retrofit: Retrofit): MedicalHistorySyncApi {
+  fun syncApi(@Named("for_deployment") retrofit: Retrofit): MedicalHistorySyncApi {
     return retrofit.create(MedicalHistorySyncApi::class.java)
   }
 

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentModule.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentModule.kt
@@ -41,7 +41,7 @@ class AppointmentModule {
   }
 
   @Provides
-  fun syncApiV3(@Named("for_country") retrofit: Retrofit): AppointmentSyncApi {
+  fun syncApiV3(@Named("for_deployment") retrofit: Retrofit): AppointmentSyncApi {
     return retrofit.create(AppointmentSyncApi::class.java)
   }
 

--- a/app/src/main/java/org/simple/clinic/patient/sync/PatientSyncModule.kt
+++ b/app/src/main/java/org/simple/clinic/patient/sync/PatientSyncModule.kt
@@ -17,7 +17,7 @@ import javax.inject.Named
 open class PatientSyncModule {
 
   @Provides
-  fun api(@Named("for_country") retrofit: Retrofit): PatientSyncApi {
+  fun api(@Named("for_deployment") retrofit: Retrofit): PatientSyncApi {
     return retrofit.create(PatientSyncApi::class.java)
   }
 

--- a/app/src/main/java/org/simple/clinic/protocol/ProtocolModule.kt
+++ b/app/src/main/java/org/simple/clinic/protocol/ProtocolModule.kt
@@ -25,7 +25,7 @@ class ProtocolModule {
   }
 
   @Provides
-  fun protocolSyncApi(@Named("for_country") retrofit: Retrofit): ProtocolSyncApi {
+  fun protocolSyncApi(@Named("for_deployment") retrofit: Retrofit): ProtocolSyncApi {
     return retrofit.create(ProtocolSyncApi::class.java)
   }
 

--- a/app/src/main/java/org/simple/clinic/reports/ReportsModule.kt
+++ b/app/src/main/java/org/simple/clinic/reports/ReportsModule.kt
@@ -8,7 +8,7 @@ import javax.inject.Named
 @Module
 class ReportsModule {
   @Provides
-  fun reportsApi(@Named("for_country") retrofit: Retrofit): ReportsApi = retrofit.create(ReportsApi::class.java)
+  fun reportsApi(@Named("for_deployment") retrofit: Retrofit): ReportsApi = retrofit.create(ReportsApi::class.java)
 
   @Provides
   @Named("reports_file_path")

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryModule.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryModule.kt
@@ -15,7 +15,7 @@ import javax.inject.Named
 class PatientSummaryModule {
 
   @Provides
-  fun teleconsultationFacilitySyncApi(@Named("for_country") retrofit: Retrofit): TeleconsultFacilityInfoApi {
+  fun teleconsultationFacilitySyncApi(@Named("for_deployment") retrofit: Retrofit): TeleconsultFacilityInfoApi {
     return retrofit.create(TeleconsultFacilityInfoApi::class.java)
   }
 

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/teleconsultrecord/TeleconsultRecordModule.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/teleconsultrecord/TeleconsultRecordModule.kt
@@ -12,7 +12,7 @@ class TeleconsultRecordModule {
   fun teleconsultRecordDao(appDatabase: AppDatabase) = appDatabase.teleconsultRecordDao()
 
   @Provides
-  fun teleconsultRecordSyncApi(@Named("for_country") retrofit: Retrofit): TeleconsultRecordApi {
+  fun teleconsultRecordSyncApi(@Named("for_deployment") retrofit: Retrofit): TeleconsultRecordApi {
     return retrofit.create(TeleconsultRecordApi::class.java)
   }
 }

--- a/app/src/sharedTest/java/org/simple/clinic/TestData.kt
+++ b/app/src/sharedTest/java/org/simple/clinic/TestData.kt
@@ -916,9 +916,9 @@ object TestData {
       deploymentName: String = "IHCI",
       deploymentEndPoint: String = "https://simple.org",
       deployments: List<Deployment> = listOf(
-          Deployment(
+          deployment(
               displayName = deploymentName,
-              endPoint = URI.create(deploymentEndPoint)
+              endPoint = deploymentEndPoint
           )
       )
   ): CountryV2 {
@@ -927,6 +927,16 @@ object TestData {
         displayName = displayName,
         isdCode = isdCode,
         deployments = deployments
+    )
+  }
+
+  fun deployment(
+      displayName: String = "IHCI",
+      endPoint: String = "https://simple.org",
+  ): Deployment {
+    return Deployment(
+        displayName = displayName,
+        endPoint = URI.create(endPoint)
     )
   }
 

--- a/app/src/sharedTest/java/org/simple/clinic/TestData.kt
+++ b/app/src/sharedTest/java/org/simple/clinic/TestData.kt
@@ -2,6 +2,8 @@ package org.simple.clinic
 
 import io.bloco.faker.Faker
 import org.simple.clinic.appconfig.Country
+import org.simple.clinic.appconfig.CountryV2
+import org.simple.clinic.appconfig.Deployment
 import org.simple.clinic.bloodsugar.BloodSugarMeasurement
 import org.simple.clinic.bloodsugar.BloodSugarMeasurementType
 import org.simple.clinic.bloodsugar.BloodSugarReading
@@ -33,12 +35,12 @@ import org.simple.clinic.overdue.AppointmentCancelReason
 import org.simple.clinic.overdue.AppointmentPayload
 import org.simple.clinic.patient.Age
 import org.simple.clinic.patient.CompleteMedicalRecord
-import org.simple.clinic.patient.PatientAgeDetails
 import org.simple.clinic.patient.DeletedReason
 import org.simple.clinic.patient.Gender
 import org.simple.clinic.patient.OngoingNewPatientEntry
 import org.simple.clinic.patient.Patient
 import org.simple.clinic.patient.PatientAddress
+import org.simple.clinic.patient.PatientAgeDetails
 import org.simple.clinic.patient.PatientPhoneNumber
 import org.simple.clinic.patient.PatientPhoneNumberType
 import org.simple.clinic.patient.PatientPrefillInfo
@@ -904,6 +906,27 @@ object TestData {
         endpoint = URI.create(endpoint),
         displayName = displayName,
         isdCode = isdCode
+    )
+  }
+
+  fun countryV2(
+      isoCountryCode: String = "IN",
+      displayName: String = "India",
+      isdCode: String = "91",
+      deploymentName: String = "IHCI",
+      deploymentEndPoint: String = "https://simple.org",
+      deployments: List<Deployment> = listOf(
+          Deployment(
+              displayName = deploymentName,
+              endPoint = URI.create(deploymentEndPoint)
+          )
+      )
+  ): CountryV2 {
+    return CountryV2(
+        isoCountryCode = isoCountryCode,
+        displayName = displayName,
+        isdCode = isdCode,
+        deployments = deployments
     )
   }
 

--- a/app/src/test/java/org/simple/clinic/appconfig/AppConfigRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/appconfig/AppConfigRepositoryTest.kt
@@ -24,8 +24,14 @@ class AppConfigRepositoryTest {
   private val manifestFetchApi = mock<ManifestFetchApi>()
   private val selectedCountryPreference = mock<Preference<Optional<Country>>>()
   private val selectedCountryV2Preference = mock<Preference<Optional<CountryV2>>>()
+  private val selectedDeployment = mock<Preference<Optional<Deployment>>>()
 
-  private val repository = AppConfigRepository(manifestFetchApi, selectedCountryPreference, selectedCountryV2Preference)
+  private val repository = AppConfigRepository(
+      manifestFetchApi,
+      selectedCountryPreference,
+      selectedCountryV2Preference,
+      selectedDeployment
+  )
 
   @Test
   fun `successful network calls to fetch the app manifest should return the app manifest`() {
@@ -170,5 +176,21 @@ class AppConfigRepositoryTest {
 
     verify(selectedCountryV2Preference).set(Optional.of(country))
     verifyNoMoreInteractions(selectedCountryV2Preference)
+  }
+
+  @Test
+  fun `saving the deployment, must save it to local persistence`() {
+    // given
+    val deployment = TestData.deployment(
+        displayName = "IHCI",
+        endPoint = "https://in.simple.org"
+    )
+
+    // when
+    repository.saveDeployment(deployment)
+
+    // then
+    verify(selectedDeployment).set(Optional.of(deployment))
+    verifyNoMoreInteractions(selectedDeployment)
   }
 }

--- a/app/src/test/java/org/simple/clinic/appconfig/AppConfigRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/appconfig/AppConfigRepositoryTest.kt
@@ -10,6 +10,7 @@ import io.reactivex.Single
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Test
+import org.simple.clinic.TestData
 import org.simple.clinic.appconfig.api.ManifestFetchApi
 import org.simple.clinic.util.ResolvedError
 import retrofit2.HttpException
@@ -22,8 +23,9 @@ class AppConfigRepositoryTest {
 
   private val manifestFetchApi = mock<ManifestFetchApi>()
   private val selectedCountryPreference = mock<Preference<Optional<Country>>>()
+  private val selectedCountryV2Preference = mock<Preference<Optional<CountryV2>>>()
 
-  private val repository = AppConfigRepository(manifestFetchApi, selectedCountryPreference)
+  private val repository = AppConfigRepository(manifestFetchApi, selectedCountryPreference, selectedCountryV2Preference)
 
   @Test
   fun `successful network calls to fetch the app manifest should return the app manifest`() {
@@ -150,5 +152,23 @@ class AppConfigRepositoryTest {
         .assertComplete()
     verify(selectedCountryPreference).set(Optional.of(country))
     verifyNoMoreInteractions(selectedCountryPreference)
+  }
+
+  @Test
+  fun `saving the countryV2, must save it to local persistence`() {
+    // given
+    val country = TestData.countryV2(
+        isoCountryCode = "IN",
+        displayName = "India",
+        isdCode = "91",
+        deploymentName = "IHCI",
+        deploymentEndPoint = "https://in.simple.org"
+    )
+
+    // then
+    repository.saveCurrentCountry(country)
+
+    verify(selectedCountryV2Preference).set(Optional.of(country))
+    verifyNoMoreInteractions(selectedCountryV2Preference)
   }
 }


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/4753/migrate-v1-country-usages-to-v2-country

In later PRs we will migrate all the `Country` usages with `CountryV2`. In this PR, we migrated the `Country#endPoint` usage with `Deployment` usage.

**Testing steps**:
- Before running this PR, sign in into the `master` branch app
- Run the app from this branch
- You should see updated preferences in Flipper
![image](https://user-images.githubusercontent.com/6140516/131286821-51ee8bb8-9882-4f53-a7ab-fcc4742170cf.png)
- Verify sync is working as expected. You can look at the network panel of Flipper to make sure all calls are successful. 