### PR TITLE
Move opening of facility selection screen to patient summary screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
 - Parse `Country_Old` manually when migrating to v2 `Country`
 - Remove `Country_Old`
 - Fetch states for selected country deployments
+- Remove login failed errors from UiRenderer, and add via effect handler when logging in
+- Move opening of facility selection screen to `PatientSummaryScreen` from `AssignedFacilityView`  
 - [In Progress: 31 Aug 2021] Record call results instead of updating the same appointment record
 - [In Progress: 31 Aug 2021] Refactor logic around providing drug frequencies label depending on the country
-- Remove login failed errors from UiRenderer, and add via effect handler when logging in
 
 ### Changes
 - Implement providing drug frequencies label depending on the country

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffect.kt
@@ -68,3 +68,5 @@ object ShowAddBloodPressureWarningDialog : PatientSummaryEffect()
 object ShowAddBloodSugarWarningDialog : PatientSummaryEffect()
 
 object OpenSelectFacilitySheet: PatientSummaryEffect()
+
+data class DispatchNewAssignedFacility(val facility: Facility): PatientSummaryEffect()

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffect.kt
@@ -66,3 +66,5 @@ object ShowAddMeasurementsWarningDialog : PatientSummaryEffect()
 object ShowAddBloodPressureWarningDialog : PatientSummaryEffect()
 
 object ShowAddBloodSugarWarningDialog : PatientSummaryEffect()
