### PR TITLE
Refactor logic around providing drug frequencies label depending on the country - 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Parse `Country_Old` manually when migrating to v2 `Country`
 - Remove `Country_Old`
 - [In Progress: 30 Aug 2021] Record call results instead of updating the same appointment record
+- [In Progress: 31 Aug 2021] Refactor logic around providing drug frequencies label depending on the country
 
 ### Changes
 - Implement providing drug frequencies label depending on the country

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryModel.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryModel.kt
@@ -14,7 +14,8 @@ data class CustomDrugEntryModel(
     val frequency: DrugFrequency?,
     val rxNormCode: String?,
     val dosagePlaceholder: String,
-    val drugFrequencyChoiceItems: List<DrugFrequencyChoiceItem>?
+    val drugFrequencyChoiceItems: List<DrugFrequencyChoiceItem>?,
+    val drugFrequencyToFrequencyChoiceItemMap: Map<DrugFrequency?, DrugFrequencyChoiceItem>?
 ) : Parcelable {
   companion object {
     fun default(
@@ -28,7 +29,8 @@ data class CustomDrugEntryModel(
         frequency = null,
         rxNormCode = null,
         dosagePlaceholder = dosagePlaceholder,
-        drugFrequencyChoiceItems = null)
+        drugFrequencyChoiceItems = null,
+        drugFrequencyToFrequencyChoiceItemMap = null)
   }
 
   fun dosageEdited(dosage: String?): CustomDrugEntryModel {
@@ -53,5 +55,9 @@ data class CustomDrugEntryModel(
 
   fun drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceItems: List<DrugFrequencyChoiceItem>): CustomDrugEntryModel {
     return copy(drugFrequencyChoiceItems = drugFrequencyChoiceItems)
+  }
+
+  fun drugFrequencyToFrequencyChoiceItemMapLoaded(drugFrequencyToFrequencyChoiceItemMap: Map<DrugFrequency?, DrugFrequencyChoiceItem>?): CustomDrugEntryModel {
+    return copy(drugFrequencyToFrequencyChoiceItemMap = drugFrequencyToFrequencyChoiceItemMap)
   }
 }

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandlerTest.kt
@@ -13,7 +13,6 @@ import org.simple.clinic.TestData
 import org.simple.clinic.drugs.PrescriptionRepository
 import org.simple.clinic.drugs.search.DrugFrequency
 import org.simple.clinic.drugs.search.DrugRepository
-import org.simple.clinic.drugs.selection.custom.drugfrequency.country.DrugFrequencyChoiceItem
 import org.simple.clinic.drugs.selection.custom.drugfrequency.country.DrugFrequencyChoiceItems
 import org.simple.clinic.drugs.selection.custom.drugfrequency.country.DrugFrequencyFactory
 import org.simple.clinic.drugs.selection.custom.drugfrequency.country.EthiopiaDrugFrequencyProvider
@@ -56,19 +55,14 @@ class CustomDrugEntryEffectHandlerTest {
   fun `when show edit frequency dialog effect is received, show edit frequency dialog`() {
     // given
     val frequency = DrugFrequency.OD
-    val drugFrequencyChoiceList = listOf(
-        DrugFrequencyChoiceItem(drugFrequency = null, labelResId = R.string.custom_drug_entry_sheet_frequency_none),
-        DrugFrequencyChoiceItem(drugFrequency = DrugFrequency.OD, labelResId = R.string.custom_drug_entry_sheet_frequency_OD),
-        DrugFrequencyChoiceItem(drugFrequency = DrugFrequency.BD, labelResId = R.string.custom_drug_entry_sheet_frequency_BD),
-        DrugFrequencyChoiceItem(drugFrequency = DrugFrequency.QDS, labelResId = R.string.custom_drug_entry_sheet_frequency_QDS),
-        DrugFrequencyChoiceItem(drugFrequency = DrugFrequency.TDS, labelResId = R.string.custom_drug_entry_sheet_frequency_TDS))
+    val drugFrequencyChoiceItems = drugFrequencyFactory.provideFields()
 
     // when
-    testCase.dispatch(ShowEditFrequencyDialog(frequency, drugFrequencyChoiceList))
+    testCase.dispatch(ShowEditFrequencyDialog(frequency, drugFrequencyChoiceItems))
 
     // then
     testCase.assertNoOutgoingEvents()
-    verify(uiActions).showEditFrequencyDialog(frequency, drugFrequencyChoiceList)
+    verify(uiActions).showEditFrequencyDialog(frequency, drugFrequencyChoiceItems)
   }
 
   @Test

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUiRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUiRendererTest.kt
@@ -6,7 +6,8 @@ import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import org.junit.Test
 import org.simple.clinic.R
 import org.simple.clinic.drugs.search.DrugFrequency
-import org.simple.clinic.drugs.selection.custom.drugfrequency.country.DrugFrequencyChoiceItem
+import org.simple.clinic.drugs.selection.custom.drugfrequency.country.CommonDrugFrequencyProvider
+import org.simple.clinic.drugs.selection.custom.drugfrequency.country.DrugFrequencyFactory
 import java.util.UUID
 
 class CustomDrugEntryUiRendererTest {
@@ -15,14 +16,10 @@ class CustomDrugEntryUiRendererTest {
   private val uiRenderer = CustomDrugEntryUiRenderer(ui, dosagePlaceholder = "mg")
   private val drugName = "Amlodipine"
   private val dosagePlaceholder = "mg"
-  private val drugFrequencyChoiceList = listOf(
-      DrugFrequencyChoiceItem(drugFrequency = null, labelResId = R.string.custom_drug_entry_sheet_frequency_none),
-      DrugFrequencyChoiceItem(drugFrequency = DrugFrequency.OD, labelResId = R.string.custom_drug_entry_sheet_frequency_OD),
-      DrugFrequencyChoiceItem(drugFrequency = DrugFrequency.BD, labelResId = R.string.custom_drug_entry_sheet_frequency_BD),
-      DrugFrequencyChoiceItem(drugFrequency = DrugFrequency.QDS, labelResId = R.string.custom_drug_entry_sheet_frequency_QDS),
-      DrugFrequencyChoiceItem(drugFrequency = DrugFrequency.TDS, labelResId = R.string.custom_drug_entry_sheet_frequency_TDS))
+  private val drugFrequencyFactory = DrugFrequencyFactory(CommonDrugFrequencyProvider())
+  private val drugFrequencyChoiceItems = drugFrequencyFactory.provideFields()
 
-  private val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugName(drugName), dosagePlaceholder).drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceList)
+  private val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugName(drugName), dosagePlaceholder).drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceItems)
 
   @Test
   fun `when drug dosage focus is changed and dosage is null, then set drug dosage text with the placeholder and move the cursor to the beginning`() {
@@ -48,7 +45,7 @@ class CustomDrugEntryUiRendererTest {
   fun `when drug dosage focus is changed and dosage is not null but only contains the placeholder, then set drug dosage text as an empty string and update the sheet title`() {
     // given
     val dosageText = "mg"
-    val drugDosageChangedModel = defaultModel.drugNameLoaded(drugName).dosageEdited(dosageText).dosageFocusChanged(hasFocus = false).drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceList)
+    val drugDosageChangedModel = defaultModel.drugNameLoaded(drugName).dosageEdited(dosageText).dosageFocusChanged(hasFocus = false).drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceItems)
     val frequencyLabelResId = R.string.custom_drug_entry_sheet_frequency_none
 
     // when
@@ -66,7 +63,7 @@ class CustomDrugEntryUiRendererTest {
   fun `when the screen is loaded in update mode, then render the drug name and setup ui for updating drug entry`() {
     // given
     val prescribedDrugUuid = UUID.fromString("96633994-6e4d-4528-b796-f03ae016553a")
-    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.Update(prescribedDrugUuid), dosagePlaceholder).drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceList)
+    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.Update(prescribedDrugUuid), dosagePlaceholder).drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceItems)
     val frequencyLabelResId = R.string.custom_drug_entry_sheet_frequency_none
 
     // when

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
@@ -10,8 +10,9 @@ import org.junit.Test
 import org.simple.clinic.R
 import org.simple.clinic.TestData
 import org.simple.clinic.drugs.search.DrugFrequency
