### PR TITLE
Restart ADB as root before running the performance regression test suite

### DIFF
--- a/.github/workflows/benchmark_suite.yml
+++ b/.github/workflows/benchmark_suite.yml
@@ -32,6 +32,7 @@ jobs:
           arch: x86_64
           disable-animations: true
           script: |
+            adb root
             ./gradlew -PmanifestEndpoint=https://api-sandbox.simple.org/api/ installQaDebug installQaDebugAndroidTest lockClocks
             adb shell am instrument -w -e filter org.simple.clinic.benchmark.SelectBenchmarkTests -e benchmark_app_performance true dd_client_token ${{ secrets.DD_PERF_CLIENT_TOKEN }} dd_application_id ${{ secrets.DD_PERF_APPLICATION_ID }} org.simple.clinic.qa.debug.test/org.simple.clinic.AndroidTestJUnitRunner
             adb uninstall org.simple.clinic.qa.debug


### PR DESCRIPTION
This is being done because the first time we try to lock the clocks, the task always fails with the device being offline but it works the second time. This commit restarts ADB as root in order to make the test pass.