### PR TITLE
Remove `isFlexibleUpdateType` as parameter from `UpdateInfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Bump sentry to 5.6.1
 - Provide `AppUpdateHelpContact` based on the `Country`
 - Bump flipper to v0.135.0
+- Remove `isFlexibleUpdateType` as parameter from `UpdateInfo`
 
 ### Changes
 

--- a/app/src/main/java/org/simple/clinic/appupdate/CheckAppUpdateAvailability.kt
+++ b/app/src/main/java/org/simple/clinic/appupdate/CheckAppUpdateAvailability.kt
@@ -32,7 +32,7 @@ class CheckAppUpdateAvailability @Inject constructor(
     return updateManager
         .updateInfo()
         .map {
-          if (it.isUpdateAvailable && it.isFlexibleUpdateType) {
+          if (it.isUpdateAvailable) {
             ShowAppUpdate
           } else {
             DontShowAppUpdate
@@ -60,7 +60,6 @@ class CheckAppUpdateAvailability @Inject constructor(
   private fun checkForUpdate(updateInfo: UpdateInfo, config: AppUpdateConfig): Boolean {
     return features.isEnabled(NotifyAppUpdateAvailable)
         && updateInfo.isUpdateAvailable
-        && updateInfo.isFlexibleUpdateType
         && versionUpdateCheck(updateInfo.availableVersionCode, appContext, config)
   }
 }

--- a/app/src/main/java/org/simple/clinic/appupdate/UpdateInfo.kt
+++ b/app/src/main/java/org/simple/clinic/appupdate/UpdateInfo.kt
@@ -2,6 +2,5 @@ package org.simple.clinic.appupdate
 
 data class UpdateInfo(
     val availableVersionCode: Int,
-    val isUpdateAvailable: Boolean,
-    val isFlexibleUpdateType: Boolean
+    val isUpdateAvailable: Boolean
 )

--- a/app/src/main/java/org/simple/clinic/appupdate/UpdateManager.kt
+++ b/app/src/main/java/org/simple/clinic/appupdate/UpdateManager.kt
@@ -2,7 +2,6 @@ package org.simple.clinic.appupdate
 
 import com.google.android.play.core.appupdate.AppUpdateInfo
 import com.google.android.play.core.appupdate.AppUpdateManager
-import com.google.android.play.core.install.model.AppUpdateType.FLEXIBLE
 import com.google.android.play.core.install.model.UpdateAvailability.UPDATE_AVAILABLE
 import io.reactivex.Observable
 import javax.inject.Inject
@@ -34,7 +33,6 @@ class PlayUpdateManager @Inject constructor(
 
   private fun createUpdateInfo(appUpdateInfo: AppUpdateInfo) = UpdateInfo(
       availableVersionCode = appUpdateInfo.availableVersionCode(),
-      isUpdateAvailable = appUpdateInfo.updateAvailability() == UPDATE_AVAILABLE,
-      isFlexibleUpdateType = appUpdateInfo.isUpdateTypeAllowed(FLEXIBLE)
+      isUpdateAvailable = appUpdateInfo.updateAvailability() == UPDATE_AVAILABLE
   )
 }

--- a/app/src/test/java/org/simple/clinic/appupdate/CheckAppUpdateAvailabilityTest.kt
+++ b/app/src/test/java/org/simple/clinic/appupdate/CheckAppUpdateAvailabilityTest.kt
@@ -1,7 +1,6 @@
 package org.simple.clinic.appupdate
 
 import android.app.Application
-import android.app.PendingIntent
 import com.google.android.play.core.install.model.UpdateAvailability
 import com.nhaarman.mockitokotlin2.mock
 import io.reactivex.subjects.PublishSubject
@@ -30,11 +29,9 @@ class CheckAppUpdateAvailabilityTest {
   fun `when app update is available and it is eligible for updates, then the user should be nudged for an app update`(
       availableVersionCode: Int,
       updateAvailabilityState: Int,
-      flexibleUpdateIntent: PendingIntent?,
       isInAppUpdateEnabled: Boolean,
       appUpdateState: AppUpdateState
   ) {
-
     val isUpdateAvailable = updateAvailabilityState == UpdateAvailability.UPDATE_AVAILABLE
     val updateInfo = UpdateInfo(
         availableVersionCode = availableVersionCode,
@@ -61,53 +58,40 @@ class CheckAppUpdateAvailabilityTest {
     fun testCase(
         versionCode: Int,
         updateAvailabilityState: Int,
-        flexibleUpdateIntent: PendingIntent?,
         isInAppUpdateEnabled: Boolean,
         appUpdateState: AppUpdateState
     ): List<Any?> {
-      return listOf(versionCode, updateAvailabilityState, flexibleUpdateIntent, isInAppUpdateEnabled, appUpdateState)
+      return listOf(versionCode, updateAvailabilityState, isInAppUpdateEnabled, appUpdateState)
     }
 
     return listOf(
         testCase(
             versionCode = 1,
             updateAvailabilityState = UpdateAvailability.UPDATE_AVAILABLE,
-            flexibleUpdateIntent = mock(),
             isInAppUpdateEnabled = true,
             appUpdateState = DontShowAppUpdate
         ),
         testCase(
             versionCode = 2111,
             updateAvailabilityState = UpdateAvailability.UPDATE_NOT_AVAILABLE,
-            flexibleUpdateIntent = mock(),
-            isInAppUpdateEnabled = true,
-            appUpdateState = DontShowAppUpdate
-        ),
-        testCase(
-            versionCode = 2000,
-            updateAvailabilityState = UpdateAvailability.UPDATE_AVAILABLE,
-            flexibleUpdateIntent = null,
             isInAppUpdateEnabled = true,
             appUpdateState = DontShowAppUpdate
         ),
         testCase(
             versionCode = 1000,
             updateAvailabilityState = UpdateAvailability.UPDATE_AVAILABLE,
-            flexibleUpdateIntent = mock(),
             isInAppUpdateEnabled = false,
             appUpdateState = DontShowAppUpdate
         ),
         testCase(
             versionCode = 2,
             updateAvailabilityState = UpdateAvailability.UPDATE_AVAILABLE,
-            flexibleUpdateIntent = mock(),
             isInAppUpdateEnabled = true,
             appUpdateState = ShowAppUpdate
         ),
         testCase(
             versionCode = 2111,
             updateAvailabilityState = UpdateAvailability.UPDATE_AVAILABLE,
-            flexibleUpdateIntent = mock(),
             isInAppUpdateEnabled = true,
             appUpdateState = ShowAppUpdate
         )

--- a/app/src/test/java/org/simple/clinic/appupdate/CheckAppUpdateAvailabilityTest.kt
+++ b/app/src/test/java/org/simple/clinic/appupdate/CheckAppUpdateAvailabilityTest.kt
@@ -3,7 +3,7 @@ package org.simple.clinic.appupdate
 import android.app.Application
 import com.google.android.play.core.install.model.UpdateAvailability
 import com.nhaarman.mockitokotlin2.mock
-import io.reactivex.subjects.PublishSubject
+import io.reactivex.Observable
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Test
@@ -18,9 +18,9 @@ import org.simple.clinic.remoteconfig.NoOpRemoteConfigService
 @RunWith(JUnitParamsRunner::class)
 class CheckAppUpdateAvailabilityTest {
 
-  private val configProvider = PublishSubject.create<AppUpdateConfig>()
   private val currentAppVersionCode = 1
   private val differenceInVersionsToShowUpdate = 1
+  private val config = Observable.just(AppUpdateConfig(differenceBetweenVersionsToNudge = 1))
 
   lateinit var checkUpdateAvailable: CheckAppUpdateAvailability
 
@@ -43,8 +43,6 @@ class CheckAppUpdateAvailabilityTest {
     val testObserver = checkUpdateAvailable
         .shouldNudgeForUpdate(updateInfo)
         .test()
-
-    configProvider.onNext(AppUpdateConfig(1))
 
     with(testObserver) {
       assertNoErrors()
@@ -111,7 +109,7 @@ class CheckAppUpdateAvailabilityTest {
     )
     checkUpdateAvailable = CheckAppUpdateAvailability(
         appContext = mock(),
-        config = configProvider,
+        config = config,
         updateManager = mock(),
         versionUpdateCheck = versionCodeCheck,
         features = features

--- a/app/src/test/java/org/simple/clinic/appupdate/CheckAppUpdateAvailabilityTest.kt
+++ b/app/src/test/java/org/simple/clinic/appupdate/CheckAppUpdateAvailabilityTest.kt
@@ -38,8 +38,7 @@ class CheckAppUpdateAvailabilityTest {
     val isUpdateAvailable = updateAvailabilityState == UpdateAvailability.UPDATE_AVAILABLE
     val updateInfo = UpdateInfo(
         availableVersionCode = availableVersionCode,
-        isUpdateAvailable = isUpdateAvailable,
-        isFlexibleUpdateType = flexibleUpdateIntent != null
+        isUpdateAvailable = isUpdateAvailable
     )
 
     setup(isFeatureEnabled = isInAppUpdateEnabled)


### PR DESCRIPTION
Since we are not using the `AppUpdateManager` to start a update flow, it doesn't matter if a update is flexible or immediate, we are not listening to update status in the app. We just open the Google Play page for Simple and let user update from there.