### PR TITLE
Replace the entire screen history in `TheActivityUpdate` instead of loading a single screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Enable custom drug search feature
 - Enable placeholders in overdue screen
 - Use overdue list count to display the count in the tab bar
+- Change `TheActivity` to load the entire screen history instead of a single screen key
 
 ### Changes
 

--- a/app/src/main/java/org/simple/clinic/main/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivity.kt
@@ -30,7 +30,6 @@ import org.simple.clinic.login.applock.AppLockScreenKey
 import org.simple.clinic.mobius.MobiusDelegate
 import org.simple.clinic.navigation.v2.History
 import org.simple.clinic.navigation.v2.Router
-import org.simple.clinic.navigation.v2.ScreenKey
 import org.simple.clinic.navigation.v2.compat.wrap
 import org.simple.clinic.registerorlogin.AuthenticationActivity
 import org.simple.clinic.remoteconfig.UpdateRemoteConfigWorker
@@ -298,10 +297,6 @@ class TheActivity : AppCompatActivity(), TheActivityUi {
 
   override fun showAccessDeniedScreen(fullName: String) {
     router.clearHistoryAndPush(AccessDeniedScreenKey(fullName))
-  }
-
-  override fun showInitialScreen(screenKey: ScreenKey) {
-    router.clearHistoryAndPush(screenKey)
   }
 
   override fun setCurrentScreenHistory(newHistory: History) {

--- a/app/src/main/java/org/simple/clinic/main/TheActivity.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivity.kt
@@ -28,6 +28,7 @@ import org.simple.clinic.home.patients.LoggedOutOnOtherDeviceDialog
 import org.simple.clinic.login.applock.AppLockConfig
 import org.simple.clinic.login.applock.AppLockScreenKey
 import org.simple.clinic.mobius.MobiusDelegate
+import org.simple.clinic.navigation.v2.History
 import org.simple.clinic.navigation.v2.Router
 import org.simple.clinic.navigation.v2.ScreenKey
 import org.simple.clinic.navigation.v2.compat.wrap
@@ -301,5 +302,9 @@ class TheActivity : AppCompatActivity(), TheActivityUi {
 
   override fun showInitialScreen(screenKey: ScreenKey) {
     router.clearHistoryAndPush(screenKey)
+  }
+
+  override fun setCurrentScreenHistory(newHistory: History) {
+    router.replaceHistory(newHistory)
   }
 }

--- a/app/src/main/java/org/simple/clinic/main/TheActivityEffect.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityEffect.kt
@@ -1,7 +1,6 @@
 package org.simple.clinic.main
 
 import org.simple.clinic.navigation.v2.History
-import org.simple.clinic.navigation.v2.ScreenKey
 
 sealed class TheActivityEffect
 
@@ -22,7 +21,5 @@ object ListenForUserDisapprovals : TheActivityEffect()
 object ClearPatientData : TheActivityEffect()
 
 object ShowAccessDeniedScreen : TheActivityEffect()
-
-data class ShowInitialScreen(val screen: ScreenKey) : TheActivityEffect()
 
 data class SetCurrentScreenHistory(val history: History) : TheActivityEffect()

--- a/app/src/main/java/org/simple/clinic/main/TheActivityEffect.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityEffect.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.main
 
+import org.simple.clinic.navigation.v2.History
 import org.simple.clinic.navigation.v2.ScreenKey
 
 sealed class TheActivityEffect
@@ -23,3 +24,5 @@ object ClearPatientData : TheActivityEffect()
 object ShowAccessDeniedScreen : TheActivityEffect()
 
 data class ShowInitialScreen(val screen: ScreenKey) : TheActivityEffect()
+
+data class SetCurrentScreenHistory(val history: History) : TheActivityEffect()

--- a/app/src/main/java/org/simple/clinic/main/TheActivityEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityEffectHandler.kt
@@ -42,7 +42,6 @@ class TheActivityEffectHandler @AssistedInject constructor(
         .addTransformer(ListenForUserDisapprovals::class.java, listenForUserDisapprovals())
         .addTransformer(ClearPatientData::class.java, clearPatientData())
         .addTransformer(ShowAccessDeniedScreen::class.java, openAccessDeniedScreen())
-        .addConsumer(ShowInitialScreen::class.java, { uiActions.showInitialScreen(it.screen) }, schedulers.ui())
         .addConsumer(SetCurrentScreenHistory::class.java, { uiActions.setCurrentScreenHistory(it.history) }, schedulers.ui())
         .build()
   }

--- a/app/src/main/java/org/simple/clinic/main/TheActivityEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityEffectHandler.kt
@@ -43,6 +43,7 @@ class TheActivityEffectHandler @AssistedInject constructor(
         .addTransformer(ClearPatientData::class.java, clearPatientData())
         .addTransformer(ShowAccessDeniedScreen::class.java, openAccessDeniedScreen())
         .addConsumer(ShowInitialScreen::class.java, { uiActions.showInitialScreen(it.screen) }, schedulers.ui())
+        .addConsumer(SetCurrentScreenHistory::class.java, { uiActions.setCurrentScreenHistory(it.history) }, schedulers.ui())
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/main/TheActivityUiActions.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityUiActions.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.main
 
+import org.simple.clinic.navigation.v2.History
 import org.simple.clinic.navigation.v2.ScreenKey
 
 interface TheActivityUiActions {
@@ -9,4 +10,5 @@ interface TheActivityUiActions {
   fun redirectToLogin()
   fun showAccessDeniedScreen(fullName: String)
   fun showInitialScreen(screenKey: ScreenKey)
+  fun setCurrentScreenHistory(newHistory: History)
 }

--- a/app/src/main/java/org/simple/clinic/main/TheActivityUiActions.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityUiActions.kt
@@ -1,7 +1,6 @@
 package org.simple.clinic.main
 
 import org.simple.clinic.navigation.v2.History
-import org.simple.clinic.navigation.v2.ScreenKey
 
 interface TheActivityUiActions {
   // This is here because we need to show the same alert in multiple
@@ -9,6 +8,5 @@ interface TheActivityUiActions {
   fun showUserLoggedOutOnOtherDeviceAlert()
   fun redirectToLogin()
   fun showAccessDeniedScreen(fullName: String)
-  fun showInitialScreen(screenKey: ScreenKey)
   fun setCurrentScreenHistory(newHistory: History)
 }

--- a/app/src/main/java/org/simple/clinic/main/TheActivityUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/main/TheActivityUpdate.kt
@@ -7,6 +7,8 @@ import org.simple.clinic.forgotpin.createnewpin.ForgotPinCreateNewPinScreenKey
 import org.simple.clinic.home.HomeScreenKey
 import org.simple.clinic.login.applock.AppLockScreenKey
 import org.simple.clinic.mobius.dispatch
+import org.simple.clinic.navigation.v2.History
+import org.simple.clinic.navigation.v2.Normal
 import org.simple.clinic.navigation.v2.compat.wrap
 import org.simple.clinic.user.User
 import org.simple.clinic.user.User.LoggedInStatus.LOGGED_IN
@@ -67,10 +69,14 @@ class TheActivityUpdate : Update<TheActivityModel, TheActivityEvent, TheActivity
       else -> throw IllegalStateException("Unknown user status combinations: [${user.loggedInStatus}, ${user.status}]")
     }
 
-    return if (shouldShowAppLockScreen && !model.isFreshLogin)
-      dispatch(ShowInitialScreen(AppLockScreenKey(initialScreen)))
-    else
-      dispatch(ShowInitialScreen(initialScreen), ClearLockAfterTimestamp)
+    return if (shouldShowAppLockScreen && !model.isFreshLogin) {
+      val newHistory = History(listOf(Normal(AppLockScreenKey(initialScreen))))
+      dispatch(SetCurrentScreenHistory(newHistory))
+    }
+    else {
+      val newHistory = History(listOf(Normal(initialScreen)))
+      dispatch(SetCurrentScreenHistory(newHistory), ClearLockAfterTimestamp)
+    }
   }
 
   private fun shouldShowAppLockScreenForUser(

--- a/app/src/main/java/org/simple/clinic/navigation/v2/Router.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/Router.kt
@@ -103,6 +103,10 @@ class Router(
     executeStateChange(newHistory, Direction.Forward, null)
   }
 
+  fun replaceHistory(newHistory: History) {
+    executeStateChange(newHistory, Direction.Replace, null)
+  }
+
   fun pop() {
     val newHistory = history.removeLast()
 

--- a/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
+++ b/app/src/test/java/org/simple/clinic/activity/TheActivityControllerTest.kt
@@ -27,6 +27,8 @@ import org.simple.clinic.main.TheActivityModel
 import org.simple.clinic.main.TheActivityUi
 import org.simple.clinic.main.TheActivityUiRenderer
 import org.simple.clinic.main.TheActivityUpdate
+import org.simple.clinic.navigation.v2.History
+import org.simple.clinic.navigation.v2.Normal
 import org.simple.clinic.navigation.v2.compat.wrap
 import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.storage.MemoryValue
@@ -87,7 +89,7 @@ class TheActivityControllerTest {
     setupController(lockAtTime = lockAfterTime)
 
     // then
-    verify(ui).showInitialScreen(AppLockScreenKey(HomeScreenKey))
+    verify(ui).setCurrentScreenHistory(History(listOf(Normal(AppLockScreenKey(HomeScreenKey)))))
     verifyNoMoreInteractions(ui)
   }
 
@@ -102,7 +104,7 @@ class TheActivityControllerTest {
     setupController(lockAtTime = lockAfterTime)
 
     // then
-    verify(ui).showInitialScreen(AppLockScreenKey(HomeScreenKey))
+    verify(ui).setCurrentScreenHistory(History(listOf(Normal(AppLockScreenKey(HomeScreenKey)))))
     verifyNoMoreInteractions(ui)
   }
 
@@ -116,7 +118,7 @@ class TheActivityControllerTest {
     setupController(lockAtTime = lockAfterTime)
 
     // then
-    verify(ui).showInitialScreen(AppLockScreenKey(HomeScreenKey))
+    verify(ui).setCurrentScreenHistory(History(listOf(Normal(AppLockScreenKey(HomeScreenKey)))))
     verifyNoMoreInteractions(ui)
   }
 
@@ -131,7 +133,7 @@ class TheActivityControllerTest {
     setupController(lockAtTime = lockAfterTime)
 
     // then
-    verify(ui).showInitialScreen(ForgotPinCreateNewPinScreenKey().wrap())
+    verify(ui).setCurrentScreenHistory(History(listOf(Normal(ForgotPinCreateNewPinScreenKey().wrap()))))
     verifyNoMoreInteractions(ui)
   }
 
@@ -150,7 +152,7 @@ class TheActivityControllerTest {
 
     // then
     assertThat(lockAfterTimestamp.hasValue).isFalse()
-    verify(ui).showInitialScreen(HomeScreenKey)
+    verify(ui).setCurrentScreenHistory(History(listOf(Normal(HomeScreenKey))))
     verifyNoMoreInteractions(ui)
   }
 
@@ -168,7 +170,7 @@ class TheActivityControllerTest {
 
     // then
     assertThat(lockAfterTimestamp.hasValue).isTrue()
-    verify(ui).showInitialScreen(AppLockScreenKey(HomeScreenKey))
+    verify(ui).setCurrentScreenHistory(History(listOf(Normal(AppLockScreenKey(HomeScreenKey)))))
     verifyNoMoreInteractions(ui)
   }
 
@@ -189,7 +191,7 @@ class TheActivityControllerTest {
     )
 
     // then
-    verify(ui).showInitialScreen(HomeScreenKey)
+    verify(ui).setCurrentScreenHistory(History(listOf(Normal(HomeScreenKey))))
     verify(ui).showUserLoggedOutOnOtherDeviceAlert()
     verifyNoMoreInteractions(ui)
   }
@@ -209,7 +211,7 @@ class TheActivityControllerTest {
     setupController()
 
     // then
-    verify(ui).showInitialScreen(AppLockScreenKey(HomeScreenKey))
+    verify(ui).setCurrentScreenHistory(History(listOf(Normal(AppLockScreenKey(HomeScreenKey)))))
     verify(ui, never()).showUserLoggedOutOnOtherDeviceAlert()
     verifyNoMoreInteractions(ui)
   }
@@ -230,7 +232,7 @@ class TheActivityControllerTest {
         lockAtTime = Instant.now(clock)
     )
     // then
-    verify(ui).showInitialScreen(HomeScreenKey)
+    verify(ui).setCurrentScreenHistory(History(listOf(Normal(HomeScreenKey))))
     verifyNoMoreInteractions(ui)
     verify(patientRepository, never()).clearPatientData()
 
@@ -253,7 +255,7 @@ class TheActivityControllerTest {
     setupController(lockAtTime = Instant.now(clock))
 
     //then
-    verify(ui).showInitialScreen(HomeScreenKey)
+    verify(ui).setCurrentScreenHistory(History(listOf(Normal(HomeScreenKey))))
     verifyNoMoreInteractions(ui)
     verify(patientRepository, never()).clearPatientData()
   }

--- a/app/src/test/java/org/simple/clinic/activity/TheActivityUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/activity/TheActivityUpdateTest.kt
@@ -12,9 +12,11 @@ import org.simple.clinic.home.HomeScreenKey
 import org.simple.clinic.login.applock.AppLockScreenKey
 import org.simple.clinic.main.ClearLockAfterTimestamp
 import org.simple.clinic.main.InitialScreenInfoLoaded
-import org.simple.clinic.main.ShowInitialScreen
+import org.simple.clinic.main.SetCurrentScreenHistory
 import org.simple.clinic.main.TheActivityModel
 import org.simple.clinic.main.TheActivityUpdate
+import org.simple.clinic.navigation.v2.History
+import org.simple.clinic.navigation.v2.Normal
 import org.simple.clinic.navigation.v2.compat.wrap
 import org.simple.clinic.user.User
 import org.simple.clinic.user.UserStatus
@@ -38,7 +40,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(HomeScreenKey), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(HomeScreenKey)))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -51,7 +53,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(HomeScreenKey), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(HomeScreenKey)))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -64,7 +66,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(HomeScreenKey), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(HomeScreenKey)))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -77,7 +79,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(HomeScreenKey), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(HomeScreenKey)))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -90,7 +92,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(HomeScreenKey), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(HomeScreenKey)))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -103,7 +105,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(HomeScreenKey), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(HomeScreenKey)))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -116,7 +118,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(HomeScreenKey), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(HomeScreenKey)))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -129,7 +131,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(HomeScreenKey), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(HomeScreenKey)))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -142,7 +144,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(ForgotPinCreateNewPinScreenKey().wrap()), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(ForgotPinCreateNewPinScreenKey().wrap())))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -155,7 +157,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(ForgotPinCreateNewPinScreenKey().wrap()), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(ForgotPinCreateNewPinScreenKey().wrap())))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -168,7 +170,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(AccessDeniedScreenKey(user.fullName)), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(AccessDeniedScreenKey(user.fullName))))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -181,7 +183,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(AccessDeniedScreenKey(user.fullName)), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(AccessDeniedScreenKey(user.fullName))))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -194,7 +196,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(AccessDeniedScreenKey(user.fullName)), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(AccessDeniedScreenKey(user.fullName))))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -207,7 +209,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(AccessDeniedScreenKey(user.fullName)), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(AccessDeniedScreenKey(user.fullName))))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -220,7 +222,7 @@ class TheActivityUpdateTest {
         .whenEvent(InitialScreenInfoLoaded(user, currentTimestamp, lockAtTime))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(AccessDeniedScreenKey(user.fullName)), ClearLockAfterTimestamp)
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(AccessDeniedScreenKey(user.fullName))))), ClearLockAfterTimestamp)
         ))
   }
 
