### PR TITLE
Add support for Android 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Enable placeholders in overdue screen
 - Use overdue list count to display the count in the tab bar
 - Change `TheActivity` to load the entire screen history instead of a single screen key
+- Add support for Android 12
+  - Bump compile & target SDK to 31
+  - Add exported attr in `AndroidManifest.xml` for activities/services/receivers with intent filters
+  - Add `ACCESS_COARSE_LOCATION` permission
 
 ### Changes
 

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -21,6 +21,7 @@
 
     <receiver
       android:name=".FakeDataGenerationReceiver"
+      android:exported="false"
       tools:ignore="ExportedReceiver">
       <intent-filter>
         <action android:name="org.simple.clinic.debug.GENERATE_FAKE_DATA" />
@@ -38,6 +39,7 @@
     <activity
       android:name=".WebviewTestActivity"
       android:enabled="false"
+      android:exported="false"
       android:label="WebViewTest">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />

--- a/app/src/debug/java/org/simple/clinic/DebugNotification.kt
+++ b/app/src/debug/java/org/simple/clinic/DebugNotification.kt
@@ -23,11 +23,17 @@ object DebugNotification {
       notificationManager.createNotificationChannel(NotificationChannel(NOTIF_CHANNEL_ID, "Debug", NotificationManager.IMPORTANCE_MIN))
     }
 
+    val syncPendingIntentFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_CANCEL_CURRENT
+    } else {
+      PendingIntent.FLAG_CANCEL_CURRENT
+    }
     val syncPendingIntent = PendingIntent.getBroadcast(
         context,
         0,
         Intent(context, DebugNotificationActionReceiver::class.java),
-        PendingIntent.FLAG_CANCEL_CURRENT)
+        syncPendingIntentFlags)
+
     val syncAction = NotificationCompat.Action(R.drawable.ic_favorite_20dp, "Sync data", syncPendingIntent)
 
     val notif = NotificationCompat.Builder(context, NOTIF_CHANNEL_ID)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission
     android:name="android.permission.WRITE_EXTERNAL_STORAGE"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,6 +64,7 @@
 
     <activity
       android:name=".setup.SetupActivity"
+      android:exported="true"
       android:launchMode="singleTask"
       android:screenOrientation="portrait">
       <intent-filter>
@@ -119,6 +120,7 @@
 
     <activity
       android:name=".deeplink.DeepLinkActivity"
+      android:exported="true"
       android:screenOrientation="portrait"
       android:windowSoftInputMode="adjustResize">
       <intent-filter>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
   extra.apply {
     set("compileSdkVersion", 31)
     set("minSdkVersion", 21)
-    set("targetSdkVersion", 30)
+    set("targetSdkVersion", 31)
   }
 
   repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 buildscript {
   extra.apply {
-    set("compileSdkVersion", 30)
+    set("compileSdkVersion", 31)
     set("minSdkVersion", 21)
     set("targetSdkVersion", 30)
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ androidx-cameraView = "1.0.0-alpha27"
 androidx-paging = "3.0.1"
 androidx-room = "2.3.0"
 androidx-test = "1.4.0"
-androidx-work = "2.5.0"
+androidx-work = "2.7.0-rc01"
 
 dagger = "2.38.1"
 


### PR DESCRIPTION
**Testing steps**
- Run the app on an Android 12 device or emulator to make sure the app is installing and running correctly.
