### PR TITLE
Remove login failed errors from UiRenderer, and add via effect handler when logging in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fetch states for selected country deployments
 - [In Progress: 31 Aug 2021] Record call results instead of updating the same appointment record
 - [In Progress: 31 Aug 2021] Refactor logic around providing drug frequencies label depending on the country
+- Remove login failed errors from UiRenderer, and add via effect handler when logging in
 
 ### Changes
 - Implement providing drug frequencies label depending on the country

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpEffect.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpEffect.kt
@@ -23,3 +23,5 @@ object RequestLoginOtp : EnterOtpEffect()
 object ShowSmsSentMessage : EnterOtpEffect()
 
 data class FailedLoginOtpAttempt(val result: LoginResult) : EnterOtpEffect()
+
+object ShowNetworkError : EnterOtpEffect()

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpEffect.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpEffect.kt
@@ -25,3 +25,5 @@ object ShowSmsSentMessage : EnterOtpEffect()
 data class FailedLoginOtpAttempt(val result: LoginResult) : EnterOtpEffect()
 
 object ShowNetworkError : EnterOtpEffect()
+
+object ShowUnexpectedError : EnterOtpEffect()

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpEffectHandler.kt
@@ -43,6 +43,7 @@ class EnterOtpEffectHandler @AssistedInject constructor(
         .addAction(ShowSmsSentMessage::class.java, uiActions::showSmsSentMessage, schedulers.ui())
         .addConsumer(FailedLoginOtpAttempt::class.java, { bruteForceProtection.incrementFailedOtpAttempt() }, schedulers.io())
         .addAction(ShowNetworkError::class.java, uiActions::showNetworkError, schedulers.ui())
+        .addAction(ShowUnexpectedError::class.java, uiActions::showUnexpectedError, schedulers.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpEffectHandler.kt
@@ -42,6 +42,7 @@ class EnterOtpEffectHandler @AssistedInject constructor(
         .addTransformer(RequestLoginOtp::class.java, activateUser())
         .addAction(ShowSmsSentMessage::class.java, uiActions::showSmsSentMessage, schedulers.ui())
         .addConsumer(FailedLoginOtpAttempt::class.java, { bruteForceProtection.incrementFailedOtpAttempt() }, schedulers.io())
+        .addAction(ShowNetworkError::class.java, uiActions::showNetworkError, schedulers.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpModel.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpModel.kt
@@ -50,10 +50,6 @@ data class EnterOtpModel(
     return copy(isAsyncOperationOngoing = false, asyncOpError = null)
   }
 
-  fun loginFailed(error: AsyncOpError): EnterOtpModel {
-    return copy(asyncOpError = error)
-  }
-
   fun requestLoginOtpStarted(): EnterOtpModel {
     return copy(asyncOpError = null, isAsyncOperationOngoing = true)
   }

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUi.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUi.kt
@@ -2,8 +2,6 @@ package org.simple.clinic.enterotp
 
 interface EnterOtpUi {
   fun showUserPhoneNumber(phoneNumber: String)
-  fun showUnexpectedError()
-  fun showNetworkError()
   fun showServerError(error: String)
   fun showIncorrectOtpError()
   fun hideError()

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUiActions.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUiActions.kt
@@ -4,4 +4,5 @@ interface EnterOtpUiActions {
   fun clearPin()
   fun goBack()
   fun showSmsSentMessage()
+  fun showNetworkError()
 }

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUiActions.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUiActions.kt
@@ -5,4 +5,5 @@ interface EnterOtpUiActions {
   fun goBack()
   fun showSmsSentMessage()
   fun showNetworkError()
+  fun showUnexpectedError()
 }

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUiRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUiRenderer.kt
@@ -12,8 +12,6 @@ class EnterOtpUiRenderer(
 
   private val phoneNumberChangedCallback = ValueChangedCallback<String>()
 
-  private val loginErrorChangedCallback = ValueChangedCallback<AsyncOpError?>()
-
   private val isAsyncOperationOngoingChangedCallback = ValueChangedCallback<Boolean>()
 
   override fun render(model: EnterOtpModel) {
@@ -26,15 +24,6 @@ class EnterOtpUiRenderer(
       }
       IsNotRequiredLength -> ui.showIncorrectOtpError()
       Valid -> { /* Nothing to do here */
-      }
-    }
-
-    loginErrorChangedCallback.pass(model.asyncOpError) { loginError ->
-      when (loginError) {
-        NetworkError -> ui.showNetworkError()
-        is ServerError -> ui.showServerError(loginError.errorMessage)
-        OtherError -> ui.showUnexpectedError()
-        null -> ui.hideError()
       }
     }
 

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUpdate.kt
@@ -47,6 +47,7 @@ class EnterOtpUpdate(
       is LoginResult.ServerError -> showLoginFailedAttemptIfIncorrectOtp(result, updatedModel)
       LoginResult.NetworkError -> dispatch(ShowNetworkError, ClearPin)
       else -> next(updatedModel.loginFailed(AsyncOpError.from(result)), ClearPin as EnterOtpEffect)
+      LoginResult.UnexpectedError -> dispatch(ShowUnexpectedError, ClearPin)
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUpdate.kt
@@ -46,7 +46,6 @@ class EnterOtpUpdate(
       LoginResult.Success -> next(updatedModel, ClearLoginEntry, TriggerSync)
       is LoginResult.ServerError -> showLoginFailedAttemptIfIncorrectOtp(result, updatedModel)
       LoginResult.NetworkError -> dispatch(ShowNetworkError, ClearPin)
-      else -> next(updatedModel.loginFailed(AsyncOpError.from(result)), ClearPin as EnterOtpEffect)
       LoginResult.UnexpectedError -> dispatch(ShowUnexpectedError, ClearPin)
     }
   }

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUpdate.kt
@@ -45,6 +45,7 @@ class EnterOtpUpdate(
     return when (val result = event.result) {
       LoginResult.Success -> next(updatedModel, ClearLoginEntry, TriggerSync)
       is LoginResult.ServerError -> showLoginFailedAttemptIfIncorrectOtp(result, updatedModel)
+      LoginResult.NetworkError -> dispatch(ShowNetworkError, ClearPin)
       else -> next(updatedModel.loginFailed(AsyncOpError.from(result)), ClearPin as EnterOtpEffect)
     }
   }

--- a/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/enterotp/EnterOtpUpdate.kt
@@ -44,18 +44,10 @@ class EnterOtpUpdate(
     val updatedModel = model.loginFinished()
     return when (val result = event.result) {
       LoginResult.Success -> next(updatedModel, ClearLoginEntry, TriggerSync)
-      is LoginResult.ServerError -> showLoginFailedAttemptIfIncorrectOtp(result, updatedModel)
+      is LoginResult.ServerError -> dispatch(FailedLoginOtpAttempt(result), ClearPin)
       LoginResult.NetworkError -> dispatch(ShowNetworkError, ClearPin)
       LoginResult.UnexpectedError -> dispatch(ShowUnexpectedError, ClearPin)
     }
-  }
-
-  private fun showLoginFailedAttemptIfIncorrectOtp(
-      result: LoginResult.ServerError,
-      updatedModel: EnterOtpModel
-  ): Next<EnterOtpModel, EnterOtpEffect> {
-    val model = updatedModel.loginFailed(AsyncOpError.from(result))
-    return next(model, FailedLoginOtpAttempt(result), ClearPin)
   }
 
   private fun otpSubmitted(

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpEffectHandlerTest.kt
@@ -59,4 +59,14 @@ class EnterOtpEffectHandlerTest {
     verify(uiActions).showNetworkError()
     verifyNoMoreInteractions(uiActions)
   }
+
+  @Test
+  fun `when show unexpected error effect is received, then show unexpected error`() {
+    // when
+    testCase.dispatch(ShowUnexpectedError)
+
+    // then
+    verify(uiActions).showUnexpectedError()
+    verifyNoMoreInteractions(uiActions)
+  }
 }

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpEffectHandlerTest.kt
@@ -1,12 +1,9 @@
 package org.simple.clinic.enterotp
 
-import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
-import com.nhaarman.mockitokotlin2.whenever
-import io.reactivex.Completable
 import org.junit.After
 import org.junit.Test
 import org.simple.clinic.login.LoginResult

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpEffectHandlerTest.kt
@@ -48,4 +48,15 @@ class EnterOtpEffectHandlerTest {
     verifyNoMoreInteractions(bruteForceOtpEntryProtection)
     verifyZeroInteractions(uiActions)
   }
+
+
+  @Test
+  fun `when show network error effect is received, then show network error`() {
+    // when
+    testCase.dispatch(ShowNetworkError)
+
+    // then
+    verify(uiActions).showNetworkError()
+    verifyNoMoreInteractions(uiActions)
+  }
 }

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpLogicTest.kt
@@ -244,11 +244,11 @@ class EnterOtpLogicTest {
     uiEvents.onNext(EnterOtpSubmitted(otp))
 
     // then
-    verify(ui).showUnexpectedError()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui, times(2)).hideProgress()
+    verify(ui, times(1)).hideProgress()
     verify(uiActions).clearPin()
+    verify(uiActions).showUnexpectedError()
     verifyNoMoreInteractions(ui, uiActions)
     verify(dataSync, never()).fireAndForgetSync()
   }
@@ -264,11 +264,11 @@ class EnterOtpLogicTest {
     uiEvents.onNext(EnterOtpSubmitted(otp))
 
     // then
-    verify(ui).showNetworkError()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui, times(2)).hideProgress()
+    verify(ui, times(1)).hideProgress()
     verify(uiActions).clearPin()
+    verify(uiActions).showNetworkError()
     verifyNoMoreInteractions(ui, uiActions)
     verify(dataSync, never()).fireAndForgetSync()
   }
@@ -285,10 +285,9 @@ class EnterOtpLogicTest {
     uiEvents.onNext(EnterOtpSubmitted(otp))
 
     // then
-    verify(ui).showServerError(errorMessage)
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui, times(2)).hideProgress()
+    verify(ui, times(1)).hideProgress()
     verify(uiActions).clearPin()
     verifyNoMoreInteractions(ui, uiActions)
     verify(dataSync, never()).fireAndForgetSync()
@@ -308,8 +307,8 @@ class EnterOtpLogicTest {
     verify(uiActions).clearPin()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui, times(2)).hideProgress()
-    verify(ui).showUnexpectedError()
+    verify(ui, times(1)).hideProgress()
+    verify(uiActions).showUnexpectedError()
     verifyNoMoreInteractions(ui, uiActions)
   }
 
@@ -327,8 +326,8 @@ class EnterOtpLogicTest {
     verify(uiActions).clearPin()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui, times(2)).hideProgress()
-    verify(ui).showNetworkError()
+    verify(ui, times(1)).hideProgress()
+    verify(uiActions).showNetworkError()
     verifyNoMoreInteractions(ui, uiActions)
   }
 
@@ -346,8 +345,7 @@ class EnterOtpLogicTest {
     verify(uiActions).clearPin()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui, times(2)).hideProgress()
-    verify(ui).showServerError("Error")
+    verify(ui, times(1)).hideProgress()
     verifyNoMoreInteractions(ui, uiActions)
   }
 