@@ -243,7 +245,7 @@ class TheActivityUpdateTest {
         ))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(AppLockScreenKey(HomeScreenKey)))
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(AppLockScreenKey(HomeScreenKey))))))
         ))
   }
 
@@ -266,7 +268,7 @@ class TheActivityUpdateTest {
         ))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(ShowInitialScreen(HomeScreenKey))
+            hasEffects(SetCurrentScreenHistory(History(listOf(Normal(HomeScreenKey)))))
         ))
   }
 }

--- a/app/src/test/java/org/simple/clinic/main/TheActivityEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/main/TheActivityEffectHandlerTest.kt
@@ -5,8 +5,12 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import org.junit.After
 import org.junit.Test
+import org.simple.clinic.empty.EmptyScreenKey
 import org.simple.clinic.home.HomeScreenKey
 import org.simple.clinic.mobius.EffectHandlerTestCase
+import org.simple.clinic.navigation.v2.History
+import org.simple.clinic.navigation.v2.Normal
+import org.simple.clinic.navigation.v2.compat.wrap
 import org.simple.clinic.storage.MemoryValue
 import org.simple.clinic.util.TestUtcClock
 import org.simple.clinic.util.scheduler.TestSchedulersProvider
@@ -43,6 +47,23 @@ class TheActivityEffectHandlerTest {
     // then
     testCase.assertNoOutgoingEvents()
     verify(uiActions).showInitialScreen(HomeScreenKey)
+    verifyNoMoreInteractions(uiActions)
+  }
+
+  @Test
+  fun `when the set current screen history effect is received, the current screen history must be replaced`() {
+    // given
+    val history = History(listOf(
+        Normal(EmptyScreenKey().wrap()),
+        Normal(HomeScreenKey)
+    ))
+
+    // when
+    testCase.dispatch(SetCurrentScreenHistory(history))
+
+    // then
+    testCase.assertNoOutgoingEvents()
+    verify(uiActions).setCurrentScreenHistory(history)
     verifyNoMoreInteractions(uiActions)
   }
 }

--- a/app/src/test/java/org/simple/clinic/main/TheActivityEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/main/TheActivityEffectHandlerTest.kt
@@ -40,17 +40,6 @@ class TheActivityEffectHandlerTest {
   }
 
   @Test
-  fun `when the show initial screen effect is received, the initial screen must be shown`() {
-    // when
-    testCase.dispatch(ShowInitialScreen(HomeScreenKey))
-
-    // then
-    testCase.assertNoOutgoingEvents()
-    verify(uiActions).showInitialScreen(HomeScreenKey)
-    verifyNoMoreInteractions(uiActions)
-  }
-
-  @Test
   fun `when the set current screen history effect is received, the current screen history must be replaced`() {
     // given
     val history = History(listOf(


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/5181/restore-correct-navigation-state-after-app-is-resumed-from-background