### PR TITLE
Handle visibility of Bp Passport label and button when scan health id from edit patient is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Add benchmark test for loading overdue appointments in a facility
 - Support scanning list of unique Bp passports in `EditPatientScreen`
 - Add benchmark test for patient registration queries
+- Handle visibility of Bp Passport label and button when scan health id from edit patient is enabled
 
 ### Changes
 

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
@@ -455,6 +455,10 @@ class EditPatientScreen : BaseScreen<
     bpPassportsLabel.visibility = GONE
   }
 
+  override fun hideBpPassportButton() {
+    addBpPassportButton.visibility = GONE
+  }
+
   private fun showOrHideInputFields(inputFields: InputFields) {
     val allTypesOfInputFields: Map<Class<*>, View> = mapOf(
         PatientNameField::class.java to fullNameInputLayout,

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
@@ -554,8 +554,6 @@ class EditPatientScreen : BaseScreen<
   override fun displayBpPassports(identifiers: List<String>) {
     bpPassportsContainer.removeAllViews()
     identifiers.forEach { identifier -> inflateBpPassportView(identifier) }
-
-    bpPassportsLabel.visibleOrGone(identifiers.isNotEmpty())
   }
 
   private fun inflateBpPassportView(identifier: String) {

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
@@ -447,6 +447,10 @@ class EditPatientScreen : BaseScreen<
     addBpPassportButton.visibility = VISIBLE
   }
 
+  override fun showBpPassportLabel() {
+    bpPassportsLabel.visibility = VISIBLE
+  }
+
   private fun showOrHideInputFields(inputFields: InputFields) {
     val allTypesOfInputFields: Map<Class<*>, View> = mapOf(
         PatientNameField::class.java to fullNameInputLayout,

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
@@ -451,6 +451,10 @@ class EditPatientScreen : BaseScreen<
     bpPassportsLabel.visibility = VISIBLE
   }
 
+  override fun hideBpPassportLabel() {
+    bpPassportsLabel.visibility = GONE
+  }
+
   private fun showOrHideInputFields(inputFields: InputFields) {
     val allTypesOfInputFields: Map<Class<*>, View> = mapOf(
         PatientNameField::class.java to fullNameInputLayout,

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientUi.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientUi.kt
@@ -37,4 +37,5 @@ interface EditPatientUi {
   fun hideAddNHIDButton()
   fun showIndiaNHIDLabel()
   fun showBPPassportButton()
+  fun showBpPassportLabel()
 }

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientUi.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientUi.kt
@@ -38,4 +38,5 @@ interface EditPatientUi {
   fun showIndiaNHIDLabel()
   fun showBPPassportButton()
   fun showBpPassportLabel()
+  fun hideBpPassportLabel()
 }

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientUi.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientUi.kt
@@ -39,4 +39,5 @@ interface EditPatientUi {
   fun showBPPassportButton()
   fun showBpPassportLabel()
   fun hideBpPassportLabel()
+  fun hideBpPassportButton()
 }

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
@@ -45,6 +45,11 @@ class EditPatientViewRenderer(private val ui: EditPatientUi) : ViewRenderer<Edit
         model.canAddNHID
     )
 
+    handleBpPassportButtonAndLabelVisibility(model)
+    displayBpPassports(model)
+  }
+
+  private fun handleBpPassportButtonAndLabelVisibility(model: EditPatientModel) {
     if (model.isAddingHealthIDsFromEditPatientEnabled) {
       ui.showBPPassportButton()
       ui.showBpPassportLabel()
@@ -53,8 +58,6 @@ class EditPatientViewRenderer(private val ui: EditPatientUi) : ViewRenderer<Edit
       val hasBpPassports = !model.bpPassports.isNullOrEmpty()
       handleLabelVisibilityIfBpPassportsNotEmpty(hasBpPassports)
     }
-
-    displayBpPassports(model)
   }
 
   private fun handleLabelVisibilityIfBpPassportsNotEmpty(hasBpPassports: Boolean) {

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
@@ -44,11 +44,7 @@ class EditPatientViewRenderer(private val ui: EditPatientUi) : ViewRenderer<Edit
       ui.showBpPassportLabel()
     } else {
       val identifiers = model.bpPassports?.map { it.identifier.displayValue() }.orEmpty()
-      if (identifiers.isNotEmpty()) {
-        ui.showBpPassportLabel()
-      } else {
-        ui.hideBpPassportLabel()
-      }
+      showBpPassportLabelIfIdentifierNotEmpty(identifiers)
     }
 
     fillFormFields(
@@ -57,6 +53,14 @@ class EditPatientViewRenderer(private val ui: EditPatientUi) : ViewRenderer<Edit
         model.canAddNHID
     )
     displayBpPassports(model)
+  }
+
+  private fun showBpPassportLabelIfIdentifierNotEmpty(identifiers: List<String>) {
+    if (identifiers.isNotEmpty()) {
+      ui.showBpPassportLabel()
+    } else {
+      ui.hideBpPassportLabel()
+    }
   }
 
   private fun displayNewlyAddedNHID(alternativeId: String) {

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
@@ -42,6 +42,11 @@ class EditPatientViewRenderer(private val ui: EditPatientUi) : ViewRenderer<Edit
     if (model.isAddingHealthIDsFromEditPatientEnabled) {
       ui.showBPPassportButton()
       ui.showBpPassportLabel()
+    } else {
+      val identifiers = model.bpPassports?.map { it.identifier.displayValue() }.orEmpty()
+      if (identifiers.isNotEmpty()) {
+        ui.showBpPassportLabel()
+      }
     }
 
     fillFormFields(

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
@@ -41,6 +41,7 @@ class EditPatientViewRenderer(private val ui: EditPatientUi) : ViewRenderer<Edit
 
     if (model.isAddingHealthIDsFromEditPatientEnabled) {
       ui.showBPPassportButton()
+      ui.showBpPassportLabel()
     }
 
     fillFormFields(

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
@@ -39,6 +39,12 @@ class EditPatientViewRenderer(private val ui: EditPatientUi) : ViewRenderer<Edit
       ui.setupUi(model.inputFields!!)
     }
 
+    fillFormFields(
+        model.ongoingEntry,
+        model.savedBangladeshNationalId,
+        model.canAddNHID
+    )
+
     if (model.isAddingHealthIDsFromEditPatientEnabled) {
       ui.showBPPassportButton()
       ui.showBpPassportLabel()
@@ -47,11 +53,6 @@ class EditPatientViewRenderer(private val ui: EditPatientUi) : ViewRenderer<Edit
       handleLabelVisibilityIfBpPassportsNotEmpty(hasBpPassports)
     }
 
-    fillFormFields(
-        model.ongoingEntry,
-        model.savedBangladeshNationalId,
-        model.canAddNHID
-    )
     displayBpPassports(model)
   }
 

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
@@ -43,8 +43,8 @@ class EditPatientViewRenderer(private val ui: EditPatientUi) : ViewRenderer<Edit
       ui.showBPPassportButton()
       ui.showBpPassportLabel()
     } else {
-      val identifiers = model.bpPassports?.map { it.identifier.displayValue() }.orEmpty()
-      showBpPassportLabelIfIdentifierNotEmpty(identifiers)
+      val hasBpPassports = !model.bpPassports.isNullOrEmpty()
+      handleLabelVisibilityIfBpPassportsNotEmpty(hasBpPassports)
     }
 
     fillFormFields(
@@ -55,8 +55,8 @@ class EditPatientViewRenderer(private val ui: EditPatientUi) : ViewRenderer<Edit
     displayBpPassports(model)
   }
 
-  private fun showBpPassportLabelIfIdentifierNotEmpty(identifiers: List<String>) {
-    if (identifiers.isNotEmpty()) {
+  private fun handleLabelVisibilityIfBpPassportsNotEmpty(hasBpPassports: Boolean) {
+    if (hasBpPassports) {
       ui.showBpPassportLabel()
     } else {
       ui.hideBpPassportLabel()

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
@@ -49,6 +49,7 @@ class EditPatientViewRenderer(private val ui: EditPatientUi) : ViewRenderer<Edit
       ui.showBPPassportButton()
       ui.showBpPassportLabel()
     } else {
+      ui.hideBpPassportButton()
       val hasBpPassports = !model.bpPassports.isNullOrEmpty()
       handleLabelVisibilityIfBpPassportsNotEmpty(hasBpPassports)
     }

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientViewRenderer.kt
@@ -46,6 +46,8 @@ class EditPatientViewRenderer(private val ui: EditPatientUi) : ViewRenderer<Edit
       val identifiers = model.bpPassports?.map { it.identifier.displayValue() }.orEmpty()
       if (identifiers.isNotEmpty()) {
         ui.showBpPassportLabel()
+      } else {
+        ui.hideBpPassportLabel()
       }
     }
 

--- a/app/src/main/res/layout/screen_edit_patient.xml
+++ b/app/src/main/res/layout/screen_edit_patient.xml
@@ -199,7 +199,6 @@
         android:textAppearance="?attr/textAppearanceButton"
         app:icon="@drawable/ic_add_circle_outline_24px"
         app:iconGravity="start"
-        android:visibility="gone"
         app:iconPadding="@dimen/spacing_8" />
 
       <RadioGroup

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientViewRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientViewRendererTest.kt
@@ -143,6 +143,7 @@ class EditPatientViewRendererTest {
     verify(ui).showProgress()
     verify(ui).displayBpPassports(expectedIdentifiers)
     verify(ui).setAlternateIdTextField("")
+    verify(ui).showBpPassportLabel()
     verifyNoMoreInteractions(ui)
   }
 

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientViewRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientViewRendererTest.kt
@@ -68,6 +68,7 @@ class EditPatientViewRendererTest {
     verify(ui).showProgress()
     verify(ui).displayBpPassports(emptyList())
     verify(ui).setAlternateIdTextField("")
+    verify(ui).hideBpPassportLabel()
     verifyNoMoreInteractions(ui)
   }
 
@@ -100,6 +101,7 @@ class EditPatientViewRendererTest {
     verify(ui).setupUi(inputFields)
     verify(ui).displayBpPassports(emptyList())
     verify(ui).setAlternateIdTextField("")
+    verify(ui).hideBpPassportLabel()
     verifyNoMoreInteractions(ui)
   }
 
@@ -185,6 +187,7 @@ class EditPatientViewRendererTest {
     verify(ui).showProgress()
     verify(ui).displayBpPassports(emptyList())
     verify(ui).setAlternateIdTextField("1234567")
+    verify(ui).hideBpPassportLabel()
     verifyNoMoreInteractions(ui)
   }
 
@@ -226,6 +229,7 @@ class EditPatientViewRendererTest {
     verify(ui).showProgress()
     verify(ui).displayBpPassports(emptyList())
     verify(ui).setAlternateIdContainer(identifier, false)
+    verify(ui).hideBpPassportLabel()
     verifyNoMoreInteractions(ui)
   }
 

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientViewRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientViewRendererTest.kt
@@ -263,6 +263,7 @@ class EditPatientViewRendererTest {
     verify(ui).setAlternateIdContainer(identifier, true)
     verify(ui).hideAddNHIDButton()
     verify(ui).showBPPassportButton()
+    verify(ui).showBpPassportLabel()
     verifyNoMoreInteractions(ui)
   }
 
@@ -299,11 +300,12 @@ class EditPatientViewRendererTest {
     verify(ui).showAddNHIDButton()
     verify(ui).showIndiaNHIDLabel()
     verify(ui).showBPPassportButton()
+    verify(ui).showBpPassportLabel()
     verifyNoMoreInteractions(ui)
   }
 
   @Test
-  fun `when adding health ids from edit patient is enabled, then show bp passport button`() {
+  fun `when adding health ids from edit patient is enabled, then show bp passport button and label`() {
     // given
     val model = EditPatientModel.from(
         patient = patientProfile.patient,
@@ -333,6 +335,7 @@ class EditPatientViewRendererTest {
     verify(ui).setAlternateIdTextField("")
     verify(ui).displayBpPassports(emptyList())
     verify(ui).showBPPassportButton()
+    verify(ui).showBpPassportLabel()
     verifyNoMoreInteractions(ui)
   }
 }

--- a/app/src/test/java/org/simple/clinic/editpatient/EditPatientViewRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/editpatient/EditPatientViewRendererTest.kt
@@ -69,6 +69,7 @@ class EditPatientViewRendererTest {
     verify(ui).displayBpPassports(emptyList())
     verify(ui).setAlternateIdTextField("")
     verify(ui).hideBpPassportLabel()
+    verify(ui).hideBpPassportButton()
     verifyNoMoreInteractions(ui)
   }
 
@@ -102,6 +103,7 @@ class EditPatientViewRendererTest {
     verify(ui).displayBpPassports(emptyList())
     verify(ui).setAlternateIdTextField("")
     verify(ui).hideBpPassportLabel()
+    verify(ui).hideBpPassportButton()
     verifyNoMoreInteractions(ui)
   }
 
@@ -146,6 +148,7 @@ class EditPatientViewRendererTest {
     verify(ui).displayBpPassports(expectedIdentifiers)
     verify(ui).setAlternateIdTextField("")
     verify(ui).showBpPassportLabel()
+    verify(ui).hideBpPassportButton()
     verifyNoMoreInteractions(ui)
   }
 
@@ -188,6 +191,7 @@ class EditPatientViewRendererTest {
     verify(ui).displayBpPassports(emptyList())
     verify(ui).setAlternateIdTextField("1234567")
     verify(ui).hideBpPassportLabel()
+    verify(ui).hideBpPassportButton()
     verifyNoMoreInteractions(ui)
   }
 
@@ -230,6 +234,7 @@ class EditPatientViewRendererTest {
     verify(ui).displayBpPassports(emptyList())
     verify(ui).setAlternateIdContainer(identifier, false)
     verify(ui).hideBpPassportLabel()
+    verify(ui).hideBpPassportButton()
     verifyNoMoreInteractions(ui)
   }
 


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/6763/show-bp-passport-text-when-bp-passport-is-null-as-well