### PR TITLE
Fix state selection list content hidden behind Android navigation bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 - Render custom drug frequency in drug summary view
 - [In Progress: 22 Jul 2021] Add option to download & share overdue list
 
+### Fixes
+
+- Fix state selection list content hidden behind Android navigation bar
+
 ## 2021-10-04-7971
 
 ### Internal
@@ -69,7 +73,7 @@
 - Add support for Sri Lanka
 - Add support for displaying drug frequencies label depending on the country
 - Restrict OTP entries to 5 attempts
-- Remove next button from state selection screen, you can now select a state to go to next screen  
+- Remove next button from state selection screen, you can now select a state to go to next screen
 - Remove next button from the country selection screen, you can now select a country to go to next screen
 - Custom Drug Entry Sheet UI Improvements
 - Navigate back to `SelectCountryScreen` from `RegistrationPhoneScreen` when there's only one state present in the country

--- a/app/src/main/res/layout/screen_select_state.xml
+++ b/app/src/main/res/layout/screen_select_state.xml
@@ -35,6 +35,7 @@
     android:layout_marginTop="@dimen/spacing_44"
     android:layout_marginEnd="@dimen/spacing_24"
     android:layout_marginBottom="@dimen/spacing_24"
+    app:layout_constrainedHeight="true"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
@@ -76,13 +77,15 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/spacing_16"
         android:layout_marginTop="@dimen/spacing_24"
+        android:clipToPadding="false"
         android:paddingBottom="@dimen/spacing_8"
         android:visibility="gone"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constrainedHeight="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/select_state_title"
-        tools:layout_height="128dp"
-        tools:listitem="@layout/list_selectstate_state_view" />
+        tools:listitem="@layout/list_selectstate_state_view"
+        tools:minHeight="@dimen/spacing_128" />
 
       <TextView
         android:id="@+id/errorMessageTextView"


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/5357/fix-state-selection-list-content-hidden-behind-android-navigation-bar

**Testing steps**
- Change the manifest endpoint to `https://api.simple.org/api/` in `gradle.properties`
- Run the app and verify entire state list is visible when scrolling