### PR TITLE
Allow state selection during app onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - [In Progress: 2 Sep 2021] Add a progress state in `CustomDrugEntrySheet`
 
 ### Features
-- [In-progress: 06 Sep 2021] Add support for state selection after selecting country
+- [In-progress: 07 Sep 2021] Add support for state selection after selecting country
 
 ### Changes
 - Implement providing drug frequencies label depending on the country

--- a/app/src/main/java/org/simple/clinic/appconfig/AppConfigModule.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/AppConfigModule.kt
@@ -43,8 +43,8 @@ class AppConfigModule {
   fun providesSelectedState(
       rxSharedPreferences: RxSharedPreferences,
       moshi: Moshi
-  ): Preference<Optional<State>> {
-    val statePreferenceConverter = MoshiObjectPreferenceConverter(moshi, State::class.java)
-    return rxSharedPreferences.getOptional("preference_selected_state_v1", statePreferenceConverter)
+  ): Preference<Optional<String>> {
+    val statePreferenceConverter = MoshiObjectPreferenceConverter(moshi, String::class.java)
+    return rxSharedPreferences.getOptional("preference_selected_state_v1", statePreferenceConverter, Optional.empty())
   }
 }

--- a/app/src/main/java/org/simple/clinic/appconfig/AppConfigRepository.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/AppConfigRepository.kt
@@ -22,7 +22,7 @@ class AppConfigRepository @Inject constructor(
     private val manifestFetchApi: ManifestFetchApi,
     private val selectedCountryPreference: Preference<Optional<Country>>,
     private val selectedDeployment: Preference<Optional<Deployment>>,
-    private val selectedStatePreference: Preference<Optional<State>>,
+    private val selectedStatePreference: Preference<Optional<String>>,
     private val statesFetcher: StatesFetcher
 ) {
 
@@ -56,7 +56,7 @@ class AppConfigRepository @Inject constructor(
   }
 
   fun saveState(state: State) {
-    selectedStatePreference.set(Optional.of(state))
+    selectedStatePreference.set(Optional.of(state.displayName))
   }
 
   fun fetchStatesInSelectedCountry(): StatesResult {

--- a/app/src/main/java/org/simple/clinic/appconfig/StatePayload.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/StatePayload.kt
@@ -1,0 +1,11 @@
+package org.simple.clinic.appconfig
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class StatePayload(
+
+    @Json(name = "name")
+    val displayName: String
+)

--- a/app/src/main/java/org/simple/clinic/appconfig/StatesFetcher.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/StatesFetcher.kt
@@ -13,11 +13,16 @@ class StatesFetcher @Inject constructor(
   @Throws(ConnectException::class)
   fun fetchStates(deployment: Deployment): List<State> {
     val statesApi = createStatesApi(deployment)
-    return statesApi
+    val statesPayload = statesApi
         .fetchStates()
+        .execute()
+        .body()
+    val states = statesPayload?.states.orEmpty()
+
+    return states
         .map { state ->
           State(
-              displayName = state,
+              displayName = state.displayName,
               deployment = deployment
           )
         }

--- a/app/src/main/java/org/simple/clinic/appconfig/StatesPayload.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/StatesPayload.kt
@@ -1,0 +1,11 @@
+package org.simple.clinic.appconfig
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class StatesPayload(
+
+    @Json(name = "states")
+    val states: List<StatePayload>
+)

--- a/app/src/main/java/org/simple/clinic/appconfig/api/StatesApi.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/api/StatesApi.kt
@@ -1,9 +1,11 @@
 package org.simple.clinic.appconfig.api
 
+import org.simple.clinic.appconfig.StatesPayload
+import retrofit2.Call
 import retrofit2.http.GET
 
 interface StatesApi {
 
   @GET("v4/states")
-  fun fetchStates(): List<String>
+  fun fetchStates(): Call<StatesPayload>
 }

--- a/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActiivtyComponent.kt
+++ b/app/src/main/java/org/simple/clinic/registerorlogin/AuthenticationActiivtyComponent.kt
@@ -20,6 +20,7 @@ import org.simple.clinic.registration.register.RegistrationLoadingScreen
 import org.simple.clinic.router.ScreenResultBus
 import org.simple.clinic.security.pin.PinEntryCardView
 import org.simple.clinic.selectcountry.SelectCountryScreenInjector
+import org.simple.clinic.selectstate.SelectStateScreen
 
 @Subcomponent(modules = [
   FragmentScreenKeyModule::class
@@ -38,7 +39,8 @@ interface AuthenticationActivityComponent :
     PinEntryCardView.Injector,
     LoggedOutOfDeviceDialog.Injector,
     SelectCountryScreenInjector,
-    FacilityPickerView.Injector {
+    FacilityPickerView.Injector,
+    SelectStateScreen.Injector {
   fun inject(target: AuthenticationActivity)
 
   @Subcomponent.Factory

--- a/app/src/main/java/org/simple/clinic/selectcountry/SelectCountryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/selectcountry/SelectCountryEffect.kt
@@ -9,7 +9,7 @@ object FetchManifest : SelectCountryEffect()
 
 data class SaveCountryEffect(val country: Country) : SelectCountryEffect()
 
-object GoToNextScreen : SelectCountryEffect()
+object GoToStateSelectionScreen : SelectCountryEffect()
 
 data class SaveDeployment(val deployment: Deployment) : SelectCountryEffect()
 

--- a/app/src/main/java/org/simple/clinic/selectcountry/SelectCountryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/selectcountry/SelectCountryEffectHandler.kt
@@ -33,7 +33,7 @@ class SelectCountryEffectHandler(
         .subtypeEffectHandler<SelectCountryEffect, SelectCountryEvent>()
         .addTransformer(FetchManifest::class.java, fetchManifest())
         .addTransformer(SaveCountryEffect::class.java, saveCountry())
-        .addAction(GoToNextScreen::class.java, uiActions::goToNextScreen, schedulersProvider.ui())
+        .addAction(GoToStateSelectionScreen::class.java, uiActions::goToStateSelectionScreen, schedulersProvider.ui())
         .addTransformer(SaveDeployment::class.java, saveDeployment())
         .addAction(GoToRegistrationScreen::class.java, uiActions::goToRegistrationScreen, schedulersProvider.ui())
         .build()

--- a/app/src/main/java/org/simple/clinic/selectcountry/SelectCountryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/selectcountry/SelectCountryScreen.kt
@@ -204,7 +204,7 @@ class SelectCountryScreen(
     nextButtonFrame.visibility = VISIBLE
   }
 
-  override fun goToNextScreen() {
+  override fun goToStateSelectionScreen() {
     // TODO: Navigate to state selection screen
     router.push(RegistrationPhoneScreenKey())
   }

--- a/app/src/main/java/org/simple/clinic/selectcountry/SelectCountryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/selectcountry/SelectCountryScreen.kt
@@ -24,6 +24,7 @@ import org.simple.clinic.registration.phone.RegistrationPhoneScreenKey
 import org.simple.clinic.selectcountry.adapter.Event
 import org.simple.clinic.selectcountry.adapter.SelectableCountryItem
 import org.simple.clinic.selectcountry.adapter.SelectableCountryItemDiffCallback
+import org.simple.clinic.selectstate.SelectStateScreen
 import org.simple.clinic.util.scheduler.SchedulersProvider
 import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.widgets.ItemAdapter
@@ -205,8 +206,7 @@ class SelectCountryScreen(
   }
 
   override fun goToStateSelectionScreen() {
-    // TODO: Navigate to state selection screen
-    router.push(RegistrationPhoneScreenKey())
+    router.push(SelectStateScreen.Key())
   }
 
   override fun goToRegistrationScreen() {

--- a/app/src/main/java/org/simple/clinic/selectcountry/SelectCountryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/selectcountry/SelectCountryUpdate.kt
@@ -27,7 +27,7 @@ class SelectCountryUpdate : Update<SelectCountryModel, SelectCountryEvent, Selec
       val selectedCountryDeployment = model.selectedCountry!!.deployments.first()
       SaveDeployment(selectedCountryDeployment)
     } else {
-      GoToNextScreen
+      GoToStateSelectionScreen
     }
 
     return dispatch(effect = effect)

--- a/app/src/main/java/org/simple/clinic/selectcountry/UiActions.kt
+++ b/app/src/main/java/org/simple/clinic/selectcountry/UiActions.kt
@@ -2,6 +2,6 @@ package org.simple.clinic.selectcountry
 
 interface UiActions {
 
-  fun goToNextScreen()
+  fun goToStateSelectionScreen()
   fun goToRegistrationScreen()
 }

--- a/app/src/main/java/org/simple/clinic/selectstate/SelectStateEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/selectstate/SelectStateEffectHandler.kt
@@ -32,7 +32,8 @@ class SelectStateEffectHandler @AssistedInject constructor(
     return ObservableTransformer { effects ->
       effects
           .observeOn(schedulers.io())
-          .map { appConfigRepository.saveState(it.state) }
+          .doOnNext { appConfigRepository.saveState(it.state) }
+          .doOnNext { appConfigRepository.saveDeployment(it.state.deployment) }
           .map { StateSaved }
     }
   }

--- a/app/src/main/java/org/simple/clinic/selectstate/SelectStateEvent.kt
+++ b/app/src/main/java/org/simple/clinic/selectstate/SelectStateEvent.kt
@@ -1,8 +1,9 @@
 package org.simple.clinic.selectstate
 
 import org.simple.clinic.appconfig.State
+import org.simple.clinic.widgets.UiEvent
 
-sealed class SelectStateEvent
+sealed class SelectStateEvent : UiEvent
 
 object StateSaved : SelectStateEvent()
 
@@ -10,8 +11,14 @@ data class StatesFetched(val states: List<State>) : SelectStateEvent()
 
 data class FailedToFetchStates(val error: StatesFetchError) : SelectStateEvent()
 
-object RetryButtonClicked : SelectStateEvent()
+object RetryButtonClicked : SelectStateEvent() {
+  override val analyticsName: String = "Select State:Retry Clicked"
+}
 
-data class StateChanged(val state: State) : SelectStateEvent()
+data class StateChanged(val state: State) : SelectStateEvent() {
+  override val analyticsName: String = "Select State:State Changed:${state.displayName}"
+}
 
-object NextClicked : SelectStateEvent()
+object NextClicked : SelectStateEvent() {
+  override val analyticsName: String = "Select State:Next Clicked"
+}

--- a/app/src/main/java/org/simple/clinic/selectstate/SelectStateScreen.kt
+++ b/app/src/main/java/org/simple/clinic/selectstate/SelectStateScreen.kt
@@ -1,0 +1,186 @@
+package org.simple.clinic.selectstate
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.jakewharton.rxbinding3.view.clicks
+import com.spotify.mobius.functions.Consumer
+import io.reactivex.Observable
+import io.reactivex.rxkotlin.cast
+import kotlinx.parcelize.Parcelize
+import org.simple.clinic.R
+import org.simple.clinic.ReportAnalyticsEvents
+import org.simple.clinic.appconfig.State
+import org.simple.clinic.databinding.ListSelectstateStateViewBinding
+import org.simple.clinic.databinding.ScreenSelectStateBinding
+import org.simple.clinic.di.injector
+import org.simple.clinic.navigation.v2.Router
+import org.simple.clinic.navigation.v2.ScreenKey
+import org.simple.clinic.navigation.v2.fragments.BaseScreen
+import org.simple.clinic.registration.phone.RegistrationPhoneScreenKey
+import org.simple.clinic.widgets.ItemAdapter
+import org.simple.clinic.widgets.UiEvent
+import javax.inject.Inject
+
+class SelectStateScreen : BaseScreen<
+    SelectStateScreen.Key,
+    ScreenSelectStateBinding,
+    SelectStateModel,
+    SelectStateEvent,
+    SelectStateEffect,
+    SelectStateViewEffect>(), SelectStateUi, SelectStateUiActions {
+
+  @Inject
+  lateinit var effectHandlerFactory: SelectStateEffectHandler.Factory
+
+  @Inject
+  lateinit var router: Router
+
+  private val nextButtonFrame
+    get() = binding.nextButtonFrame
+
+  private val nextButton
+    get() = binding.nextButton
+
+  private val statesListGroup
+    get() = binding.statesListGroup
+
+  private val errorGroup
+    get() = binding.errorGroup
+
+  private val errorMessageTextView
+    get() = binding.errorMessageTextView
+
+  private val statesList
+    get() = binding.statesList
+
+  private val progressBar
+    get() = binding.progressBar
+
+  private val retryButton
+    get() = binding.tryAgain
+
+  private val statesAdapter = ItemAdapter(
+      diffCallback = SelectableStateItem.SelectableStateItemDiffCallback(),
+      bindings = mapOf(
+          R.layout.list_selectstate_state_view to { layoutInflater, parent ->
+            ListSelectstateStateViewBinding.inflate(layoutInflater, parent, false)
+          }
+      )
+  )
+
+  override fun onAttach(context: Context) {
+    super.onAttach(context)
+    context.injector<Injector>().inject(this)
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+    statesList.adapter = statesAdapter
+  }
+
+  override fun defaultModel() = SelectStateModel.create()
+
+  override fun bindView(
+      layoutInflater: LayoutInflater,
+      container: ViewGroup?
+  ) = ScreenSelectStateBinding.inflate(layoutInflater, container, false)
+
+  override fun uiRenderer() = SelectStateUiRenderer(this)
+
+  override fun viewEffectHandler() = SelectStateViewEffectHandler(this)
+
+  override fun createInit() = SelectStateInit()
+
+  override fun createUpdate() = SelectStateUpdate()
+
+  override fun createEffectHandler(viewEffectsConsumer: Consumer<SelectStateViewEffect>) =
+      effectHandlerFactory
+          .create(viewEffectsConsumer)
+          .build()
+
+  override fun events() = Observable
+      .mergeArray(
+          nextButtonClicks(),
+          retryButtonClicks(),
+          stateSelectedEvents()
+      )
+      .compose(ReportAnalyticsEvents())
+      .cast<SelectStateEvent>()
+
+  override fun showStates(states: List<State>, selectedState: State?) {
+    statesListGroup.visibility = View.VISIBLE
+    statesAdapter.submitList(SelectableStateItem.from(states = states, selectedState = selectedState))
+  }
+
+  override fun hideStates() {
+    statesListGroup.visibility = View.GONE
+  }
+
+  override fun showNextButton() {
+    nextButtonFrame.visibility = View.VISIBLE
+  }
+
+  override fun showNetworkErrorMessage() {
+    errorGroup.visibility = View.VISIBLE
+    errorMessageTextView.setText(R.string.select_state_networkerror)
+  }
+
+  override fun showServerErrorMessage() {
+    errorGroup.visibility = View.VISIBLE
+    errorMessageTextView.setText(R.string.select_state_servererror)
+  }
+
+  override fun showGenericErrorMessage() {
+    errorGroup.visibility = View.VISIBLE
+    errorMessageTextView.setText(R.string.select_state_genericerror)
+  }
+
+  override fun hideErrorView() {
+    errorGroup.visibility = View.GONE
+  }
+
+  override fun showProgress() {
+    progressBar.visibility = View.VISIBLE
+  }
+
+  override fun hideProgress() {
+    progressBar.visibility = View.GONE
+  }
+
+  override fun goToRegistrationScreen() {
+    router.push(RegistrationPhoneScreenKey())
+  }
+
+  private fun stateSelectedEvents(): Observable<UiEvent> {
+    return statesAdapter
+        .itemEvents
+        .map { StateChanged(it.state) }
+  }
+
+  private fun nextButtonClicks(): Observable<UiEvent> {
+    return nextButton
+        .clicks()
+        .map { NextClicked }
+  }
+
+  private fun retryButtonClicks(): Observable<UiEvent> {
+    return retryButton
+        .clicks()
+        .map { RetryButtonClicked }
+  }
+
+  @Parcelize
+  data class Key(
+      override val analyticsName: String = "Select State Screen"
+  ) : ScreenKey() {
+
+    override fun instantiateFragment() = SelectStateScreen()
+  }
+
+  interface Injector {
+    fun inject(target: SelectStateScreen)
+  }
+}

--- a/app/src/main/java/org/simple/clinic/selectstate/SelectableStateItem.kt
+++ b/app/src/main/java/org/simple/clinic/selectstate/SelectableStateItem.kt
@@ -1,0 +1,70 @@
+package org.simple.clinic.selectstate
+
+import androidx.core.view.isInvisible
+import androidx.recyclerview.widget.DiffUtil
+import io.reactivex.subjects.Subject
+import org.simple.clinic.R
+import org.simple.clinic.appconfig.State
+import org.simple.clinic.databinding.ListSelectstateStateViewBinding
+import org.simple.clinic.widgets.ItemAdapter
+import org.simple.clinic.widgets.recyclerview.BindingViewHolder
+
+data class SelectableStateItem(
+    private val state: State,
+    private val isStateSelectedByUser: Boolean,
+    private val showDivider: Boolean
+) : ItemAdapter.Item<SelectableStateItem.StateClicked> {
+
+  companion object {
+
+    fun from(
+        states: List<State>,
+        selectedState: State?
+    ): List<SelectableStateItem> {
+      return states
+          .mapIndexed { index, state ->
+            val isLastStateInList = index == states.lastIndex
+            val hasUserSelectedCountry = state == selectedState
+
+            SelectableStateItem(
+                state = state,
+                isStateSelectedByUser = hasUserSelectedCountry,
+                showDivider = !isLastStateInList
+            )
+          }
+    }
+  }
+
+  override fun layoutResId() = R.layout.list_selectstate_state_view
+
+  override fun render(holder: BindingViewHolder, subject: Subject<StateClicked>) {
+    val binding = holder.binding as ListSelectstateStateViewBinding
+
+    binding.stateRadioButton.apply {
+      text = state.displayName
+      isChecked = isStateSelectedByUser
+      setOnClickListener { subject.onNext(StateClicked(state)) }
+    }
+
+    binding.divider.isInvisible = !showDivider
+  }
+
+  data class StateClicked(val state: State)
+
+  class SelectableStateItemDiffCallback : DiffUtil.ItemCallback<SelectableStateItem>() {
+
+    override fun areItemsTheSame(
+        oldItem: SelectableStateItem,
+        newItem: SelectableStateItem
+    ): Boolean {
+      return oldItem.state.displayName == newItem.state.displayName
+    }
+
+    override fun areContentsTheSame(
+        oldItem: SelectableStateItem,
+        newItem: SelectableStateItem
+    ): Boolean {
+      return oldItem == newItem
+    }
+  }
+}

--- a/app/src/main/res/layout/list_selectstate_state_view.xml
+++ b/app/src/main/res/layout/list_selectstate_state_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="wrap_content"
+  tools:background="?attr/colorSurface">
+
+  <com.google.android.material.radiobutton.MaterialRadioButton
+    android:id="@+id/stateRadioButton"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/spacing_12"
+    android:padding="@dimen/spacing_16"
+    android:textAppearance="?attr/textAppearanceBody1"
+    app:layout_constraintBottom_toTopOf="@id/divider"
+    tools:text="Andhra Pradesh" />
+
+  <View
+    android:id="@+id/divider"
+    android:layout_width="match_parent"
+    android:layout_height="1dp"
+    android:layout_marginStart="@dimen/spacing_16"
+    android:layout_marginEnd="@dimen/spacing_16"
+    android:background="@drawable/divider"
+    app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/screen_select_state.xml
+++ b/app/src/main/res/layout/screen_select_state.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+
+  <View
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/spacing_192"
+    android:background="?attr/colorToolbarPrimary"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent" />
+
+  <ImageView
+    android:id="@+id/simple_logo"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/spacing_40"
+    android:contentDescription="@string/selectcountry_logo_contentdescription"
+    app:layout_constraintBottom_toTopOf="@id/contentContainer"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    app:srcCompat="@drawable/logo_large" />
+
+  <com.google.android.material.card.MaterialCardView
+    android:id="@+id/contentContainer"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/spacing_24"
+    android:layout_marginTop="@dimen/spacing_44"
+    android:layout_marginEnd="@dimen/spacing_24"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/simple_logo">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:minHeight="@dimen/spacing_128">
+
+      <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:indeterminate="false"
+        tools:progress="50" />
+
+      <TextView
+        android:id="@+id/select_state_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_24"
+        android:text="@string/select_state_title"
+        android:textAppearance="?attr/textAppearanceHeadline6"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+      <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/statesList"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/spacing_16"
+        android:layout_marginTop="@dimen/spacing_24"
+        android:paddingBottom="@dimen/spacing_8"
+        android:visibility="gone"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/select_state_title"
+        tools:layout_height="128dp"
+        tools:listitem="@layout/list_selectstate_state_view" />
+
+      <TextView
+        android:id="@+id/errorMessageTextView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/spacing_24"
+        android:layout_marginTop="@dimen/spacing_24"
+        android:textAlignment="center"
+        android:textAppearance="?attr/textAppearanceHeadline6"
+        android:textColor="@color/color_on_surface_67"
+        app:layout_constraintBottom_toTopOf="@id/tryAgain"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="@string/select_state_genericerror" />
+
+      <com.google.android.material.button.MaterialButton
+        android:id="@+id/tryAgain"
+        style="?attr/materialButtonOutlinedStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/spacing_40"
+        android:layout_marginTop="@dimen/spacing_24"
+        android:layout_marginEnd="@dimen/spacing_40"
+        android:layout_marginBottom="@dimen/spacing_24"
+        android:text="@string/selectcountry_retry"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/errorMessageTextView" />
+
+      <androidx.constraintlayout.widget.Group
+        android:id="@+id/statesListGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:constraint_referenced_ids="select_state_title, statesList"
+        tools:visibility="visible" />
+
+      <androidx.constraintlayout.widget.Group
+        android:id="@+id/errorGroup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:constraint_referenced_ids="errorMessageTextView, tryAgain" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+  </com.google.android.material.card.MaterialCardView>
+
+  <FrameLayout
+    android:id="@+id/nextButtonFrame"
+    style="@style/Widget.Simple.Button.Frame"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:visibility="gone"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    tools:visibility="visible">
+
+    <com.google.android.material.button.MaterialButton
+      android:id="@+id/nextButton"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:text="@string/selectcountry_next" />
+
+  </FrameLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -856,4 +856,10 @@
   <string name="custom_drug_entry_sheet_frequency_ethiopia_QID" translatable="false">QID</string>
   <string name="custom_drug_entry_sheet_frequency_ethiopia_TID" translatable="false">TID</string>
 
+  <!-- Select state screen -->
+  <string name="select_state_title">Where is your clinic?</string>
+  <string name="select_state_networkerror">No internet connection!</string>
+  <string name="select_state_servererror">Server error! Please try again later!</string>
+  <string name="select_state_genericerror">Something went wrong! Please try again later!</string>
+
 </resources>

--- a/app/src/test/java/org/simple/clinic/appconfig/AppConfigRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/appconfig/AppConfigRepositoryTest.kt
@@ -27,7 +27,7 @@ class AppConfigRepositoryTest {
   private val manifestFetchApi = mock<ManifestFetchApi>()
   private val selectedCountryV2Preference = mock<Preference<Optional<Country>>>()
   private val selectedDeployment = mock<Preference<Optional<Deployment>>>()
-  private val selectedStatePreference = mock<Preference<Optional<State>>>()
+  private val selectedStatePreference = mock<Preference<Optional<String>>>()
   private val statesFetcher = mock<StatesFetcher>()
 
   private val repository = AppConfigRepository(
@@ -294,7 +294,7 @@ class AppConfigRepositoryTest {
   }
 
   @Test
-  fun `saving the state, should save it to local persistence`() {
+  fun `saving the state, should save state name to local persistence`() {
     // given
     val deployment = TestData.deployment(
         displayName = "IHCI",
@@ -309,7 +309,7 @@ class AppConfigRepositoryTest {
     repository.saveState(state)
 
     // then
-    verify(selectedStatePreference).set(Optional.of(state))
+    verify(selectedStatePreference).set(Optional.of(state.displayName))
     verifyNoMoreInteractions(selectedStatePreference)
   }
 }

--- a/app/src/test/java/org/simple/clinic/selectcountry/SelectCountryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/selectcountry/SelectCountryEffectHandlerTest.kt
@@ -94,14 +94,14 @@ class SelectCountryEffectHandlerTest {
   }
 
   @Test
-  fun `when the go to next screen effect is received, the next screen must be opened`() {
+  fun `when the go to state selection screen effect is received, then go to state selection screen`() {
     // when
-    testCase.dispatch(GoToNextScreen)
+    testCase.dispatch(GoToStateSelectionScreen)
 
     // then
     verifyZeroInteractions(repository)
     testCase.assertNoOutgoingEvents()
-    verify(uiActions).goToNextScreen()
+    verify(uiActions).goToStateSelectionScreen()
     verifyNoMoreInteractions(uiActions)
   }
 

--- a/app/src/test/java/org/simple/clinic/selectcountry/SelectCountryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/selectcountry/SelectCountryUpdateTest.kt
@@ -137,7 +137,7 @@ class SelectCountryUpdateTest {
   }
 
   @Test
-  fun `when selected country is saved and there is only one deployment, then go to next screen`() {
+  fun `when selected country is saved and there is more than one deployment, then go to state selection screen`() {
     val ihci = TestData.deployment(
         endPoint = "https://in.simple.org",
         displayName = "IHCI"
@@ -161,7 +161,7 @@ class SelectCountryUpdateTest {
         .whenEvent(CountrySaved)
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(GoToNextScreen)
+            hasEffects(GoToStateSelectionScreen)
         ))
   }
 }

--- a/app/src/test/java/org/simple/clinic/selectstate/SelectStateEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/selectstate/SelectStateEffectHandlerTest.kt
@@ -66,13 +66,21 @@ class SelectStateEffectHandlerTest {
   @Test
   fun `when save state effect is received, then save state to local persistence`() {
     // given
-    val state = TestData.state(displayName = "Andhra Pradesh")
+    val deployment = TestData.deployment(
+        displayName = "IHCI",
+        endPoint = "https://simple.org"
+    )
+    val state = TestData.state(displayName = "Andhra Pradesh", deployment = deployment)
 
     // when
     testCase.dispatch(SaveSelectedState(state))
 
     // then
     testCase.assertOutgoingEvents(StateSaved)
+
+    verify(appConfigRepository).saveState(state)
+    verify(appConfigRepository).saveDeployment(deployment)
+    verifyNoMoreInteractions(appConfigRepository)
   }
 
   @Test

--- a/app/src/test/java/org/simple/clinic/selectstate/SelectableStateItemTest.kt
+++ b/app/src/test/java/org/simple/clinic/selectstate/SelectableStateItemTest.kt
@@ -1,0 +1,54 @@
+package org.simple.clinic.selectstate
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.simple.clinic.TestData
+
+class SelectableStateItemTest {
+
+  private val andhraPradesh = TestData.state(displayName = "Andhra Pradesh")
+  private val kerala = TestData.state(displayName = "Kerala")
+  private val punjab = TestData.state(displayName = "Punjab")
+
+  private val states = listOf(andhraPradesh, kerala, punjab)
+
+  @Test
+  fun `if the user hasn't selected a state, then none of list items should be selected`() {
+    // when
+    val listItems = SelectableStateItem.from(states = states, selectedState = null)
+
+    // then
+    assertThat(listItems)
+        .containsExactly(
+            SelectableStateItem(state = andhraPradesh, isStateSelectedByUser = false, showDivider = true),
+            SelectableStateItem(state = kerala, isStateSelectedByUser = false, showDivider = true),
+            SelectableStateItem(state = punjab, isStateSelectedByUser = false, showDivider = false)
+        ).inOrder()
+  }
+
+  @Test
+  fun `if the user has selected a state, then list item should be selected`() {
+    // when
+    val listItems = SelectableStateItem.from(states = states, selectedState = kerala)
+
+    // then
+    assertThat(listItems)
+        .containsExactly(
+            SelectableStateItem(state = andhraPradesh, isStateSelectedByUser = false, showDivider = true),
+            SelectableStateItem(state = kerala, isStateSelectedByUser = true, showDivider = true),
+            SelectableStateItem(state = punjab, isStateSelectedByUser = false, showDivider = false)
+        ).inOrder()
+  }
+
+  @Test
+  fun `if there is only one item in the list, then divider must not be shown`() {
+    // when
+    val listItems = SelectableStateItem.from(states = listOf(andhraPradesh), selectedState = andhraPradesh)
+
+    // then
+    assertThat(listItems)
+        .containsExactly(
+            SelectableStateItem(state = andhraPradesh, isStateSelectedByUser = true, showDivider = false)
+        ).inOrder()
+  }
+}


### PR DESCRIPTION
https://app.clubhouse.io/simpledotorg/story/4035/allow-state-selection-during-app-onboarding

**Testing steps**

- Enable clear text traffic in debug `AndroidManifest` using `android:usesCleartextTraffic="true"` (This is temporary since some deployments have `http` instead of `https`, so we don't need it in prod)
- Replace manifest and fallback endpoints in `gradle.properties` with this: `https://simple-review-pr-2870.herokuapp.com/api/`
- Clear app data and run the app