### PR TITLE
Add support for manually running Heroku cleanup workflow

### DIFF
--- a/.github/workflows/cleanup_heroku_review_apps.yml
+++ b/.github/workflows/cleanup_heroku_review_apps.yml
@@ -6,7 +6,7 @@ on:
       - master
   # Also run a nightly (at 12 AM IST) workflow to clean up dangling instances for redundancy
   schedule:
-    - cron: '30 6 * * 1-5'
+    - cron: '30 18 * * 1-5'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cleanup_heroku_review_apps.yml
+++ b/.github/workflows/cleanup_heroku_review_apps.yml
@@ -7,6 +7,7 @@ on:
   # Also run a nightly (at 12 AM IST) workflow to clean up dangling instances for redundancy
   schedule:
     - cron: '30 6 * * 1-5'
+  workflow_dispatch:
 
 jobs:
   teardown_heroku_instance:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Use view render to setup UI and fill fields in edit screen
 - Remove unused properties from `SetupActivityModel`
 - Fix text change events not triggering in edit patient screen
+- Add support for running Heroku cleanup instance manually
 
 ## 2021-12-08-8060
 


### PR DESCRIPTION
Currently, if we need to reset a Heroku instance for a PR, the only way is to login to the Heroku console and manually delete the instance. This allows us to  trigger it via GitHub Actions by taking the following steps:

- Close the PR
- Manually the Heroku cleanup workflow
- Reopen the PR