### PR TITLE
Provide standardized mechanism for keeping user details updated in third party tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Enable overdue list download and share feature in India only
 - Extend `RxWorker` in `OverdueDownloadWorker`
 - Implement overdue list download/share format dialog
+- Set user ID as user property in `MixpanelAnalyticsReporter`
+- Provide a standardized mechanism to update user and deployment details in third-party tooling
 
 ### Changes
 

--- a/app/src/main/java/org/simple/clinic/ClinicApp.kt
+++ b/app/src/main/java/org/simple/clinic/ClinicApp.kt
@@ -24,6 +24,7 @@ import org.simple.clinic.di.AppComponent
 import org.simple.clinic.platform.analytics.Analytics
 import org.simple.clinic.platform.analytics.AnalyticsReporter
 import org.simple.clinic.platform.crash.CrashReporter
+import org.simple.clinic.plumbing.infrastructure.UpdateInfrastructureUserDetails
 import org.simple.clinic.remoteconfig.ConfigReader
 import org.simple.clinic.storage.monitoring.AnalyticsSqlPerformanceReportingSink
 import org.simple.clinic.storage.monitoring.DatadogSqlPerformanceReportingSink
@@ -55,6 +56,9 @@ abstract class ClinicApp : Application(), CameraXConfig.Provider {
   @Inject
   lateinit var remoteConfig: ConfigReader
 
+  @Inject
+  lateinit var updateInfrastructureUserDetails: UpdateInfrastructureUserDetails
+
   protected open val analyticsReporters = emptyList<AnalyticsReporter>()
 
   protected open val crashReporterSinks = emptyList<CrashReporter.Sink>()
@@ -65,6 +69,7 @@ abstract class ClinicApp : Application(), CameraXConfig.Provider {
 
     appComponent = buildDaggerGraph()
     appComponent.inject(this)
+    updateInfrastructureUserDetails.track()
 
     crashReporterSinks.forEach(CrashReporter::addSink)
 

--- a/app/src/main/java/org/simple/clinic/analytics/MixpanelAnalyticsReporter.kt
+++ b/app/src/main/java/org/simple/clinic/analytics/MixpanelAnalyticsReporter.kt
@@ -19,6 +19,8 @@ class MixpanelAnalyticsReporter(app: ClinicApp) : AnalyticsReporter {
       }
 
       mixpanel.identify(userId)
+
+      // The current facility, deployment, etc are being tracked in `MixpanelInfrastructure`
       with(mixpanel.people) {
         identify(userId)
         set("id", userId)

--- a/app/src/main/java/org/simple/clinic/appconfig/AppConfigRepository.kt
+++ b/app/src/main/java/org/simple/clinic/appconfig/AppConfigRepository.kt
@@ -38,6 +38,10 @@ class AppConfigRepository @Inject constructor(
     return selectedDeployment.get().toNullable()
   }
 
+  fun currentDeploymentObservable(): Observable<Optional<Deployment>> {
+    return selectedDeployment.asObservable()
+  }
+
   fun currentCountry(): Country? {
     return selectedCountryPreference.get().toNullable()
   }

--- a/app/src/main/java/org/simple/clinic/di/AppModule.kt
+++ b/app/src/main/java/org/simple/clinic/di/AppModule.kt
@@ -26,6 +26,7 @@ import org.simple.clinic.login.LoginModule
 import org.simple.clinic.login.LoginOtpSmsListenerModule
 import org.simple.clinic.onboarding.OnboardingModule
 import org.simple.clinic.patient.PatientModule
+import org.simple.clinic.plumbing.infrastructure.InfrastructureModule
 import org.simple.clinic.registration.RegistrationModule
 import org.simple.clinic.remoteconfig.RemoteConfigModule
 import org.simple.clinic.remoteconfig.firebase.FirebaseRemoteConfigModule
@@ -91,7 +92,8 @@ import javax.inject.Named
   CountryModule::class,
   OverdueAppointmentsConfigModule::class,
   BruteForceOtpEntryProtectionModule::class,
-  DrugFrequencyModule::class
+  DrugFrequencyModule::class,
+  InfrastructureModule::class
 ])
 class AppModule(private val appContext: Application) {
 

--- a/app/src/main/java/org/simple/clinic/plumbing/infrastructure/DatadogInfrastructure.kt
+++ b/app/src/main/java/org/simple/clinic/plumbing/infrastructure/DatadogInfrastructure.kt
@@ -1,0 +1,21 @@
+package org.simple.clinic.plumbing.infrastructure
+
+import com.datadog.android.Datadog
+import org.simple.clinic.appconfig.Country
+import org.simple.clinic.appconfig.Deployment
+import org.simple.clinic.user.User
+
+class DatadogInfrastructure: Infrastructure {
+
+  override fun addDetails(user: User, country: Country, deployment: Deployment) {
+    Datadog.setUserInfo(
+        id = user.uuid.toString(),
+        name = user.fullName,
+        extraInfo = mapOf(
+            "facilityId" to user.currentFacilityUuid.toString(),
+            "countryCode" to country.isoCountryCode,
+            "deployment" to deployment.endPoint.toString()
+        )
+    )
+  }
+}

--- a/app/src/main/java/org/simple/clinic/plumbing/infrastructure/DatadogInfrastructure.kt
+++ b/app/src/main/java/org/simple/clinic/plumbing/infrastructure/DatadogInfrastructure.kt
@@ -4,8 +4,9 @@ import com.datadog.android.Datadog
 import org.simple.clinic.appconfig.Country
 import org.simple.clinic.appconfig.Deployment
 import org.simple.clinic.user.User
+import javax.inject.Inject
 
-class DatadogInfrastructure: Infrastructure {
+class DatadogInfrastructure @Inject constructor(): Infrastructure {
 
   override fun addDetails(user: User, country: Country, deployment: Deployment) {
     Datadog.setUserInfo(

--- a/app/src/main/java/org/simple/clinic/plumbing/infrastructure/Infrastructure.kt
+++ b/app/src/main/java/org/simple/clinic/plumbing/infrastructure/Infrastructure.kt
@@ -1,0 +1,14 @@
+package org.simple.clinic.plumbing.infrastructure
+
+import org.simple.clinic.appconfig.Country
+import org.simple.clinic.appconfig.Deployment
+import org.simple.clinic.user.User
+
+interface Infrastructure {
+
+  fun addDetails(
+      user: User,
+      country: Country,
+      deployment: Deployment
+  )
+}

--- a/app/src/main/java/org/simple/clinic/plumbing/infrastructure/InfrastructureModule.kt
+++ b/app/src/main/java/org/simple/clinic/plumbing/infrastructure/InfrastructureModule.kt
@@ -9,6 +9,7 @@ class InfrastructureModule {
   @Provides
   fun provideInfrastructure(
       sentryInfrastructure: SentryInfrastructure,
-      datadogInfrastructure: DatadogInfrastructure
-  ) = listOf(sentryInfrastructure, datadogInfrastructure)
+      datadogInfrastructure: DatadogInfrastructure,
+      mixpanelInfrastructure: MixpanelInfrastructure
+  ) = listOf(sentryInfrastructure, datadogInfrastructure, mixpanelInfrastructure)
 }

--- a/app/src/main/java/org/simple/clinic/plumbing/infrastructure/InfrastructureModule.kt
+++ b/app/src/main/java/org/simple/clinic/plumbing/infrastructure/InfrastructureModule.kt
@@ -1,0 +1,11 @@
+package org.simple.clinic.plumbing.infrastructure
+
+import dagger.Module
+import dagger.Provides
+
+@Module
+class InfrastructureModule {
+
+  @Provides
+  fun provideInfrastructure() = emptyList<Infrastructure>()
+}

--- a/app/src/main/java/org/simple/clinic/plumbing/infrastructure/InfrastructureModule.kt
+++ b/app/src/main/java/org/simple/clinic/plumbing/infrastructure/InfrastructureModule.kt
@@ -7,5 +7,8 @@ import dagger.Provides
 class InfrastructureModule {
 
   @Provides
-  fun provideInfrastructure() = emptyList<Infrastructure>()
+  fun provideInfrastructure(
+      sentryInfrastructure: SentryInfrastructure,
+      datadogInfrastructure: DatadogInfrastructure
+  ) = listOf(sentryInfrastructure, datadogInfrastructure)
 }

--- a/app/src/main/java/org/simple/clinic/plumbing/infrastructure/MixpanelInfrastructure.kt
+++ b/app/src/main/java/org/simple/clinic/plumbing/infrastructure/MixpanelInfrastructure.kt
@@ -1,0 +1,27 @@
+package org.simple.clinic.plumbing.infrastructure
+
+import android.app.Application
+import com.mixpanel.android.mpmetrics.MixpanelAPI
+import org.simple.clinic.BuildConfig
+import org.simple.clinic.appconfig.Country
+import org.simple.clinic.appconfig.Deployment
+import org.simple.clinic.user.User
+import javax.inject.Inject
+
+class MixpanelInfrastructure @Inject constructor(
+    private val application: Application
+): Infrastructure {
+
+  override fun addDetails(user: User, country: Country, deployment: Deployment) {
+    val mixpanel = MixpanelAPI.getInstance(application, BuildConfig.MIXPANEL_TOKEN)
+
+    // We are deliberately not registering the user ID here because Mixpanel has a slightly tricky
+    // flow for user identification where we need to track new registrations and logins differently.
+    // This is being taken care of elsewhere, in the `Analytics#setLoggedInUser` class.
+    mixpanel.registerSuperPropertiesMap(mapOf(
+        "facilityId" to user.currentFacilityUuid,
+        "countryCode" to country.isoCountryCode,
+        "deployment" to deployment.endPoint.toString()
+    ))
+  }
+}

--- a/app/src/main/java/org/simple/clinic/plumbing/infrastructure/SentryInfrastructure.kt
+++ b/app/src/main/java/org/simple/clinic/plumbing/infrastructure/SentryInfrastructure.kt
@@ -4,8 +4,9 @@ import io.sentry.Sentry
 import org.simple.clinic.appconfig.Country
 import org.simple.clinic.appconfig.Deployment
 import org.simple.clinic.user.User
+import javax.inject.Inject
 
-class SentryInfrastructure: Infrastructure {
+class SentryInfrastructure @Inject constructor(): Infrastructure {
 
   override fun addDetails(user: User, country: Country, deployment: Deployment) {
     Sentry.setTag("userUuid", user.uuid.toString())

--- a/app/src/main/java/org/simple/clinic/plumbing/infrastructure/SentryInfrastructure.kt
+++ b/app/src/main/java/org/simple/clinic/plumbing/infrastructure/SentryInfrastructure.kt
@@ -1,0 +1,16 @@
+package org.simple.clinic.plumbing.infrastructure
+
+import io.sentry.Sentry
+import org.simple.clinic.appconfig.Country
+import org.simple.clinic.appconfig.Deployment
+import org.simple.clinic.user.User
+
+class SentryInfrastructure: Infrastructure {
+
+  override fun addDetails(user: User, country: Country, deployment: Deployment) {
+    Sentry.setTag("userUuid", user.uuid.toString())
+    Sentry.setTag("facilityUuid", user.currentFacilityUuid.toString())
+    Sentry.setTag("countryCode", country.isoCountryCode)
+    Sentry.setTag("deployment", deployment.endPoint.toString())
+  }
+}

--- a/app/src/main/java/org/simple/clinic/plumbing/infrastructure/UpdateInfrastructureUserDetails.kt
+++ b/app/src/main/java/org/simple/clinic/plumbing/infrastructure/UpdateInfrastructureUserDetails.kt
@@ -1,0 +1,49 @@
+package org.simple.clinic.plumbing.infrastructure
+
+import android.annotation.SuppressLint
+import io.reactivex.rxkotlin.Observables
+import org.simple.clinic.appconfig.AppConfigRepository
+import org.simple.clinic.appconfig.Country
+import org.simple.clinic.appconfig.Deployment
+import org.simple.clinic.user.User
+import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.extractIfPresent
+import org.simple.clinic.util.scheduler.SchedulersProvider
+import javax.inject.Inject
+
+class UpdateInfrastructureUserDetails @Inject constructor(
+    private val infrastructures: List<@JvmSuppressWildcards Infrastructure>,
+    private val userSession: UserSession,
+    private val appConfigRepository: AppConfigRepository,
+    private val schedulers: SchedulersProvider
+) {
+
+  @SuppressLint("CheckResult")
+  fun track() {
+    val currentUser = userSession
+        .loggedInUser()
+        .extractIfPresent()
+
+    val currentCountry = appConfigRepository
+        .currentCountryObservable()
+        .extractIfPresent()
+
+    val currentDeployment = appConfigRepository
+        .currentDeploymentObservable()
+        .extractIfPresent()
+
+    Observables
+        .combineLatest(currentUser, currentCountry, currentDeployment)
+        .subscribeOn(schedulers.io())
+        .take(1)
+        .subscribe { (user, country, deployment) -> updateInfrastructures(user, country, deployment) }
+  }
+
+  private fun updateInfrastructures(
+      user: User,
+      country: Country,
+      deployment: Deployment
+  ) {
+    infrastructures.forEach { infrastructure -> infrastructure.addDetails(user, country, deployment) }
+  }
+}

--- a/app/src/test/java/org/simple/clinic/plumbing/infrastructure/UpdateInfrastructureUserDetailsTest.kt
+++ b/app/src/test/java/org/simple/clinic/plumbing/infrastructure/UpdateInfrastructureUserDetailsTest.kt
@@ -1,0 +1,76 @@
+package org.simple.clinic.plumbing.infrastructure
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import io.reactivex.subjects.PublishSubject
+import org.junit.Test
+import org.simple.clinic.TestData
+import org.simple.clinic.appconfig.AppConfigRepository
+import org.simple.clinic.appconfig.Country
+import org.simple.clinic.appconfig.Deployment
+import org.simple.clinic.user.User
+import org.simple.clinic.user.UserSession
+import org.simple.clinic.util.scheduler.TestSchedulersProvider
+import java.util.Optional
+import java.util.UUID
+
+class UpdateInfrastructureUserDetailsTest {
+
+  @Test
+  fun `the user details must be set on each infrastructure registered`() {
+    // given
+    val user = TestData.loggedInUser(
+        uuid = UUID.fromString("3daad1ea-ef5d-41fc-9b42-a1bb82c80bd7"),
+        registrationFacilityUuid = UUID.fromString("10fe996b-373a-4c42-998e-98ed84f0a7e3")
+    )
+    val userSubject = PublishSubject.create<Optional<User>>()
+    val userSession = mock<UserSession>()
+    whenever(userSession.loggedInUser()).thenReturn(userSubject)
+
+    val country = TestData.country()
+    val deployment = country.deployments.first()
+    val countrySubject = PublishSubject.create<Optional<Country>>()
+    val deploymentSubject = PublishSubject.create<Optional<Deployment>>()
+    val appConfigRepository = mock<AppConfigRepository>()
+    whenever(appConfigRepository.currentCountryObservable()).thenReturn(countrySubject)
+    whenever(appConfigRepository.currentDeploymentObservable()).thenReturn(deploymentSubject)
+
+    val firstInfrastructure = mock<Infrastructure>()
+    val secondInfrastructure = mock<Infrastructure>()
+    val updateInfrastructureUserDetails = UpdateInfrastructureUserDetails(
+        infrastructures = listOf(firstInfrastructure, secondInfrastructure),
+        userSession = userSession,
+        appConfigRepository = appConfigRepository,
+        schedulers = TestSchedulersProvider.trampoline()
+    )
+
+    // when
+    updateInfrastructureUserDetails.track()
+
+    // then
+    verifyZeroInteractions(firstInfrastructure, secondInfrastructure)
+
+    // when
+    userSubject.onNext(Optional.of(user))
+
+    // then
+    verifyZeroInteractions(firstInfrastructure, secondInfrastructure)
+
+    // when
+    countrySubject.onNext(Optional.of(country))
+
+    // then
+    verifyZeroInteractions(firstInfrastructure, secondInfrastructure)
+
+    // when
+    deploymentSubject.onNext(Optional.of(deployment))
+
+    // then
+    verify(firstInfrastructure).addDetails(user, country, deployment)
+    verify(secondInfrastructure).addDetails(user, country, deployment)
+    verifyNoMoreInteractions(firstInfrastructure, secondInfrastructure)
+  }
+}


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/6107/clean-up-assigning-user-meta-data-to-apm-and-crash-reporting-tools