### PR TITLE
Return early if the required `Timeout` conditions are not satisfied in `TimeoutCallAdapterFactory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Inject a new `AppDatabase` in instrumented tests instead of using a singleton instance
 - Add support for writing performance regression test suites
 - Remove QA Android tests from PR comment GH Action
+- Return early if the required `Timeout` conditions are not satisfied in `TimeoutCallAdapterFactory`
 
 ## On Demo
 

--- a/app/src/main/java/org/simple/clinic/di/network/TimeoutCallAdapterFactory.kt
+++ b/app/src/main/java/org/simple/clinic/di/network/TimeoutCallAdapterFactory.kt
@@ -14,12 +14,12 @@ class TimeoutCallAdapterFactory : CallAdapter.Factory() {
   }
 
   override fun get(returnType: Type, annotations: Array<out Annotation>, retrofit: Retrofit): CallAdapter<*, *>? {
-    val timeout = annotations.firstOrNull { it is Timeout } as? Timeout
-    val delegate = retrofit.nextCallAdapter(this, returnType, annotations)
-
     if (getRawType(returnType) != Call::class.java) {
       return null
     }
+
+    val timeout = annotations.firstOrNull { it is Timeout } as? Timeout
+    val delegate = retrofit.nextCallAdapter(this, returnType, annotations)
 
     return object : CallAdapter<Any, Call<Any>> {
       override fun responseType(): Type {

--- a/app/src/main/java/org/simple/clinic/di/network/TimeoutCallAdapterFactory.kt
+++ b/app/src/main/java/org/simple/clinic/di/network/TimeoutCallAdapterFactory.kt
@@ -18,7 +18,7 @@ class TimeoutCallAdapterFactory : CallAdapter.Factory() {
       return null
     }
 
-    val timeout = annotations.firstOrNull { it is Timeout } as? Timeout
+    val timeout = annotations.firstOrNull { it is Timeout } as? Timeout ?: return null
     val delegate = retrofit.nextCallAdapter(this, returnType, annotations)
 
     return object : CallAdapter<Any, Call<Any>> {
@@ -27,9 +27,7 @@ class TimeoutCallAdapterFactory : CallAdapter.Factory() {
       }
 
       override fun adapt(call: Call<Any>): Call<Any> {
-        if (timeout != null) {
-          call.timeout().timeout(timeout.value, timeout.unit)
-        }
+        call.timeout().timeout(timeout.value, timeout.unit)
         return call
       }
     }


### PR DESCRIPTION
If the required conditions are not satisfied, we are returning early to avoid checking annotations or creating a new call adapter.