### PR TITLE
Enable `OverdueListDownloadAndShare` feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,11 @@
 - Download/Share CSV only for API below 24
 - Show error dialog when overdue list download fails
 - Fix sharing downloaded overdue list through Whatsapp is not working
+- Enable `OverdueListDownloadAndShare` feature flag
 
 ### Changes
 
-- [In Progress: 26 Nov 2021] Add option to download & share overdue list
+- Add option to download & share overdue list
 
 ### Fixes
 

--- a/app/src/main/java/org/simple/clinic/feature/Feature.kt
+++ b/app/src/main/java/org/simple/clinic/feature/Feature.kt
@@ -27,7 +27,7 @@ enum class Feature(
   InstantSearchQrCode(true, "instant_search_qr_code"),
   EthiopianCalendar(true, "ethiopian_calendar"),
   IndiaNationalHealthID(true, "india_national_health_id"),
-  OverdueListDownloadAndShare(false, "overdue_list_download_and_share"),
+  OverdueListDownloadAndShare(false, "download_and_share_overdue_list"),
   CustomDrugSearchScreen(true, "drug_search_screen"),
   OnlinePatientLookup(true, "online_patient_lookup"),
   HttpRequestBodyCompression(false, "http_request_body_compression_enabled"),

--- a/app/src/main/java/org/simple/clinic/feature/Feature.kt
+++ b/app/src/main/java/org/simple/clinic/feature/Feature.kt
@@ -27,7 +27,7 @@ enum class Feature(
   InstantSearchQrCode(true, "instant_search_qr_code"),
   EthiopianCalendar(true, "ethiopian_calendar"),
   IndiaNationalHealthID(true, "india_national_health_id"),
-  OverdueListDownloadAndShare(false, "download_and_share_overdue_list"),
+  OverdueListDownloadAndShare(true, "download_and_share_overdue_list"),
   CustomDrugSearchScreen(true, "drug_search_screen"),
   OnlinePatientLookup(true, "online_patient_lookup"),
   HttpRequestBodyCompression(false, "http_request_body_compression_enabled"),


### PR DESCRIPTION
Waiting for [Sharing downloaded overdue list through Whatsapp is not working](https://app.shortcut.com/simpledotorg/story/6120/sharing-downloaded-overdue-list-through-whatsapp-is-not-working) bug's fix to get merged in.