@@ -396,11 +394,11 @@ class EnterOtpLogicTest {
     uiEvents.onNext(EnterOtpSubmitted(otp))
 
     // then
-    verify(ui, times(2)).hideProgress()
+    verify(ui, times(1)).hideProgress()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui).showNetworkError()
     verify(uiActions).clearPin()
+    verify(uiActions).showNetworkError()
     verifyNoMoreInteractions(ui, uiActions)
   }
 
@@ -415,10 +413,9 @@ class EnterOtpLogicTest {
     uiEvents.onNext(EnterOtpSubmitted(otp))
 
     // then
-    verify(ui, times(2)).hideProgress()
+    verify(ui, times(1)).hideProgress()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui).showServerError("Test")
     verify(uiActions).clearPin()
     verifyNoMoreInteractions(ui, uiActions)
   }
@@ -434,11 +431,11 @@ class EnterOtpLogicTest {
     uiEvents.onNext(EnterOtpSubmitted(otp))
 
     // then
-    verify(ui, times(2)).hideProgress()
+    verify(ui, times(1)).hideProgress()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui).showUnexpectedError()
     verify(uiActions).clearPin()
+    verify(uiActions).showUnexpectedError()
     verifyNoMoreInteractions(ui, uiActions)
   }
 
@@ -578,7 +575,6 @@ class EnterOtpLogicTest {
     // then
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui).showNetworkError()
     verify(ui, times(2)).hideProgress()
     verify(uiActions).clearPin()
     verifyNoMoreInteractions(ui, uiActions)