-import org.simple.clinic.drugs.selection.custom.drugfrequency.country.DrugFrequencyChoiceItem
+import org.simple.clinic.drugs.selection.custom.drugfrequency.country.CommonDrugFrequencyProvider
 import org.simple.clinic.drugs.selection.custom.drugfrequency.country.DrugFrequencyChoiceItems
+import org.simple.clinic.drugs.selection.custom.drugfrequency.country.DrugFrequencyFactory
 import org.simple.clinic.teleconsultlog.medicinefrequency.MedicineFrequency
 import java.util.UUID
 
@@ -23,15 +24,8 @@ class CustomDrugEntryUpdateTest {
   private val dosagePlaceholder = "mg"
   private val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.New.FromDrugName(drugName), dosagePlaceholder)
 
-  private val drugFrequencyChoiceList = listOf(
-      DrugFrequencyChoiceItem(drugFrequency = null, labelResId = R.string.custom_drug_entry_sheet_frequency_none),
-      DrugFrequencyChoiceItem(drugFrequency = DrugFrequency.OD, labelResId = R.string.custom_drug_entry_sheet_frequency_OD),
-      DrugFrequencyChoiceItem(drugFrequency = DrugFrequency.BD, labelResId = R.string.custom_drug_entry_sheet_frequency_BD),
-      DrugFrequencyChoiceItem(drugFrequency = DrugFrequency.QDS, labelResId = R.string.custom_drug_entry_sheet_frequency_QDS),
-      DrugFrequencyChoiceItem(drugFrequency = DrugFrequency.TDS, labelResId = R.string.custom_drug_entry_sheet_frequency_TDS))
-
-  private val drugFrequencyChoiceItems = DrugFrequencyChoiceItems(items = drugFrequencyChoiceList)
-
+  private val drugFrequencyFactory = DrugFrequencyFactory(CommonDrugFrequencyProvider())
+  private val drugFrequencyChoiceItems = drugFrequencyFactory.provideFields()
 
   @Test
   fun `when dosage is edited, then update the model with the new dosage`() {
@@ -64,18 +58,18 @@ class CustomDrugEntryUpdateTest {
   fun `when edit frequency is clicked, then show edit frequency dialog and pass drug frequency choice list`() {
     val frequency = DrugFrequency.OD
 
-    updateSpec.given(defaultModel.frequencyEdited(frequency).drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceList))
+    updateSpec.given(defaultModel.frequencyEdited(frequency).drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceItems))
         .whenEvent(EditFrequencyClicked)
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowEditFrequencyDialog(frequency, drugFrequencyChoiceList))
+            hasEffects(ShowEditFrequencyDialog(frequency, drugFrequencyChoiceItems))
         ))
   }
 
   @Test
   fun `when frequency is edited, then update the model and set drug frequency in the ui`() {
     val frequency = DrugFrequency.OD
-    val drugNameLoadedModel = defaultModel.drugNameLoaded(drugName).drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceList)
+    val drugNameLoadedModel = defaultModel.drugNameLoaded(drugName).drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceItems)
     val frequencyResId = R.string.custom_drug_entry_sheet_frequency_OD
 
     updateSpec.given(drugNameLoadedModel)
