### PR TITLE
Scroll to top when drugs list content is changed in edit medicines screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changes
 
 - Purge call results when database purges run
+- Scroll to top when drugs list content is changed in edit medicines screen
 - [In Progress: 22 Jul 2021] Add option to download & share overdue list
 
 ## 2021-10-04-7971

--- a/app/src/main/java/org/simple/clinic/drugs/selection/EditMedicinesScreen.kt
+++ b/app/src/main/java/org/simple/clinic/drugs/selection/EditMedicinesScreen.kt
@@ -183,18 +183,18 @@ class EditMedicinesScreen :
     }
 
     val newAdapterItems = protocolDrugItems + AddNewPrescriptionListItem
+    val hasDrugsListChanged = adapter.currentList != newAdapterItems
 
-    val hasNewItems = (adapter.itemCount == 0).not() && adapter.itemCount < newAdapterItems.size
     adapter.submitList(newAdapterItems)
 
-    // Scroll to end to show newly added prescriptions.
-    if (hasNewItems) {
-      recyclerView.postDelayed(::scrollListToLastPosition, 300)
+    // Scroll to top to show newly added or edited prescriptions.
+    if (hasDrugsListChanged) {
+      recyclerView.postDelayed(::scrollListToTopPosition, 300)
     }
   }
 
-  private fun scrollListToLastPosition() {
-    recyclerView.smoothScrollToPosition(recyclerView.adapter!!.itemCount - 1)
+  private fun scrollListToTopPosition() {
+    recyclerView.smoothScrollToPosition(0)
   }
 
   override fun showNewPrescriptionEntrySheet(patientUuid: UUID) {


### PR DESCRIPTION
- Scroll to top when drugs list content is changed in edit medicines screen
- Update CHANGELOG
