### PR TITLE
Remove Google Guava dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Migrate `AppLockScreen` to use view effects
 - Bump Gradle to v7.4
 - Bump RootBeer to 0.1.0
+- Remove Google Guava dependency
 
 ## 2022-02-07-8126
 

--- a/mobius-migration/build.gradle.kts
+++ b/mobius-migration/build.gradle.kts
@@ -3,8 +3,6 @@ plugins {
 }
 
 dependencies {
-  implementation(libs.guava)
-
   implementation(libs.kotlin.stdlib)
 
   implementation(libs.mobius.core)

--- a/mobius-migration/src/main/java/org/simple/mobius/migration/MobiusTestFixture.kt
+++ b/mobius-migration/src/main/java/org/simple/mobius/migration/MobiusTestFixture.kt
@@ -1,6 +1,5 @@
 package org.simple.mobius.migration
 
-import com.google.common.util.concurrent.MoreExecutors
 import com.spotify.mobius.Connectable
 import com.spotify.mobius.Connection
 import com.spotify.mobius.EventSource
@@ -9,8 +8,8 @@ import com.spotify.mobius.Init
 import com.spotify.mobius.Mobius
 import com.spotify.mobius.MobiusLoop
 import com.spotify.mobius.Update
+import com.spotify.mobius.runners.ImmediateWorkRunner
 import com.spotify.mobius.runners.WorkRunner
-import com.spotify.mobius.runners.WorkRunners
 import com.spotify.mobius.rx2.RxMobius
 import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
@@ -36,7 +35,7 @@ class MobiusTestFixture<M : Any, E, F>(
     get() = controller.model
 
   init {
-    val immediateWorkRunner = WorkRunners.from(MoreExecutors.newDirectExecutorService())
+    val immediateWorkRunner = ImmediateWorkRunner()
     val eventSource = ImmediateEventSource<E>()
     eventsDisposable = events.subscribe(eventSource::notifyEvent)
 


### PR DESCRIPTION
Currently we are using Google Guava dependency for getting a [executor service](https://guava.dev/releases/19.0/api/docs/com/google/common/util/concurrent/MoreExecutors.html#newDirectExecutorService()) in `MobiusTestFixture`, for running tasks in the same thread they are invoked from. The usage can be replaced by [`ImmediateWorker`](https://github.com/spotify/mobius/blob/master/mobius-core/src/main/java/com/spotify/mobius/runners/ImmediateWorkRunner.java) from `mobius` package, which does the same. 