### PR TITLE
Bump Mobius to v1.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Use view binding to inflate layout in `BaseDialog`
 - Fix overdue list file name in `OverdueListDownloader`
 - Send performance monitoring events to Datadog
+- Bump Mobius to v1.5.6
 
 ### Changes
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ ktlint = "0.36.0"
 
 lint = "30.0.1"
 
-mobius = "1.5.5"
+mobius = "1.5.6"
 
 moshi = "1.12.0"
 


### PR DESCRIPTION
**Release notes**: https://github.com/spotify/mobius/releases/tag/v1.5.6