@@ -88,7 +82,7 @@ class CustomDrugEntryUpdateTest {
 
   @Test
   fun `when frequency is edited with a null value, then update the model and set drug frequency with the frequency in the ui`() {
-    val drugNameLoadedModel = defaultModel.drugNameLoaded(drugName).drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceList)
+    val drugNameLoadedModel = defaultModel.drugNameLoaded(drugName).drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceItems)
     val frequencyLabelRes = R.string.custom_drug_entry_sheet_frequency_none
 
     updateSpec.given(drugNameLoadedModel)
@@ -167,7 +161,7 @@ class CustomDrugEntryUpdateTest {
     val drugFrequency = DrugFrequency.OD
     val dosage = "12mg"
     val prescribedDrug = TestData.prescription(uuid = prescribedDrugUuid, name = drugName, isDeleted = false, frequency = MedicineFrequency.OD, dosage = dosage)
-    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.Update(prescribedDrugUuid), dosagePlaceholder).drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceList)
+    val defaultModel = CustomDrugEntryModel.default(openAs = OpenAs.Update(prescribedDrugUuid), dosagePlaceholder).drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceItems)
     val frequencyResId = R.string.custom_drug_entry_sheet_frequency_OD
 
     updateSpec
@@ -214,7 +208,7 @@ class CustomDrugEntryUpdateTest {
     val drugUuid = UUID.fromString("6bbc5bbe-863c-472a-b962-1fd3198e20d1")
     val drug = TestData.drug(id = drugUuid, frequency = DrugFrequency.OD)
     val frequencyResId = R.string.custom_drug_entry_sheet_frequency_OD
-    val drugFrequencyChoiceItemsLoaded = defaultModel.drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceList)
+    val drugFrequencyChoiceItemsLoaded = defaultModel.drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceItems)
 
     updateSpec
         .given(drugFrequencyChoiceItemsLoaded)
@@ -231,10 +225,10 @@ class CustomDrugEntryUpdateTest {
   fun `when drug frequency choice items are loaded, then update the model`() {
     updateSpec
         .given(defaultModel)
-        .whenEvent(DrugFrequencyChoiceItemsLoaded(drugFrequencyChoiceItems))
+        .whenEvent(DrugFrequencyChoiceItemsLoaded(DrugFrequencyChoiceItems(drugFrequencyChoiceItems)))
         .then(
             assertThatNext(
-                hasModel(defaultModel.drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceList))
+                hasModel(defaultModel.drugFrequencyChoiceItemsLoaded(drugFrequencyChoiceItems))
             )
         )
   }


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/4813/refactor-logic-around-providing-drug-frequencies-label-depending-on-the-country

I will change the `labelResId` references in the individual tests to getting it from the `drugFrequencyToFrequencyChoiceItemMap` value in the next PR