@@ -600,7 +596,6 @@ class EnterOtpLogicTest {
     verify(ui, times(2)).hideProgress()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui).showUnexpectedError()
     verify(uiActions).clearPin()
     verifyNoMoreInteractions(ui, uiActions)
   }
@@ -621,7 +616,6 @@ class EnterOtpLogicTest {
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
     verify(ui, times(2)).hideProgress()
-    verify(ui).showUnexpectedError()
     verify(uiActions).clearPin()
     verifyNoMoreInteractions(ui, uiActions)
   }
@@ -665,7 +659,6 @@ class EnterOtpLogicTest {
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
     verify(ui, times(2)).hideProgress()
-    verify(ui).showNetworkError()
     verify(uiActions).clearPin()
     verifyNoMoreInteractions(ui, uiActions)
   }
@@ -687,7 +680,6 @@ class EnterOtpLogicTest {
     verify(ui, times(2)).hideProgress()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui).showUnexpectedError()
     verify(uiActions).clearPin()
     verifyNoMoreInteractions(ui, uiActions)
   }
@@ -709,7 +701,6 @@ class EnterOtpLogicTest {
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
     verify(ui, times(2)).hideProgress()
-    verify(ui).showUnexpectedError()
     verify(uiActions).clearPin()
     verifyNoMoreInteractions(ui, uiActions)
   }
