### PR TITLE
Move wildcard formatting to search query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bump flipper to v0.137.0
 - Bump GH Actions `upload-artifact` to v3
 - Bump logback to v1.2.11
+- Move wildcard formatting to search query
 - [In Progress: 17 Feb 2022] Add `CriticalAppUpdateDialog`
 
 ### Changes

--- a/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientRepository.kt
@@ -53,7 +53,7 @@ class PatientRepository @Inject constructor(
       is Name -> criteria.patientName
       is NumericCriteria -> criteria.numericCriteria
     }
-    return database.patientSearchDao().search("*$query*", facilityId)
+    return database.patientSearchDao().search(query, facilityId)
   }
 
   fun patient(uuid: UUID): Observable<Optional<Patient>> {

--- a/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientSearchResult.kt
@@ -73,19 +73,19 @@ data class PatientSearchResult(
       SELECT * FROM (
         SELECT searchResult.* FROM PatientSearchResult searchResult
         JOIN PatientFts patientFts ON patientFts.uuid = searchResult.uuid
-        WHERE patientFts.fullName MATCH :query
+        WHERE patientFts.fullName MATCH "*"||:query||"*"
         
         UNION
         
         SELECT searchResult.* FROM PatientSearchResult searchResult
         JOIN PatientPhoneNumberFts phoneNumberFts ON phoneNumberFts.patientUuid = searchResult.uuid
-        WHERE number MATCH :query
+        WHERE number MATCH "*"||:query||"*"
         
         UNION
         
         SELECT searchResult.* FROM PatientSearchResult searchResult
         JOIN BusinessIdFts businessIdFts ON businessIdFts.patientUuid = searchResult.uuid
-        WHERE searchHelp MATCH :query
+        WHERE searchHelp MATCH "*"||:query||"*"
       )
       GROUP BY uuid
       ORDER BY 


### PR DESCRIPTION
I initially used the wildcard formatting in the repository layer while testing it out. Moved it to query itself to avoid any confusion/issues when using the dao query somewhere else outside of repository layer.