### PR TITLE
Fix uneven spacing between health ID labels and `ADD` button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - Add highlight when newly scanned bp passports are added
 - Index `patientUuid` in tables that are joined in `OverdueAppointment` database view
 - Fix broken back button in `EditPatientScreen`
+- Fix uneven spacing between health ID labels and `ADD` button
 
 ### Changes
 

--- a/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
+++ b/app/src/main/java/org/simple/clinic/editpatient/EditPatientScreen.kt
@@ -560,6 +560,9 @@ class EditPatientScreen : BaseScreen<
 
   override fun displayBpPassports(bpPassports: List<BPPassportListItem>) {
     bpPassportsContainer.removeAllViews()
+
+    bpPassportsContainer.visibleOrGone(bpPassports.isNotEmpty())
+
     bpPassports.forEach { identifier ->
       inflateBpPassportView(identifier)
     }

--- a/app/src/main/res/layout/screen_edit_patient.xml
+++ b/app/src/main/res/layout/screen_edit_patient.xml
@@ -177,6 +177,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/spacing_8"
+        android:visibility="gone"
+        tools:visibility="visible"
         android:orientation="vertical" />
 
       <com.google.android.material.button.MaterialButton


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/7110/ui-improvement-the-spacing-between-health-id-labels-and-add-button-is-uneven