### PR TITLE
Handle `ShowKeyboard` as a Ui Action instead of rendering it in the `UiRenderer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Remove overdue list changes feature flag
 - Implement providing drug frequencies label depending on the country in `DrugSearchScreen`
 - Add progress state in the save button when the drug is being added/updated in `CustomDrugEntrySheet` 
+- Handle `ShowKeyboard` as a Ui Action instead of rendering it in the `UiRenderer` 
 - [In Progress: 16 Sep 2021] Record call results instead of updating the same appointment record
 - [In Progress: 31 Aug 2021] Refactor logic around providing drug frequencies label depending on the country
 - [In Progress: 2 Sep 2021] Add a progress state in `CustomDrugEntrySheet`

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffect.kt
@@ -43,3 +43,5 @@ data class RemoveDrugFromPrescription(val drugUuid: UUID) : CustomDrugEntryEffec
 object LoadDrugFrequencyChoiceItems : CustomDrugEntryEffect()
 
 object HideKeyboard : CustomDrugEntryEffect()
+
+object ShowKeyboard : CustomDrugEntryEffect()

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandler.kt
@@ -47,6 +47,7 @@ class CustomDrugEntryEffectHandler @AssistedInject constructor(
         .addTransformer(RemoveDrugFromPrescription::class.java, removeDrugFromPrescription())
         .addTransformer(LoadDrugFrequencyChoiceItems::class.java, loadDrugFrequencyChoiceItems())
         .addAction(HideKeyboard::class.java, uiActions::hideKeyboard, schedulersProvider.ui())
+        .addAction(ShowKeyboard::class.java, uiActions::showKeyboard, schedulersProvider.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntrySheetUiActions.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntrySheetUiActions.kt
@@ -13,4 +13,5 @@ interface CustomDrugEntrySheetUiActions {
   fun setDrugDosage(dosage: String?)
   fun closeSheetAndGoToEditMedicineScreen()
   fun hideKeyboard()
+  fun showKeyboard()
 }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUi.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUi.kt
@@ -12,6 +12,5 @@ interface CustomDrugEntryUi {
   fun hideCustomDrugEntryUi()
   fun hideProgressBar()
   fun showCustomDrugEntryUi()
-  fun showKeyboard()
   fun showSaveButtonProgressState()
 }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUiRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUiRenderer.kt
@@ -14,7 +14,6 @@ class CustomDrugEntryUiRenderer(
     } else {
       ui.hideProgressBar()
       ui.showCustomDrugEntryUi()
-      ui.showKeyboard()
 
       initialSetup(model.openAs)
 

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
@@ -53,7 +53,7 @@ class CustomDrugEntryUpdate : Update<CustomDrugEntryModel, CustomDrugEntryEvent,
         .rxNormCodeEdited(drug.rxNormCode)
         .drugInfoProgressStateLoaded()
 
-    return next(updatedModel, SetDrugFrequency(model.drugFrequencyToFrequencyChoiceItemMap!![drug.frequency]!!.label), SetDrugDosage(drug.dosage))
+    return next(updatedModel, SetDrugFrequency(model.drugFrequencyToFrequencyChoiceItemMap!![drug.frequency]!!.label), SetDrugDosage(drug.dosage), ShowKeyboard)
   }
 
   private fun prescriptionFetched(

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
@@ -69,7 +69,7 @@ class CustomDrugEntryUpdate : Update<CustomDrugEntryModel, CustomDrugEntryEvent,
         .rxNormCodeEdited(prescription.rxNormCode)
         .drugInfoProgressStateLoaded()
 
-    return next(updatedModel, SetDrugFrequency(model.drugFrequencyToFrequencyChoiceItemMap!![frequency]!!.label), SetDrugDosage(prescription.dosage))
+    return next(updatedModel, SetDrugFrequency(model.drugFrequencyToFrequencyChoiceItemMap!![frequency]!!.label), SetDrugDosage(prescription.dosage), ShowKeyboard)
   }
 
   private fun createOrUpdatePrescriptionEntry(

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandlerTest.kt
@@ -248,4 +248,15 @@ class CustomDrugEntryEffectHandlerTest {
     verify(uiActions).hideKeyboard()
     verifyNoMoreInteractions(uiActions)
   }
+
+  @Test
+  fun `when show keyboard effect is received, then show keyboard`() {
+    // when
+    testCase.dispatch(ShowKeyboard)
+
+    // then
+    testCase.assertNoOutgoingEvents()
+    verify(uiActions).showKeyboard()
+    verifyNoMoreInteractions(uiActions)
+  }
 }

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUiRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUiRendererTest.kt
@@ -47,7 +47,6 @@ class CustomDrugEntryUiRendererTest {
     verify(ui).setSheetTitle(drugName, null, frequencyLabel)
     verify(ui).hideProgressBar()
     verify(ui).showCustomDrugEntryUi()
-    verify(ui).showKeyboard()
     verifyNoMoreInteractions(ui)
   }
 
@@ -72,7 +71,6 @@ class CustomDrugEntryUiRendererTest {
     verify(ui).setSheetTitle(drugName, dosageText, frequencyLabel)
     verify(ui).hideProgressBar()
     verify(ui).showCustomDrugEntryUi()
-    verify(ui).showKeyboard()
     verifyNoMoreInteractions(ui)
   }
 
@@ -95,7 +93,6 @@ class CustomDrugEntryUiRendererTest {
     verify(ui).setSheetTitle(null, null, frequencyLabel)
     verify(ui).hideProgressBar()
     verify(ui).showCustomDrugEntryUi()
-    verify(ui).showKeyboard()
     verifyNoMoreInteractions(ui)
   }
 
@@ -114,7 +111,6 @@ class CustomDrugEntryUiRendererTest {
     verify(ui).setSheetTitle(drugName, drugDosage, frequencyLabel)
     verify(ui).hideProgressBar()
     verify(ui).showCustomDrugEntryUi()
-    verify(ui).showKeyboard()
     verifyNoMoreInteractions(ui)
   }
 
@@ -142,7 +138,6 @@ class CustomDrugEntryUiRendererTest {
     verify(ui).showCustomDrugEntryUi()
     verify(ui).hideRemoveButton()
     verify(ui).setButtonTextAsAdd()
-    verify(ui).showKeyboard()
     verify(ui).setSheetTitle(null, null, frequencyLabel)
     verifyNoMoreInteractions(ui)
   }
@@ -161,7 +156,6 @@ class CustomDrugEntryUiRendererTest {
     verify(ui).showCustomDrugEntryUi()
     verify(ui).hideRemoveButton()
     verify(ui).setButtonTextAsAdd()
-    verify(ui).showKeyboard()
     verify(ui).setSheetTitle(null, null, frequencyLabel)
     verify(ui).showSaveButtonProgressState()
     verifyNoMoreInteractions(ui)

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
@@ -183,7 +183,7 @@ class CustomDrugEntryUpdateTest {
   }
 
   @Test
-  fun `when the drug is fetched and is not deleted, then update the model, set frequency and update the progress state to done`() {
+  fun `when the drug is fetched and is not deleted, then update the model, set frequency and show keyboard`() {
     val prescribedDrugUuid = UUID.fromString("96633994-6e4d-4528-b796-f03ae016553a")
     val drugFrequency = OD
     val dosage = "12mg"
@@ -204,7 +204,7 @@ class CustomDrugEntryUpdateTest {
                     .frequencyEdited(frequency = drugFrequency)
                     .rxNormCodeEdited(prescribedDrug.rxNormCode)
                     .drugInfoProgressStateLoaded()),
-                hasEffects(SetDrugFrequency(frequencyRes), SetDrugDosage(dosage)))
+                hasEffects(SetDrugFrequency(frequencyRes), SetDrugDosage(dosage), ShowKeyboard))
         )
   }
 

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
@@ -234,7 +234,7 @@ class CustomDrugEntryUpdateTest {
   }
 
   @Test
-  fun `when drug is fetched, then update the model with drug values, set drug frequency, dosage and update the progress state to done`() {
+  fun `when drug is fetched, then update the model with drug values, set drug frequency, dosage and show keyboard`() {
     val drugUuid = UUID.fromString("6bbc5bbe-863c-472a-b962-1fd3198e20d1")
     val drug = TestData.drug(id = drugUuid, frequency = OD)
     val frequencyRes = "OD"
@@ -251,7 +251,7 @@ class CustomDrugEntryUpdateTest {
                     .frequencyEdited(drug.frequency)
                     .rxNormCodeEdited(drug.rxNormCode)
                     .drugInfoProgressStateLoaded()),
-                hasEffects(SetDrugFrequency(frequencyRes), SetDrugDosage(drug.dosage))
+                hasEffects(SetDrugFrequency(frequencyRes), SetDrugDosage(drug.dosage), ShowKeyboard)
             )
         )
   }


### PR DESCRIPTION
This change is made because show keyboard method was getting invoked every time there was a model change. 

From [this](https://github.com/simpledotorg/simple-android/pull/3131#discussion_r708772528) PR comment

