### PR TITLE
Enable auto merge of PR when assigning reviewer

### DIFF
--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -18,3 +18,8 @@ jobs:
         with:
           token: ${{ secrets.SERVICES_ACCESS_TOKEN }}
           config: .github/reviewers.yml
+      - name: Enable auto merge
+        run: gh pr merge --auto -d -s "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add support for writing performance regression test suites
 - Remove QA Android tests from PR comment GH Action
 - Return early if the required `Timeout` conditions are not satisfied in `TimeoutCallAdapterFactory`
+- Enable auto merge of PR when assigning reviewer
 
 ## 2021-12-28-8079
 


### PR DESCRIPTION
Right now we have to manually enable auto merge when creating PR, this CI step will automatically do that when assigning the reviewer.