### PR TITLE
Fix unable to enter space while entering bp passport number in `ScanSimpleIdScreen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Migrate `RegistrationLocationPermissionScreen` to use view effects
 - Bump Lottie to v4.2.2
 
+### Fixes
+
+- Fixed unable to enter space while entering bp passport number in `ScanSimpleIdScreen`
+
 ## On Demo
 
 ### Internal

--- a/app/src/main/res/layout/screen_scan_simple.xml
+++ b/app/src/main/res/layout/screen_scan_simple.xml
@@ -127,6 +127,7 @@
             android:hint="@string/scansimpleid_hint_short_code"
             android:imeOptions="actionSearch"
             android:inputType="number"
+            android:digits="1234567890 "
             android:textAppearance="?attr/textAppearanceHeadline6" />
 
         </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/7069/bug-unable-to-enter-space-while-entering-bp-passport-number-in-scansimpleidscreen