+
+object OpenSelectFacilitySheet: PatientSummaryEffect()

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
@@ -82,6 +82,7 @@ class PatientSummaryEffectHandler @AssistedInject constructor(
         .addAction(ShowAddMeasurementsWarningDialog::class.java, uiActions::showAddMeasurementsWarningDialog, schedulersProvider.ui())
         .addAction(ShowAddBloodPressureWarningDialog::class.java, uiActions::showAddBloodPressureWarningDialog, schedulersProvider.ui())
         .addAction(ShowAddBloodSugarWarningDialog::class.java, uiActions::showAddBloodSugarWarningDialog, schedulersProvider.ui())
+        .addAction(OpenSelectFacilitySheet::class.java, uiActions::openSelectFacilitySheet, schedulersProvider.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
@@ -83,6 +83,7 @@ class PatientSummaryEffectHandler @AssistedInject constructor(
         .addAction(ShowAddBloodPressureWarningDialog::class.java, uiActions::showAddBloodPressureWarningDialog, schedulersProvider.ui())
         .addAction(ShowAddBloodSugarWarningDialog::class.java, uiActions::showAddBloodSugarWarningDialog, schedulersProvider.ui())
         .addAction(OpenSelectFacilitySheet::class.java, uiActions::openSelectFacilitySheet, schedulersProvider.ui())
+        .addConsumer(DispatchNewAssignedFacility::class.java, { uiActions.dispatchNewAssignedFacility(it.facility) }, schedulersProvider.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEvent.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEvent.kt
@@ -70,3 +70,5 @@ object LogTeleconsultClicked : PatientSummaryEvent()
 data class MedicalOfficersLoaded(val medicalOfficers: List<MedicalOfficer>) : PatientSummaryEvent()
 
 object ChangeAssignedFacilityClicked: PatientSummaryEvent()
+
+data class NewAssignedFacilitySelected(val facility: Facility): PatientSummaryEvent()

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEvent.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEvent.kt
@@ -73,4 +73,6 @@ object ChangeAssignedFacilityClicked: PatientSummaryEvent() {
   override val analyticsName: String = "Assigned Facility:Change Facility"
 }
 
-data class NewAssignedFacilitySelected(val facility: Facility): PatientSummaryEvent()
+data class NewAssignedFacilitySelected(val facility: Facility): PatientSummaryEvent() {
+  override val analyticsName: String = "Assigned Facility:Facility Selected"
+}

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEvent.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEvent.kt
@@ -68,3 +68,5 @@ object ContactDoctorClicked : PatientSummaryEvent() {
 object LogTeleconsultClicked : PatientSummaryEvent()
 
 data class MedicalOfficersLoaded(val medicalOfficers: List<MedicalOfficer>) : PatientSummaryEvent()
+
+object ChangeAssignedFacilityClicked: PatientSummaryEvent()

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEvent.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEvent.kt
@@ -69,6 +69,8 @@ object LogTeleconsultClicked : PatientSummaryEvent()
 
 data class MedicalOfficersLoaded(val medicalOfficers: List<MedicalOfficer>) : PatientSummaryEvent()
 
-object ChangeAssignedFacilityClicked: PatientSummaryEvent()
+object ChangeAssignedFacilityClicked: PatientSummaryEvent() {
+  override val analyticsName: String = "Assigned Facility:Change Facility"
+}
 
 data class NewAssignedFacilitySelected(val facility: Facility): PatientSummaryEvent()

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -25,6 +25,7 @@ import io.reactivex.ObservableTransformer
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.cast
+import io.reactivex.rxkotlin.ofType
 import io.reactivex.subjects.PublishSubject
 import kotlinx.parcelize.Parcelize
 import org.simple.clinic.R
@@ -51,6 +52,7 @@ import org.simple.clinic.patient.businessid.BusinessId
 import org.simple.clinic.patient.businessid.Identifier
 import org.simple.clinic.patient.displayLetterRes
 import org.simple.clinic.router.ScreenResultBus
+import org.simple.clinic.router.screen.ActivityResult
 import org.simple.clinic.scheduleappointment.ScheduleAppointmentSheet
 import org.simple.clinic.scheduleappointment.facilityselection.FacilitySelectionActivity
 import org.simple.clinic.summary.addphone.AddPhoneNumberDialog
@@ -60,6 +62,7 @@ import org.simple.clinic.summary.teleconsultation.messagebuilder.LongTeleconsult
 import org.simple.clinic.summary.updatephone.UpdatePhoneNumberDialog
 import org.simple.clinic.teleconsultlog.teleconsultrecord.screen.TeleconsultRecordScreenKey
 import org.simple.clinic.util.UserClock
+import org.simple.clinic.util.extractSuccessful
 import org.simple.clinic.util.messagesender.WhatsAppMessageSender
 import org.simple.clinic.util.setFragmentResultListener
 import org.simple.clinic.util.toLocalDateAtZone
@@ -212,7 +215,8 @@ class PatientSummaryScreen :
             contactDoctorClicks(),
             snackbarActionClicks,
             logTeleconsultClicks(),
-            changeAssignedFacilityClicks()
+            changeAssignedFacilityClicks(),
+            assignedFacilitySelected()
         )
         .compose(ReportAnalyticsEvents())
         .cast()
@@ -325,6 +329,14 @@ class PatientSummaryScreen :
 
       emitter.setCancellable { assignedFacilityView.changeAssignedFacilityClicks = null }
     }
+  }
+
+  private fun assignedFacilitySelected(): Observable<PatientSummaryEvent> {
+    return screenResults
+        .streamResults()
+        .ofType<ActivityResult>()
+        .extractSuccessful(ASSIGNED_FACILITY_SELECTION, FacilitySelectionActivity.Companion::selectedFacility)
+        .map(::NewAssignedFacilitySelected)
   }
 
   override fun onBackPressed(): Boolean {

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -2,6 +2,7 @@ package org.simple.clinic.summary
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 import android.text.SpannedString
@@ -51,6 +52,7 @@ import org.simple.clinic.patient.businessid.Identifier
 import org.simple.clinic.patient.displayLetterRes
 import org.simple.clinic.router.ScreenResultBus
 import org.simple.clinic.scheduleappointment.ScheduleAppointmentSheet
+import org.simple.clinic.scheduleappointment.facilityselection.FacilitySelectionActivity
 import org.simple.clinic.summary.addphone.AddPhoneNumberDialog
 import org.simple.clinic.summary.linkId.LinkIdWithPatientSheet.LinkIdWithPatientSheetKey
 import org.simple.clinic.summary.teleconsultation.contactdoctor.ContactDoctorSheet
@@ -558,6 +560,10 @@ class PatientSummaryScreen :
         .setPositiveButton(R.string.warning_add_blood_sugar_positive_button, null)
         .setNegativeButton(R.string.warning_add_blood_sugar_negative_button, null)
         .show()
+  }
+
+  override fun openSelectFacilitySheet() {
+    activity.startActivityForResult(Intent(context, FacilitySelectionActivity::class.java), ASSIGNED_FACILITY_SELECTION)
   }
 
   interface Injector {

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -566,6 +566,10 @@ class PatientSummaryScreen :
     activity.startActivityForResult(Intent(context, FacilitySelectionActivity::class.java), ASSIGNED_FACILITY_SELECTION)
   }
 
+  override fun dispatchNewAssignedFacility(facility: Facility) {
+    // Nothing to do here. Yet.
+  }
+
   interface Injector {
     fun inject(target: PatientSummaryScreen)
   }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -211,7 +211,8 @@ class PatientSummaryScreen :
             phoneNumberClicks(),
             contactDoctorClicks(),
             snackbarActionClicks,
-            logTeleconsultClicks()
+            logTeleconsultClicks(),
+            changeAssignedFacilityClicks()
         )
         .compose(ReportAnalyticsEvents())
         .cast()
@@ -316,6 +317,14 @@ class PatientSummaryScreen :
         .map {
           PatientSummaryBackClicked(screenKey.patientUuid, screenKey.screenCreatedTimestamp)
         }
+  }
+
+  private fun changeAssignedFacilityClicks(): Observable<PatientSummaryEvent> {
+    return Observable.create { emitter ->
+      assignedFacilityView.changeAssignedFacilityClicks = { emitter.onNext(ChangeAssignedFacilityClicked) }
+
+      emitter.setCancellable { assignedFacilityView.changeAssignedFacilityClicks = null }
+    }
   }
 
   override fun onBackPressed(): Boolean {

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -576,7 +576,7 @@ class PatientSummaryScreen :
   }
 
   override fun dispatchNewAssignedFacility(facility: Facility) {
-    // Nothing to do here. Yet.
+    assignedFacilityView.onNewAssignedFacilitySelected(facility)
   }
 
   interface Injector {

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryUiActions.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryUiActions.kt
@@ -29,4 +29,5 @@ interface PatientSummaryUiActions {
   fun showAddBloodPressureWarningDialog()
   fun showAddBloodSugarWarningDialog()
   fun openSelectFacilitySheet()
+  fun dispatchNewAssignedFacility(facility: Facility)
 }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryUiActions.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryUiActions.kt
@@ -28,4 +28,5 @@ interface PatientSummaryUiActions {
   fun showAddMeasurementsWarningDialog()
   fun showAddBloodPressureWarningDialog()
   fun showAddBloodSugarWarningDialog()
+  fun openSelectFacilitySheet()
 }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
@@ -49,6 +49,7 @@ class PatientSummaryUpdate : Update<PatientSummaryModel, PatientSummaryEvent, Pa
       ContactDoctorClicked -> dispatch(OpenContactDoctorSheet(model.patientUuid))
       LogTeleconsultClicked -> logTeleconsultClicked(model)
       is MedicalOfficersLoaded -> next(model.medicalOfficersLoaded(event.medicalOfficers))
+      ChangeAssignedFacilityClicked -> dispatch(OpenSelectFacilitySheet)
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
@@ -50,6 +50,7 @@ class PatientSummaryUpdate : Update<PatientSummaryModel, PatientSummaryEvent, Pa
       LogTeleconsultClicked -> logTeleconsultClicked(model)
       is MedicalOfficersLoaded -> next(model.medicalOfficersLoaded(event.medicalOfficers))
       ChangeAssignedFacilityClicked -> dispatch(OpenSelectFacilitySheet)
+      is NewAssignedFacilitySelected -> dispatch(DispatchNewAssignedFacility(event.facility))
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityEffect.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityEffect.kt
@@ -10,5 +10,3 @@ data class ChangeAssignedFacility(
     val patientUuid: UUID,
     val updatedAssignedFacilityId: UUID
 ) : AssignedFacilityEffect()
-
-object OpenFacilitySelection : AssignedFacilityEffect()

--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityEffectHandler.kt
@@ -9,8 +9,8 @@ import org.simple.clinic.facility.Facility
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.patient.Patient
 import org.simple.clinic.patient.PatientRepository
-import java.util.Optional
 import org.simple.clinic.util.scheduler.SchedulersProvider
+import java.util.Optional
 import java.util.function.Function
 
 class AssignedFacilityEffectHandler @AssistedInject constructor(
@@ -29,7 +29,6 @@ class AssignedFacilityEffectHandler @AssistedInject constructor(
       .subtypeEffectHandler<AssignedFacilityEffect, AssignedFacilityEvent>()
       .addTransformer(LoadAssignedFacility::class.java, loadAssignedFacility())
       .addConsumer(ChangeAssignedFacility::class.java, { changeAssignedFacility(it) }, schedulersProvider.io())
-      .addAction(OpenFacilitySelection::class.java, uiActions::openFacilitySelection, schedulersProvider.ui())
       .build()
 
   private fun changeAssignedFacility(effect: ChangeAssignedFacility) {

--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityEvent.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityEvent.kt
@@ -10,10 +10,6 @@ data class AssignedFacilityLoaded(val facility: Optional<Facility>) : AssignedFa
   override val analyticsName: String = "Assigned Facility:Facility Loaded"
 }
 
-object ChangeAssignedFacilityButtonClicked : AssignedFacilityEvent() {
-  override val analyticsName: String = "Assigned Facility:Change Facility"
-}
-
 data class AssignedFacilitySelected(val facility: Facility) : AssignedFacilityEvent() {
   override val analyticsName: String = "Assigned Facility:Facility Selected"
 }

--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityUpdate.kt
@@ -2,7 +2,6 @@ package org.simple.clinic.summary.assignedfacility
 
 import com.spotify.mobius.Next
 import com.spotify.mobius.Update
-import org.simple.clinic.mobius.dispatch
 import org.simple.clinic.mobius.next
 import org.simple.clinic.util.toNullable
 
@@ -14,7 +13,6 @@ class AssignedFacilityUpdate : Update<AssignedFacilityModel, AssignedFacilityEve
   ): Next<AssignedFacilityModel, AssignedFacilityEffect> {
     return when (event) {
       is AssignedFacilityLoaded -> next(model.assignedFacilityUpdated(event.facility.toNullable()))
-      ChangeAssignedFacilityButtonClicked -> dispatch(OpenFacilitySelection)
       is AssignedFacilitySelected -> next(
           model.assignedFacilityUpdated(event.facility),
           ChangeAssignedFacility(model.patientUuid, event.facility.uuid)

--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityView.kt
@@ -19,13 +19,11 @@ import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.navigation.v2.Router
 import org.simple.clinic.navigation.v2.keyprovider.ScreenKeyProvider
 import org.simple.clinic.router.ScreenResultBus
-import org.simple.clinic.router.screen.ActivityResult
 import org.simple.clinic.scheduleappointment.facilityselection.FacilitySelectionActivity
 import org.simple.clinic.summary.ASSIGNED_FACILITY_SELECTION
 import org.simple.clinic.summary.PatientSummaryChildView
 import org.simple.clinic.summary.PatientSummaryModelUpdateCallback
 import org.simple.clinic.summary.PatientSummaryScreenKey
-import org.simple.clinic.util.extractSuccessful
 import org.simple.clinic.util.unsafeLazy
 import javax.inject.Inject
 
@@ -146,11 +144,7 @@ class AssignedFacilityView(
   }
 
   private fun assignedFacilitySelected(): Observable<AssignedFacilityEvent> {
-    return screenResults
-        .streamResults()
-        .ofType<ActivityResult>()
-        .extractSuccessful(ASSIGNED_FACILITY_SELECTION, FacilitySelectionActivity.Companion::selectedFacility)
-        .map(::AssignedFacilitySelected)
+    return Observable.never()
   }
 
   fun onNewAssignedFacilitySelected(facility: Facility) {

--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityView.kt
@@ -13,6 +13,8 @@ import io.reactivex.rxkotlin.ofType
 import org.simple.clinic.ReportAnalyticsEvents
 import org.simple.clinic.databinding.PatientsummaryAssignedFacilityContentBinding
 import org.simple.clinic.di.injector
+import org.simple.clinic.facility.Facility
+import org.simple.clinic.mobius.DeferredEventSource
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.navigation.v2.Router
 import org.simple.clinic.navigation.v2.keyprovider.ScreenKeyProvider
@@ -75,6 +77,8 @@ class AssignedFacilityView(
         .compose(ReportAnalyticsEvents())
   }
 
+  private val externalEvents = DeferredEventSource<AssignedFacilityEvent>()
+
   private val delegate by unsafeLazy {
     val uiRenderer = AssignedFacilityUiRenderer(this)
     val patientUuid = screenKeyProvider.keyFor<PatientSummaryScreenKey>(this).patientUuid
@@ -85,6 +89,7 @@ class AssignedFacilityView(
         update = AssignedFacilityUpdate(),
         effectHandler = effectHandlerFactory.create(this).build(),
         init = AssignedFacilityInit(),
+        additionalEventSources = listOf(externalEvents),
         modelUpdateListener = { model ->
           modelUpdateCallback?.invoke(model)
           uiRenderer.render(model)
@@ -146,6 +151,10 @@ class AssignedFacilityView(
         .ofType<ActivityResult>()
         .extractSuccessful(ASSIGNED_FACILITY_SELECTION, FacilitySelectionActivity.Companion::selectedFacility)
         .map(::AssignedFacilitySelected)
+  }
+
+  fun onNewAssignedFacilitySelected(facility: Facility) {
+    externalEvents.notify(AssignedFacilitySelected(facility))
   }
 
   interface Injector {

--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityView.kt
@@ -8,7 +8,6 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.card.MaterialCardView
-import com.jakewharton.rxbinding3.view.clicks
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
 import org.simple.clinic.ReportAnalyticsEvents
@@ -28,10 +27,14 @@ import org.simple.clinic.util.extractSuccessful
 import org.simple.clinic.util.unsafeLazy
 import javax.inject.Inject
 
+private typealias ChangeAssignedFacilityClicked = () -> Unit
+
 class AssignedFacilityView(
     context: Context,
     attrs: AttributeSet
 ) : MaterialCardView(context, attrs), AssignedFacilityUi, UiActions, PatientSummaryChildView {
+
+  var changeAssignedFacilityClicks: ChangeAssignedFacilityClicked? = null
 
   private var binding: PatientsummaryAssignedFacilityContentBinding? = null
 
@@ -97,6 +100,9 @@ class AssignedFacilityView(
     }
 
     context.injector<Injector>().inject(this)
+    changeAssignedFacilityButton.setOnClickListener {
+      changeAssignedFacilityClicks?.invoke()
+    }
   }
 
   override fun onAttachedToWindow() {
@@ -131,7 +137,7 @@ class AssignedFacilityView(
   }
 
   private fun changeButtonClicks(): Observable<AssignedFacilityEvent> {
-    return changeAssignedFacilityButton.clicks().map { ChangeAssignedFacilityButtonClicked }
+    return Observable.never()
   }
 
   private fun assignedFacilitySelected(): Observable<AssignedFacilityEvent> {

--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityView.kt
@@ -55,11 +55,6 @@ class AssignedFacilityView(
 
   private var modelUpdateCallback: PatientSummaryModelUpdateCallback? = null
 
-  private val events by unsafeLazy {
-    assignedFacilitySelected()
-        .compose(ReportAnalyticsEvents())
-  }
-
   private val externalEvents = DeferredEventSource<AssignedFacilityEvent>()
 
   private val delegate by unsafeLazy {
@@ -67,7 +62,7 @@ class AssignedFacilityView(
     val patientUuid = screenKeyProvider.keyFor<PatientSummaryScreenKey>(this).patientUuid
 
     MobiusDelegate.forView(
-        events = events.ofType(),
+        events = Observable.never(),
         defaultModel = AssignedFacilityModel.create(patientUuid = patientUuid),
         update = AssignedFacilityUpdate(),
         effectHandler = effectHandlerFactory.create(this).build(),
@@ -118,10 +113,6 @@ class AssignedFacilityView(
 
   override fun registerSummaryModelUpdateCallback(callback: PatientSummaryModelUpdateCallback?) {
     modelUpdateCallback = callback
-  }
-
-  private fun assignedFacilitySelected(): Observable<AssignedFacilityEvent> {
-    return Observable.never()
   }
 
   fun onNewAssignedFacilitySelected(facility: Facility) {

--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityView.kt
@@ -2,11 +2,9 @@ package org.simple.clinic.summary.assignedfacility
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.Intent
 import android.os.Parcelable
 import android.util.AttributeSet
 import android.view.LayoutInflater
-import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.card.MaterialCardView
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.ofType
@@ -18,9 +16,6 @@ import org.simple.clinic.mobius.DeferredEventSource
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.navigation.v2.Router
 import org.simple.clinic.navigation.v2.keyprovider.ScreenKeyProvider
-import org.simple.clinic.router.ScreenResultBus
-import org.simple.clinic.scheduleappointment.facilityselection.FacilitySelectionActivity
-import org.simple.clinic.summary.ASSIGNED_FACILITY_SELECTION
 import org.simple.clinic.summary.PatientSummaryChildView
 import org.simple.clinic.summary.PatientSummaryModelUpdateCallback
 import org.simple.clinic.summary.PatientSummaryScreenKey
@@ -50,13 +45,7 @@ class AssignedFacilityView(
   }
 
   @Inject
-  lateinit var activity: AppCompatActivity
-
-  @Inject
   lateinit var router: Router
-
-  @Inject
-  lateinit var screenResults: ScreenResultBus
 
   @Inject
   lateinit var effectHandlerFactory: AssignedFacilityEffectHandler.Factory
@@ -67,11 +56,7 @@ class AssignedFacilityView(
   private var modelUpdateCallback: PatientSummaryModelUpdateCallback? = null
 
   private val events by unsafeLazy {
-    Observable
-        .merge(
-            changeButtonClicks(),
-            assignedFacilitySelected()
-        )
+    assignedFacilitySelected()
         .compose(ReportAnalyticsEvents())
   }
 
@@ -127,20 +112,12 @@ class AssignedFacilityView(
     super.onRestoreInstanceState(delegate.onRestoreInstanceState(state))
   }
 
-  override fun openFacilitySelection() {
-    activity.startActivityForResult(Intent(context, FacilitySelectionActivity::class.java), ASSIGNED_FACILITY_SELECTION)
-  }
-
   override fun renderAssignedFacilityName(facilityName: String) {
     assignedFacilityTextView.text = facilityName
   }
 
   override fun registerSummaryModelUpdateCallback(callback: PatientSummaryModelUpdateCallback?) {
     modelUpdateCallback = callback
-  }
-
-  private fun changeButtonClicks(): Observable<AssignedFacilityEvent> {
-    return Observable.never()
   }
 
   private fun assignedFacilitySelected(): Observable<AssignedFacilityEvent> {

--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/UiActions.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/UiActions.kt
@@ -1,5 +1,4 @@
 package org.simple.clinic.summary.assignedfacility
 
 interface UiActions {
-  fun openFacilitySelection()
 }

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
@@ -442,4 +442,19 @@ class PatientSummaryEffectHandlerTest {
     verify(uiActions).openSelectFacilitySheet()
     verifyNoMoreInteractions(uiActions)
   }
+
+  @Test
+  fun `when dispatch new assigned facility is received, then dispatch the newly selected facility`() {
+    // given
+    val selectedFacility = TestData.facility(uuid = UUID.fromString("68a067f0-e746-4191-bfe4-3c4a026642b8"))
+
+    // when
+    testCase.dispatch(DispatchNewAssignedFacility(selectedFacility))
+
+    // then
+    testCase.assertNoOutgoingEvents()
+
+    verify(uiActions).dispatchNewAssignedFacility(selectedFacility)
+    verifyNoMoreInteractions(uiActions)
+  }
 }

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
@@ -430,4 +430,16 @@ class PatientSummaryEffectHandlerTest {
     verify(uiActions).showAddBloodSugarWarningDialog()
     verifyNoMoreInteractions(uiActions)
   }
+
+  @Test
+  fun `when open select facility sheet effect is received, then show the select facility sheet`() {
+    // when
+    testCase.dispatch(OpenSelectFacilitySheet)
+
+    // then
+    testCase.assertNoOutgoingEvents()
+
+    verify(uiActions).openSelectFacilitySheet()
+    verifyNoMoreInteractions(uiActions)
+  }
 }

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
@@ -886,6 +886,22 @@ class PatientSummaryUpdateTest {
         ))
   }
 
+  @Test
+  fun `when nurse tries to change the patient assigned facility, open the select facility screen`() {
+    val model = defaultModel
+        .currentFacilityLoaded(facilityWithTeleconsultationEnabled)
+        .patientSummaryProfileLoaded(patientSummaryProfile)
+        .completedCheckForInvalidPhone()
+
+    updateSpec
+        .given(model)
+        .whenEvent(ChangeAssignedFacilityClicked)
+        .then(assertThatNext(
+            hasNoModel(),
+            hasEffects(OpenSelectFacilitySheet)
+        ))
+  }
+
   private fun PatientSummaryModel.forExistingPatient(): PatientSummaryModel {
     return copy(openIntention = ViewExistingPatient)
   }

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
@@ -902,6 +902,22 @@ class PatientSummaryUpdateTest {
         ))
   }
 
+  @Test
+  fun `when nurse selects the new assigned facility, dispatch the newly selected facility`() {
+    val model = defaultModel
+        .currentFacilityLoaded(facilityWithTeleconsultationEnabled)
+        .patientSummaryProfileLoaded(patientSummaryProfile)
+        .completedCheckForInvalidPhone()
+
+    updateSpec
+        .given(model)
+        .whenEvent(NewAssignedFacilitySelected(facilityWithDiabetesManagementEnabled))
+        .then(assertThatNext(
+            hasNoModel(),
+            hasEffects(DispatchNewAssignedFacility(facilityWithDiabetesManagementEnabled))
+        ))
+  }
+
   private fun PatientSummaryModel.forExistingPatient(): PatientSummaryModel {
     return copy(openIntention = ViewExistingPatient)
   }

--- a/app/src/test/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityEffectHandlerTest.kt
@@ -3,7 +3,6 @@ package org.simple.clinic.summary.assignedfacility
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.After
@@ -12,8 +11,8 @@ import org.simple.clinic.TestData
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.mobius.EffectHandlerTestCase
 import org.simple.clinic.patient.PatientRepository
-import java.util.Optional
 import org.simple.clinic.util.scheduler.TestSchedulersProvider
+import java.util.Optional
 import java.util.UUID
 
 class AssignedFacilityEffectHandlerTest {
@@ -79,17 +78,5 @@ class AssignedFacilityEffectHandlerTest {
 
     effectHandlerTestCase.assertNoOutgoingEvents()
     verifyZeroInteractions(uiActions)
-  }
-
-  @Test
-  fun `when open facility selection effect is received, then open the facility selection screen`() {
-    // when
-    effectHandlerTestCase.dispatch(OpenFacilitySelection)
-
-    // then
-    effectHandlerTestCase.assertNoOutgoingEvents()
-
-    verify(uiActions).openFacilitySelection()
-    verifyNoMoreInteractions(uiActions)
   }
 }

--- a/app/src/test/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityUpdateTest.kt
@@ -3,7 +3,6 @@ package org.simple.clinic.summary.assignedfacility
 import com.spotify.mobius.test.NextMatchers.hasEffects
 import com.spotify.mobius.test.NextMatchers.hasModel
 import com.spotify.mobius.test.NextMatchers.hasNoEffects
-import com.spotify.mobius.test.NextMatchers.hasNoModel
 import com.spotify.mobius.test.UpdateSpec
 import com.spotify.mobius.test.UpdateSpec.assertThatNext
 import org.junit.Test
@@ -30,17 +29,6 @@ class AssignedFacilityUpdateTest {
         .then(assertThatNext(
             hasModel(model.assignedFacilityUpdated(facility)),
             hasNoEffects()
-        ))
-  }
-
-  @Test
-  fun `when change assign facility button is clicked, then open facility selection`() {
-    updateSpec
-        .given(model)
-        .whenEvent(ChangeAssignedFacilityButtonClicked)
-        .then(assertThatNext(
-            hasNoModel(),
-            hasEffects(OpenFacilitySelection as AssignedFacilityEffect)
         ))
   }
 


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/4822/changing-the-assigned-facility-for-a-patient-goes-to-home-screen-instead-of-staying-on-summary-screen

### Note: 
In order to fix this, we need to migrate the facility selection screen to extend the `BaseScreen` and be a part of the navigation graph. However, there is an issue in the current setup where `AssignedFacilityView` is one of the components which starts this screen. This makes migration hard because we cannot handle results in a child view.

This PR moves opening of the facility selection screen to `PatientSummaryScreen`, which will then make it easier for us to migrate `FacilitySelectionScreen`