### PR TITLE
Custom Drug Entry Sheet UI Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Record call results instead of updating the same appointment record
 - Fix `Country` v2 migration not running
 - Convert commit and push bash script to Kotlin script
+- [In Progress: 22 Sep 2021] Custom Drug Entry Sheet UI Improvements
 - [In Progress: 31 Aug 2021] Refactor logic around providing drug frequencies label depending on the country
 - [In Progress: 2 Sep 2021] Add a progress state in `CustomDrugEntrySheet`
 

--- a/app/src/main/java/org/simple/clinic/drugs/selection/DrugListItem.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/DrugListItem.kt
@@ -45,9 +45,8 @@ data class ProtocolDrugListItem(
     viewBinding.protocoldrugItemName.isChecked = prescribedDrug != null
 
     viewBinding.protocoldrugItemDosageAndFrequency.visibleOrGone(prescribedDrug != null)
-    val medicineFrequency = if (prescribedDrug?.frequency == null) "" else medicineFrequencyToLabelMap[prescribedDrug.frequency]!!.label
-    val dosage = if(prescribedDrug?.dosage == null) "" else prescribedDrug.dosage
-    val dosageAndFrequency = "$dosage, $medicineFrequency"
+    val medicineFrequency = if (prescribedDrug?.frequency == null) null else medicineFrequencyToLabelMap[prescribedDrug.frequency]!!.label
+    val dosageAndFrequency = listOfNotNull(prescribedDrug?.dosage, medicineFrequency).joinToString()
     viewBinding.protocoldrugItemDosageAndFrequency.text = dosageAndFrequency
 
     viewBinding.prescribeddrugItemProtocoldrugRootlayout.shapeAppearanceModel = shapeAppearanceModel(hasTopCorners)
@@ -76,9 +75,8 @@ data class CustomPrescribedDrugListItem(
     viewBinding.prescribeddrugItemCustomdrugName.text = prescribedDrug.name
     viewBinding.prescribeddrugItemCustomdrugName.isChecked = true
 
-    val medicineFrequency = if (prescribedDrug.frequency == null) "" else medicineFrequencyToLabelMap[prescribedDrug.frequency]!!.label
-    val dosage = prescribedDrug.dosage
-    val dosageAndFrequency = "$dosage, $medicineFrequency"
+    val medicineFrequency = if (prescribedDrug.frequency == null) null else medicineFrequencyToLabelMap[prescribedDrug.frequency]!!.label
+    val dosageAndFrequency = listOfNotNull(prescribedDrug.dosage, medicineFrequency).joinToString()
     viewBinding.protocoldrugItemDosageAndFrequency.text = dosageAndFrequency
 
     viewBinding.root.setOnClickListener {

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffect.kt
@@ -41,3 +41,5 @@ object LoadDrugFrequencyChoiceItems : CustomDrugEntryEffect()
 object HideKeyboard : CustomDrugEntryEffect()
 
 object ShowKeyboard : CustomDrugEntryEffect()
+
+object ClearFocusFromDosageEditText : CustomDrugEntryEffect()

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandler.kt
@@ -48,6 +48,7 @@ class CustomDrugEntryEffectHandler @AssistedInject constructor(
         .addTransformer(LoadDrugFrequencyChoiceItems::class.java, loadDrugFrequencyChoiceItems())
         .addAction(HideKeyboard::class.java, uiActions::hideKeyboard, schedulersProvider.ui())
         .addAction(ShowKeyboard::class.java, uiActions::showKeyboard, schedulersProvider.ui())
+        .addAction(ClearFocusFromDosageEditText::class.java, uiActions::clearFocusFromDosageEditText, schedulersProvider.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntrySheet.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntrySheet.kt
@@ -194,6 +194,10 @@ class CustomDrugEntrySheet : BaseBottomSheet<
     drugDosageEditText.showKeyboard()
   }
 
+  override fun clearFocusFromDosageEditText() {
+    drugDosageEditText.clearFocus()
+  }
+
   override fun showSaveButtonProgressState() {
     saveButton.setButtonState(InProgress)
   }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntrySheetUiActions.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntrySheetUiActions.kt
@@ -9,4 +9,5 @@ interface CustomDrugEntrySheetUiActions {
   fun closeSheetAndGoToEditMedicineScreen()
   fun hideKeyboard()
   fun showKeyboard()
+  fun clearFocusFromDosageEditText()
 }

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUi.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUi.kt
@@ -7,7 +7,7 @@ interface CustomDrugEntryUi {
   fun hideRemoveButton()
   fun setButtonTextAsSave()
   fun setButtonTextAsAdd()
-  fun setSheetTitle(drugName: String?, dosage: String?, frequencyLabelResID: String)
+  fun setSheetTitle(drugName: String?, dosage: String?, frequencyLabel: String)
   fun showProgressBar()
   fun hideCustomDrugEntryUi()
   fun hideProgressBar()

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
@@ -19,7 +19,7 @@ class CustomDrugEntryUpdate : Update<CustomDrugEntryModel, CustomDrugEntryEvent,
     return when (event) {
       is DosageEdited -> next(model.dosageEdited(event.dosage))
       is DosageFocusChanged -> next(model.dosageFocusChanged(event.hasFocus))
-      is EditFrequencyClicked -> dispatch(ShowEditFrequencyDialog(model.frequency))
+      is EditFrequencyClicked -> dispatch(ShowEditFrequencyDialog(model.frequency), ClearFocusFromDosageEditText)
       is FrequencyEdited -> next(model.frequencyEdited(event.frequency), SetDrugFrequency(model.drugFrequencyToLabelMap!![event.frequency]!!.label))
       is AddMedicineButtonClicked -> createOrUpdatePrescriptionEntry(model, event.patientUuid)
       is CustomDrugSaved, ExistingDrugRemoved -> dispatch(CloseSheetAndGoToEditMedicineScreen)

--- a/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdate.kt
@@ -75,10 +75,13 @@ class CustomDrugEntryUpdate : Update<CustomDrugEntryModel, CustomDrugEntryEvent,
       model: CustomDrugEntryModel,
       patientUuid: UUID
   ): Next<CustomDrugEntryModel, CustomDrugEntryEffect> {
+    val isAValidDosage = model.dosage != null && model.dosage.filter { it.isDigit() }.isNotBlank()
+    val dosage = if (isAValidDosage) model.dosage else null
+
     val effect = when (model.openAs) {
-      is OpenAs.New.FromDrugList -> SaveCustomDrugToPrescription(patientUuid, model.drugName!!, model.dosage, model.rxNormCode, model.frequency)
-      is OpenAs.New.FromDrugName -> SaveCustomDrugToPrescription(patientUuid, model.openAs.drugName, model.dosage, null, model.frequency)
-      is OpenAs.Update -> UpdatePrescription(patientUuid, model.openAs.prescribedDrugUuid, model.drugName!!, model.dosage, model.rxNormCode, model.frequency)
+      is OpenAs.New.FromDrugList -> SaveCustomDrugToPrescription(patientUuid, model.drugName!!, dosage, model.rxNormCode, model.frequency)
+      is OpenAs.New.FromDrugName -> SaveCustomDrugToPrescription(patientUuid, model.openAs.drugName, dosage, null, model.frequency)
+      is OpenAs.Update -> UpdatePrescription(patientUuid, model.openAs.prescribedDrugUuid, model.drugName!!, dosage, model.rxNormCode, model.frequency)
     }
 
     return next(model.saveButtonStateChanged(SAVING), effect)

--- a/app/src/main/res/layout/sheet_custom_drug_entry.xml
+++ b/app/src/main/res/layout/sheet_custom_drug_entry.xml
@@ -76,8 +76,7 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:hint="@string/custom_drug_entry_sheet_dosage"
-      android:imeOptions="actionNext"
-      android:inputType="number" />
+      android:imeOptions="actionNext" />
 
   </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryEffectHandlerTest.kt
@@ -254,4 +254,15 @@ class CustomDrugEntryEffectHandlerTest {
     verify(uiActions).showKeyboard()
     verifyNoMoreInteractions(uiActions)
   }
+
+  @Test
+  fun `when clear focus from edit text effect is received, then clear focus from edit text`() {
+    // when
+    testCase.dispatch(ClearFocusFromDosageEditText)
+
+    // then
+    testCase.assertNoOutgoingEvents()
+    verify(uiActions).clearFocusFromDosageEditText()
+    verifyNoMoreInteractions(uiActions)
+  }
 }

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
@@ -61,13 +61,13 @@ class CustomDrugEntryUpdateTest {
   }
 
   @Test
-  fun `when edit frequency is clicked, then show edit frequency dialog and pass drug frequency choice list`() {
+  fun `when edit frequency is clicked, then show edit frequency dialog and clear focus from dosage edit text`() {
     val frequency = OD
     updateSpec.given(defaultModel.frequencyEdited(frequency).drugFrequencyToLabelMapLoaded(drugFrequencyToLabelMap))
         .whenEvent(EditFrequencyClicked)
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowEditFrequencyDialog(frequency))
+            hasEffects(ShowEditFrequencyDialog(frequency), ClearFocusFromDosageEditText)
         ))
   }
 

--- a/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/drugs/selection/custom/CustomDrugEntryUpdateTest.kt
@@ -141,8 +141,8 @@ class CustomDrugEntryUpdateTest {
   }
 
   @Test
-  fun `when save button is clicked, then update the prescription in the repository and set button progress state to saving`() {
-    val dosage = "200 mg"
+  fun `when save button is clicked and dosage is invalid, then update the prescription in the repository without the dosage and set button progress state to saving`() {
+    val dosage = "mg"
     val frequency = OD
     val prescribedDrugUuid = UUID.fromString("96633994-6e4d-4528-b796-f03ae016553a")
     val model = CustomDrugEntryModel
@@ -157,7 +157,7 @@ class CustomDrugEntryUpdateTest {
         .then(
             assertThatNext(
                 hasModel(model.saveButtonStateChanged(SAVING)),
-                hasEffects(UpdatePrescription(patientUuid, prescribedDrugUuid, drugName, dosage, null, frequency))
+                hasEffects(UpdatePrescription(patientUuid, prescribedDrugUuid, drugName, null, null, frequency))
             )
         )
   }


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/5046/custom-drug-entry-sheet-ui-improvements


This PR:
- Removes the focus from dosage when user clicks on frequency
- Saves `null` in the repository if dosage edit text value is equal to "mg"
- Changes from numeric keyboard to the default keyboard for drug dosage edit text
- Uses `joinToString` to correctly display dosage and frequency values in `EditMedicineScreen`

Next PR:
- Make the cursor appear right before 'mg' whenever the sheet is opened