### PR TITLE
Fix diabetes treatment input required dialog showing when diabetes management is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 
 - [In Progress: 29 Oct 2021] Add option to download & share overdue list
 
+### Fixes
+
+- Fix diabetes treatment input required dialog showing when diabetes management is disabled
+
 ## 2021-11-02-8005
 
 ### Internal

--- a/app/src/main/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryModel.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryModel.kt
@@ -59,7 +59,7 @@ data class NewMedicalHistoryModel(
     get() = diagnosedWithHypertension && country.isoCountryCode == Country.INDIA
 
   val showOngoingDiabetesTreatment: Boolean
-    get() = diagnosedWithDiabetes && country.isoCountryCode == Country.INDIA
+    get() = facilityDiabetesManagementEnabled && diagnosedWithDiabetes && country.isoCountryCode == Country.INDIA
 
   private val hasNoHypertension: Boolean
     get() = ongoingMedicalHistoryEntry.diagnosedWithHypertension == No

--- a/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/medicalhistory/newentry/NewMedicalHistoryUpdateTest.kt
@@ -308,4 +308,23 @@ class NewMedicalHistoryUpdateTest {
             hasEffects(ShowOngoingDiabetesTreatmentErrorDialog)
         ))
   }
+
+  @Test
+  fun `when save is clicked and diabetes management is disable and patient is diagnosed with diabetes and ongoing diabetes treatment question is not answered and selected country is india, then register patient`() {
+    val model = defaultModel
+        .ongoingPatientEntryLoaded(patientEntry)
+        .currentFacilityLoaded(facilityWithDiabetesManagementDisabled)
+        .answerChanged(DIAGNOSED_WITH_HYPERTENSION, Yes)
+        .answerChanged(DIAGNOSED_WITH_DIABETES, Yes)
+        .answerChanged(IS_ON_HYPERTENSION_TREATMENT, Yes)
+        .answerChanged(IS_ON_DIABETES_TREATMENT, Unanswered)
+
+    updateSpec
+        .given(model)
+        .whenEvent(SaveMedicalHistoryClicked())
+        .then(assertThatNext(
+            hasModel(model.registeringPatient()),
+            hasEffects(RegisterPatient(model.ongoingMedicalHistoryEntry))
+        ))
+  }
 }


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/5822/fix-diabetes-treatment-input-required-dialog-showing-when-diabetes-management-is-disabled