### PR TITLE
Set user ID as user property in `MixpanelAnalyticsReporter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Send performance monitoring events to Datadog
 - Bump Mobius to v1.5.6
 - Enable overdue list download and share feature in India only
+- Set user ID as user property in `MixpanelAnalyticsReporter`
 
 ### Changes
 

--- a/app/src/main/java/org/simple/clinic/analytics/MixpanelAnalyticsReporter.kt
+++ b/app/src/main/java/org/simple/clinic/analytics/MixpanelAnalyticsReporter.kt
@@ -21,10 +21,10 @@ class MixpanelAnalyticsReporter(app: ClinicApp) : AnalyticsReporter {
       mixpanel.identify(userId)
       with(mixpanel.people) {
         identify(userId)
+        set("id", userId)
         set("name", user.name)
       }
     }
-
   }
 
   override fun resetUser() {


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/6106/set-user-id-as-user-property-in-mixpanelanalyticsreporter