### PR TITLE
Run renovate bot daily after 12 am

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Bump facebook.soloader to 0.10.3
 - Bump Mobius to v1.5.7
 - Request camera permissions when add bp passport button is clicked in `EditPatientScreen`
+- Run renovate bot daily after 12 am
 - [In Progress: 11 Jan 2022] Implement adding NHID in `PatientEditScreen`
 - [In Progress: 17 Jan 2022] Implement adding scan support for BpPassport in `EditPatientScreen`
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,7 @@
     "config:base"
   ],
   "schedule": [
-    "every 2 months on the first day of the month after 12am"
+    "after 12am and before 2am"
   ],
   "ignoreDeps": [
     // Ignoring zxing update. Since update requires Java 8+ runtime.


### PR DESCRIPTION
With the previous configuration we would have received 5 PR's every 2 months and have to manually trigger the PR generation if we want from the dashboard. But we are gonna run this job daily to generate max of 5 concurrent PR's to avoid too much noise. 