### PR TITLE
Refactor `addBPPassport` and `addNHIDButton` to use `MaterialButton`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - Implement adding `NHID` in `EditPatientScreen`
 - Request camera permission when add nhid button is clicked in `EditPatientScreen`
 - Fix when scanned QR code error is shown the progress state continues to show
+- Refactor `addBPPassport` and `addNHIDButton` to use `MaterialButton`
+- Fix two duplicate NHIDs end up rendering in `EditPatientScreen`
 - [In Progress: 11 Jan 2022] Implement adding NHID in `PatientEditScreen`
 - [In Progress: 17 Jan 2022] Implement adding scan support for BpPassport in `EditPatientScreen`
 

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
@@ -833,6 +833,7 @@ class EditPatientScreen : BaseScreen<
     val layoutInflater = LayoutInflater.from(requireContext())
     val alternateIdView = PatientEditAlternateIdViewBinding.inflate(layoutInflater, rootView, false)
     alternateIdView.alternateIdentifier.text = identifier
+    alternateIdContainer.removeAllViews()
     alternateIdContainer.addView(alternateIdView.root)
   }
 

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
@@ -251,9 +251,6 @@ class EditPatientScreen : BaseScreen<
 
   private val addBpPassportButton
     get() = binding.addBpPassportButton
-    
-  private val addNHIDButtonContainer
-    get() = binding.addNHIDButtonContainer
 
   private val addNHIDButton
     get() = binding.addNHIDButton
@@ -438,11 +435,11 @@ class EditPatientScreen : BaseScreen<
   }
 
   override fun showAddNHIDButton() {
-    addNHIDButtonContainer.visibility = VISIBLE
+    addNHIDButton.visibility = VISIBLE
   }
 
   override fun hideAddNHIDButton() {
-    addNHIDButtonContainer.visibility = GONE
+    addNHIDButton.visibility = GONE
   }
 
   override fun showIndiaNHIDLabel() {

--- a/app/src/main/res/layout/screen_edit_patient.xml
+++ b/app/src/main/res/layout/screen_edit_patient.xml
@@ -153,33 +153,19 @@
         android:layout_marginTop="@dimen/spacing_8"
         android:orientation="vertical" />
 
-      <LinearLayout
-        android:layout_width="match_parent"
+      <com.google.android.material.button.MaterialButton
+        android:id="@+id/addBpPassportButton"
+        style="?attr/borderlessButtonDenseStyle"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/spacing_8"
-        android:orientation="horizontal">
-
-        <ImageButton
-          android:id="@+id/addBpPassportButton"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:padding="@dimen/spacing_2"
-          android:background="?attr/selectableItemBackgroundBorderless"
-          app:srcCompat="@drawable/ic_add_circle_outline_24px"
-          tools:ignore="ContentDescription" />
-
-        <TextView
-          android:id="@+id/addBpPassportText"
-          style="?attr/textAppearanceButton"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:paddingVertical="@dimen/spacing_2"
-          android:paddingStart="@dimen/spacing_8"
-          android:textAlignment="textStart"
-          android:text="@string/patientedit_add_button"
-          android:textColor="?attr/colorPrimary" />
-
-      </LinearLayout>
+        android:paddingStart="@dimen/spacing_2"
+        android:text="@string/patientedit_add_button"
+        android:textAlignment="viewStart"
+        android:textAppearance="?attr/textAppearanceButton"
+        app:icon="@drawable/ic_add_circle_outline_24px"
+        app:iconGravity="start"
+        app:iconPadding="@dimen/spacing_8" />
 
       <TextView
         android:id="@+id/alternateIdLabel"

--- a/app/src/main/res/layout/screen_edit_patient.xml
+++ b/app/src/main/res/layout/screen_edit_patient.xml
@@ -186,35 +186,20 @@
         android:visibility="gone"
         tools:visibility="visible" />
 
-      <LinearLayout
-        android:id="@+id/addNHIDButtonContainer"
-        android:layout_width="match_parent"
+      <com.google.android.material.button.MaterialButton
+        android:id="@+id/addNHIDButton"
+        style="?attr/borderlessButtonDenseStyle"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/spacing_8"
-        android:orientation="horizontal"
-        android:visibility="gone">
-
-        <ImageButton
-          android:id="@+id/addNHIDButton"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:padding="@dimen/spacing_2"
-          android:background="?attr/selectableItemBackgroundBorderless"
-          app:srcCompat="@drawable/ic_add_circle_outline_24px"
-          tools:ignore="ContentDescription" />
-
-        <TextView
-          android:id="@+id/addNHIDText"
-          style="?attr/textAppearanceButton"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"
-          android:paddingVertical="@dimen/spacing_2"
-          android:paddingStart="@dimen/spacing_8"
-          android:text="@string/patientedit_add_button"
-          android:textAlignment="textStart"
-          android:textColor="?attr/colorPrimary" />
-
-      </LinearLayout>
+        android:paddingStart="@dimen/spacing_2"
+        android:text="@string/patientedit_add_button"
+        android:textAlignment="viewStart"
+        android:textAppearance="?attr/textAppearanceButton"
+        android:visibility="gone"
+        app:icon="@drawable/ic_add_circle_outline_24px"
+        app:iconGravity="start"
+        app:iconPadding="@dimen/spacing_8" />
 
       <RadioGroup
         android:id="@+id/genderRadioGroup"


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/6797/refactor-addbppassport-and-addnhidbutton-to-use-materialbutton


Depended on [#3402](https://github.com/simpledotorg/simple-android/pull/3402) to be merged in 

This PR also resolves [this](https://app.shortcut.com/simpledotorg/story/6783/bug-two-duplicate-nhids-end-up-rendering-in-edit-patient-screen) bug. Added it in this PR as it was a small fix.