### PR TITLE
Remove Google Guava from `libs.versions` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,13 +45,13 @@
 - Migrate `AppLockScreen` to use view effects
 - Bump Gradle to v7.4
 - Bump RootBeer to 0.1.0
-- Remove Google Guava dependency
 - Bump Google Play Services
   - Auth to v20.1.0
   - Location to v19.0.1
   - Barcode Scanning to v18.0.0
 - Bump leakcanary to 2.8.1
 - Bump coroutines to v1.6.0
+- Remove Google Guava dependency
 
 ## 2022-02-07-8126
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,8 +89,6 @@ flipper-networkPlugin = { module = "com.facebook.flipper:flipper-network-plugin"
 
 google-services = "com.google.gms:google-services:4.3.10"
 
-guava = "com.google.guava:guava:28.1-jre"
-
 itemanimators = "com.mikepenz:itemanimators:1.1.0"
 
 itext7 = "com.itextpdf:itext7-core:7.1.16"


### PR DESCRIPTION
When removing Google Guava dependency in [this](https://github.com/simpledotorg/simple-android/pull/3515) PR, I forgot to remove it from the `libs.versions` file. This PR will remove it from the file.