### PR TITLE
Don't show appointment sheet when patient is dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Hide resend sms button when OTP attempts are blocked
 - Show patient died status in patient summary screen
 - Show patient died status in contact patient bottom sheet
+- Go back to the previous screen when done/back is clicked in the patient summary screen when the patient is marked as dead
 - [In Progress: 19 Aug 2021] UI improvements for medical history screen
   - Show hypertension diagnosis and treatment in single card
   - Show separate cards for hypertension and diabetes diagnosis

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
@@ -24,7 +24,7 @@ class PatientSummaryUpdate : Update<PatientSummaryModel, PatientSummaryEvent, Pa
     return when (event) {
       is PatientSummaryProfileLoaded -> patientSummaryProfileLoaded(model, event)
       is PatientSummaryBackClicked -> backClicked(model, event)
-      is PatientSummaryDoneClicked -> dispatch(LoadDataForDoneClick(model.patientUuid))
+      is PatientSummaryDoneClicked -> doneClicked()
       is CurrentUserAndFacilityLoaded -> currentUserAndFacilityLoaded(model, event)
       PatientSummaryEditClicked -> dispatch(HandleEditClick(model.patientSummaryProfile!!, model.currentFacility!!))
       is ScheduledAppointment -> dispatch(TriggerSync(event.sheetOpenedFrom))
@@ -51,6 +51,14 @@ class PatientSummaryUpdate : Update<PatientSummaryModel, PatientSummaryEvent, Pa
       is MedicalOfficersLoaded -> next(model.medicalOfficersLoaded(event.medicalOfficers))
       ChangeAssignedFacilityClicked -> dispatch(OpenSelectFacilitySheet)
       is NewAssignedFacilitySelected -> dispatch(DispatchNewAssignedFacility(event.facility))
+    }
+  }
+
+  private fun doneClicked(model: PatientSummaryModel): Next<PatientSummaryModel, PatientSummaryEffect> {
+    return if (model.hasPatientDied) {
+      dispatch(GoToHomeScreen)
+    } else {
+      noChange()
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
@@ -23,7 +23,7 @@ class PatientSummaryUpdate : Update<PatientSummaryModel, PatientSummaryEvent, Pa
   ): Next<PatientSummaryModel, PatientSummaryEffect> {
     return when (event) {
       is PatientSummaryProfileLoaded -> patientSummaryProfileLoaded(model, event)
-      is PatientSummaryBackClicked -> dispatch(LoadDataForBackClick(model.patientUuid, event.screenCreatedTimestamp))
+      is PatientSummaryBackClicked -> backClicked()
       is PatientSummaryDoneClicked -> dispatch(LoadDataForDoneClick(model.patientUuid))
       is CurrentUserAndFacilityLoaded -> currentUserAndFacilityLoaded(model, event)
       PatientSummaryEditClicked -> dispatch(HandleEditClick(model.patientSummaryProfile!!, model.currentFacility!!))
@@ -51,6 +51,14 @@ class PatientSummaryUpdate : Update<PatientSummaryModel, PatientSummaryEvent, Pa
       is MedicalOfficersLoaded -> next(model.medicalOfficersLoaded(event.medicalOfficers))
       ChangeAssignedFacilityClicked -> dispatch(OpenSelectFacilitySheet)
       is NewAssignedFacilitySelected -> dispatch(DispatchNewAssignedFacility(event.facility))
+    }
+  }
+
+  private fun backClicked(model: PatientSummaryModel): Next<PatientSummaryModel, PatientSummaryEffect> {
+    return if (model.hasPatientDied) {
+      dispatch(GoBackToPreviousScreen)
+    } else {
+      noChange()
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
@@ -23,7 +23,7 @@ class PatientSummaryUpdate : Update<PatientSummaryModel, PatientSummaryEvent, Pa
   ): Next<PatientSummaryModel, PatientSummaryEffect> {
     return when (event) {
       is PatientSummaryProfileLoaded -> patientSummaryProfileLoaded(model, event)
-      is PatientSummaryBackClicked -> backClicked()
+      is PatientSummaryBackClicked -> backClicked(model, event)
       is PatientSummaryDoneClicked -> dispatch(LoadDataForDoneClick(model.patientUuid))
       is CurrentUserAndFacilityLoaded -> currentUserAndFacilityLoaded(model, event)
       PatientSummaryEditClicked -> dispatch(HandleEditClick(model.patientSummaryProfile!!, model.currentFacility!!))
@@ -54,12 +54,13 @@ class PatientSummaryUpdate : Update<PatientSummaryModel, PatientSummaryEvent, Pa
     }
   }
 
-  private fun backClicked(model: PatientSummaryModel): Next<PatientSummaryModel, PatientSummaryEffect> {
-    return if (model.hasPatientDied) {
-      dispatch(GoBackToPreviousScreen)
-    } else {
-      noChange()
-    }
+  private fun backClicked(model: PatientSummaryModel, event: PatientSummaryBackClicked): Next<PatientSummaryModel, PatientSummaryEffect> {
+    val effect = if (model.hasPatientDied)
+      GoBackToPreviousScreen
+    else
+      LoadDataForBackClick(event.patientUuid, event.screenCreatedTimestamp)
+
+    return dispatch(effect)
   }
 
   private fun patientSummaryProfileLoaded(

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
@@ -24,7 +24,7 @@ class PatientSummaryUpdate : Update<PatientSummaryModel, PatientSummaryEvent, Pa
     return when (event) {
       is PatientSummaryProfileLoaded -> patientSummaryProfileLoaded(model, event)
       is PatientSummaryBackClicked -> backClicked(model, event)
-      is PatientSummaryDoneClicked -> doneClicked()
+      is PatientSummaryDoneClicked -> doneClicked(model, event)
       is CurrentUserAndFacilityLoaded -> currentUserAndFacilityLoaded(model, event)
       PatientSummaryEditClicked -> dispatch(HandleEditClick(model.patientSummaryProfile!!, model.currentFacility!!))
       is ScheduledAppointment -> dispatch(TriggerSync(event.sheetOpenedFrom))
@@ -54,12 +54,13 @@ class PatientSummaryUpdate : Update<PatientSummaryModel, PatientSummaryEvent, Pa
     }
   }
 
-  private fun doneClicked(model: PatientSummaryModel): Next<PatientSummaryModel, PatientSummaryEffect> {
-    return if (model.hasPatientDied) {
-      dispatch(GoToHomeScreen)
-    } else {
-      noChange()
-    }
+  private fun doneClicked(model: PatientSummaryModel, event: PatientSummaryDoneClicked): Next<PatientSummaryModel, PatientSummaryEffect> {
+    val effect = if (model.hasPatientDied)
+      GoToHomeScreen
+    else
+      LoadDataForDoneClick(event.patientUuid)
+
+    return dispatch(effect)
   }
 
   private fun backClicked(model: PatientSummaryModel, event: PatientSummaryBackClicked): Next<PatientSummaryModel, PatientSummaryEffect> {

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
@@ -950,6 +950,21 @@ class PatientSummaryUpdateTest {
         ))
   }
 
+  @Test
+  fun `when back is clicked and patient is not dead, then load data for back click`() {
+    val model = defaultModel
+        .currentFacilityLoaded(facility)
+        .patientSummaryProfileLoaded(patientSummaryProfile)
+
+    updateSpec
+        .given(model)
+        .whenEvent(PatientSummaryBackClicked(patientUuid, Instant.parse("2018-01-01T00:00:00Z")))
+        .then(assertThatNext(
+            hasNoModel(),
+            hasEffects(LoadDataForBackClick(patientUuid, Instant.parse("2018-01-01T00:00:00Z")))
+        ))
+  }
+
   private fun PatientSummaryModel.forExistingPatient(): PatientSummaryModel {
     return copy(openIntention = ViewExistingPatient)
   }

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
@@ -965,6 +965,36 @@ class PatientSummaryUpdateTest {
         ))
   }
 
+  @Test
+  fun `when done is clicked and patient is dead, then go back to previous screen`() {
+    val patientUuid = UUID.fromString("c28e15d1-c83c-4d07-a839-b978e4482f30")
+    val patient = TestData.patient(
+        uuid = patientUuid,
+        status = PatientStatus.Dead
+    )
+
+    val patientSummaryProfile = PatientSummaryProfile(
+        patient = patient,
+        address = patientAddress,
+        phoneNumber = phoneNumber,
+        bpPassport = bpPassport,
+        alternativeId = bangladeshNationalId,
+        facility = facility
+    )
+
+    val model = defaultModel
+        .currentFacilityLoaded(facility)
+        .patientSummaryProfileLoaded(patientSummaryProfile)
+
+    updateSpec
+        .given(model)
+        .whenEvent(PatientSummaryDoneClicked(patientUuid))
+        .then(assertThatNext(
+            hasNoModel(),
+            hasEffects(GoToHomeScreen)
+        ))
+  }
+
   private fun PatientSummaryModel.forExistingPatient(): PatientSummaryModel {
     return copy(openIntention = ViewExistingPatient)
   }

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
@@ -12,6 +12,7 @@ import org.simple.clinic.facility.FacilityConfig
 import org.simple.clinic.medicalhistory.Answer.No
 import org.simple.clinic.medicalhistory.Answer.Unanswered
 import org.simple.clinic.medicalhistory.Answer.Yes
+import org.simple.clinic.patient.PatientStatus
 import org.simple.clinic.patient.businessid.Identifier
 import org.simple.clinic.patient.businessid.Identifier.IdentifierType.BangladeshNationalId
 import org.simple.clinic.patient.businessid.Identifier.IdentifierType.BpPassport
@@ -20,6 +21,7 @@ import org.simple.clinic.summary.AppointmentSheetOpenedFrom.DONE_CLICK
 import org.simple.clinic.summary.OpenIntention.LinkIdWithPatient
 import org.simple.clinic.summary.OpenIntention.ViewExistingPatient
 import org.simple.clinic.summary.OpenIntention.ViewNewPatient
+import java.time.Instant
 import java.util.UUID
 
 class PatientSummaryUpdateTest {
@@ -27,7 +29,7 @@ class PatientSummaryUpdateTest {
   private val patientUuid = UUID.fromString("93a131b0-890e-41a3-88ec-b35b48efc6c5")
   private val defaultModel = PatientSummaryModel.from(ViewExistingPatient, patientUuid)
 
-  private val patient = TestData.patient(patientUuid)
+  private val patient = TestData.patient(patientUuid, status = PatientStatus.Active)
   private val patientAddress = TestData.patientAddress(patient.addressUuid)
   private val phoneNumber = TestData.patientPhoneNumber(patientUuid = patientUuid)
   private val bpPassportIdentifier = Identifier("526 780", BpPassport)
@@ -915,6 +917,36 @@ class PatientSummaryUpdateTest {
         .then(assertThatNext(
             hasNoModel(),
             hasEffects(DispatchNewAssignedFacility(facilityWithDiabetesManagementEnabled))
+        ))
+  }
+
+  @Test
+  fun `when back is clicked and patient is dead, then go back to previous screen`() {
+    val patientUuid = UUID.fromString("c28e15d1-c83c-4d07-a839-b978e4482f30")
+    val patient = TestData.patient(
+        uuid = patientUuid,
+        status = PatientStatus.Dead
+    )
+
+    val patientSummaryProfile = PatientSummaryProfile(
+        patient = patient,
+        address = patientAddress,
+        phoneNumber = phoneNumber,
+        bpPassport = bpPassport,
+        alternativeId = bangladeshNationalId,
+        facility = facility
+    )
+
+    val model = defaultModel
+        .currentFacilityLoaded(facility)
+        .patientSummaryProfileLoaded(patientSummaryProfile)
+
+    updateSpec
+        .given(model)
+        .whenEvent(PatientSummaryBackClicked(patientUuid, Instant.parse("2018-01-01T00:00:00Z")))
+        .then(assertThatNext(
+            hasNoModel(),
+            hasEffects(GoBackToPreviousScreen)
         ))
   }
 

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
@@ -995,6 +995,21 @@ class PatientSummaryUpdateTest {
         ))
   }
 
+  @Test
+  fun `when done is clicked and patient is not dead, then load data for done click`() {
+    val model = defaultModel
+        .currentFacilityLoaded(facility)
+        .patientSummaryProfileLoaded(patientSummaryProfile)
+
+    updateSpec
+        .given(model)
+        .whenEvent(PatientSummaryDoneClicked(patientUuid))
+        .then(assertThatNext(
+            hasNoModel(),
+            hasEffects(LoadDataForDoneClick(patientUuid))
+        ))
+  }
+
   private fun PatientSummaryModel.forExistingPatient(): PatientSummaryModel {
     return copy(openIntention = ViewExistingPatient)
   }


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/5098/go-back-to-the-previous-screen-when-done-back-is-clicked-in-the-patient-summary-screen-when-the-patient-is-marked-as-dead