### PR TITLE
Remove canceling previously scheduled periodic work in `SyncScheduler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix flaky paging test cases
 - Bump Mixpanel to v5.9.5
 - Remove post delayed callbacks when view is detached from window
+- Remove canceling previously scheduled periodic work in `SyncScheduler`
 
 ### Changes
 

--- a/app/src/main/java/org/simple/clinic/sync/SyncScheduler.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncScheduler.kt
@@ -22,19 +22,7 @@ class SyncScheduler @Inject constructor(
     return Single.just(syncConfig)
         .map { config -> createWorkRequest(config.syncInterval) }
         .doOnSuccess { request -> workManager.enqueueUniquePeriodicWork(syncConfig.name, REPLACE, request) }
-        .doOnSuccess { cancelPreviouslyScheduledPeriodicWork() }
         .ignoreElement()
-  }
-
-  /*
-   * This is meant to cancel the periodic work that was scheduled using the `SyncGroup` enum
-   * until enough devices have migrated over to the system where we schedule only one periodic
-   * sync
-   * TODO vs(2021-07-15): Remove once the single unique sync work has been deployed to enough devices
-   **/
-  private fun cancelPreviouslyScheduledPeriodicWork() {
-    workManager.cancelUniqueWork("FREQUENT")
-    workManager.cancelUniqueWork("DAILY")
   }
 
   private fun createWorkRequest(syncInterval: SyncInterval): PeriodicWorkRequest {


### PR DESCRIPTION
Enough users are on the latest version of the app, so we can remove this code now
https://mixpanel.com/s/3wOyJ4