@@ -727,9 +718,7 @@ class EnterOtpLogicTest {
     uiEvents.onNext(EnterOtpResendSmsClicked())
 
     // then
-    verify(ui, never()).showNetworkError()
     verify(ui, never()).showServerError(any())
-    verify(ui, never()).showUnexpectedError()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
     verify(ui, times(2)).hideProgress()
@@ -751,7 +740,6 @@ class EnterOtpLogicTest {
     uiEvents.onNext(EnterOtpResendSmsClicked())
 
     // then
-    verify(ui).showNetworkError()
     verify(ui, times(2)).hideProgress()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
@@ -773,7 +761,6 @@ class EnterOtpLogicTest {
     uiEvents.onNext(EnterOtpResendSmsClicked())
 
     // then
-    verify(ui).showUnexpectedError()
     verify(ui, times(2)).hideProgress()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
@@ -795,7 +782,6 @@ class EnterOtpLogicTest {
     uiEvents.onNext(EnterOtpResendSmsClicked())
 
     // then
-    verify(ui).showUnexpectedError()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
     verify(ui, times(2)).hideProgress()
@@ -817,7 +803,6 @@ class EnterOtpLogicTest {
 
     // then
     verify(uiActions).clearPin()
-    verify(ui).showNetworkError()
     verify(ui, times(2)).hideProgress()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
@@ -839,7 +824,6 @@ class EnterOtpLogicTest {
 
     // then
     verify(uiActions).clearPin()
-    verify(ui).showUnexpectedError()
     verify(ui, times(2)).hideProgress()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
@@ -860,7 +844,6 @@ class EnterOtpLogicTest {
 
     // then
     verify(uiActions).clearPin()
-    verify(ui).showUnexpectedError()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
     verify(ui, times(2)).hideProgress()
@@ -899,9 +882,9 @@ class EnterOtpLogicTest {
     verify(ongoingLoginEntryRepository, never()).clearLoginEntry()
     verify(ui).showUserPhoneNumber(phoneNumber)
     verify(ui).showProgress()
-    verify(ui, times(2)).hideProgress()
-    verify(ui).showNetworkError()
+    verify(ui, times(1)).hideProgress()
     verify(uiActions).clearPin()
+    verify(uiActions).showNetworkError()
     verifyNoMoreInteractions(ui, uiActions)
   }
 

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpUpdateTest.kt
@@ -22,19 +22,6 @@ class EnterOtpUpdateTest {
       .loginStarted()
 
   @Test
-  fun `when the login request is completed and is unsuccessful, then finish logging in and show error`() {
-    updateSpec
-        .given(loginStartedModel)
-        .whenEvent(LoginUserCompleted(NetworkError))
-        .then(
-            assertThatNext(
-                hasModel(loginStartedModel.loginFinished().loginFailed(AsyncOpError.Companion.from(NetworkError))),
-                hasEffects(ClearPin)
-            )
-        )
-  }
-
-  @Test
   fun `when the login request is completed and has returned server error saying incorrect otp, then show failed attempt and clear pin`() {
     val incorrectOtp = "Your entered Otp is incorrect, please try again"
     val result = ServerError(incorrectOtp)

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpUpdateTest.kt
@@ -7,8 +7,10 @@ import com.spotify.mobius.test.UpdateSpec
 import com.spotify.mobius.test.UpdateSpec.assertThatNext
 import org.junit.Test
 import org.simple.clinic.TestData
+import org.simple.clinic.login.LoginResult
 import org.simple.clinic.login.LoginResult.NetworkError
 import org.simple.clinic.login.LoginResult.ServerError
+import org.simple.clinic.login.LoginResult.UnexpectedError
 import java.util.UUID
 
 class EnterOtpUpdateTest {
@@ -57,6 +59,20 @@ class EnterOtpUpdateTest {
             assertThatNext(
                 hasNoModel(),
                 hasEffects(ShowNetworkError, ClearPin)
+            )
+        )
+  }
+
+  @Test
+  fun `when the login request is completed and has returned unexpected error, then show show unexpected error`() {
+    val result = UnexpectedError
+    updateSpec
+        .given(loginStartedModel)
+        .whenEvent(LoginUserCompleted(result))
+        .then(
+            assertThatNext(
+                hasNoModel(),
+                hasEffects(ShowUnexpectedError, ClearPin)
             )
         )
   }

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpUpdateTest.kt
@@ -2,6 +2,7 @@ package org.simple.clinic.enterotp
 
 import com.spotify.mobius.test.NextMatchers.hasEffects
 import com.spotify.mobius.test.NextMatchers.hasModel
+import com.spotify.mobius.test.NextMatchers.hasNoModel
 import com.spotify.mobius.test.UpdateSpec
 import com.spotify.mobius.test.UpdateSpec.assertThatNext
 import org.junit.Test
@@ -42,6 +43,20 @@ class EnterOtpUpdateTest {
             assertThatNext(
                 hasModel(loginStartedModel.loginFinished().loginFailed(AsyncOpError.Companion.from(result))),
                 hasEffects(FailedLoginOtpAttempt(result), ClearPin)
+            )
+        )
+  }
+
+  @Test
+  fun `when the login request is completed and has returned network error, then show show network error`() {
+    val result = NetworkError
+    updateSpec
+        .given(loginStartedModel)
+        .whenEvent(LoginUserCompleted(result))
+        .then(
+            assertThatNext(
+                hasNoModel(),
+                hasEffects(ShowNetworkError, ClearPin)
             )
         )
   }

--- a/app/src/test/java/org/simple/clinic/enterotp/EnterOtpUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/enterotp/EnterOtpUpdateTest.kt
@@ -30,7 +30,7 @@ class EnterOtpUpdateTest {
         .whenEvent(LoginUserCompleted(result))
         .then(
             assertThatNext(
-                hasModel(loginStartedModel.loginFinished().loginFailed(AsyncOpError.Companion.from(result))),
+                hasNoModel(),
                 hasEffects(FailedLoginOtpAttempt(result), ClearPin)
             )
         )


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/4844/add-effects-for-network-error-unexpected-error-to-have-consistent-behaviour-for-login-otp-entry