### PR TITLE
Update AVD disk size to 8GB in GH Actions

### DIFF
--- a/.github/workflows/benchmark_suite.yml
+++ b/.github/workflows/benchmark_suite.yml
@@ -32,6 +32,7 @@ jobs:
           api-level: 30
           arch: x86_64
           disable-animations: true
+          disk-size: 8G
           script: |
             adb root
             ./gradlew -PmanifestEndpoint=https://api-sandbox.simple.org/api/ installQaDebug installQaDebugAndroidTest lockClocks

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -139,6 +139,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
+          disk-size: 8G
           script: echo "Generated AVD snapshot for caching."
 
       - name: set up JDK
@@ -170,6 +171,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
+          disk-size: 8G
           script: |
             adb root
             mkdir -p android-app/app/build/outputs/test-artifacts

--- a/.github/workflows/trigger_demo_release.yml
+++ b/.github/workflows/trigger_demo_release.yml
@@ -136,6 +136,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
+          disk-size: 8G
           script: echo "Generated AVD snapshot for caching."
 
       - name: set up JDK
@@ -167,6 +168,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
+          disk-size: 8G
           script: |
             adb root
             mkdir -p android-app/app/build/outputs/test-artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Implement critical app update card in `PatientsTabScreen`
 - Bump flipper to v0.140.0
 - Use `RecyclerView.AdapterDataObserver` to scroll to top when drugs are added
+- Update AVD disk size to 8GB in GH Actions
 - [In Progress: 29 Mar 2022] Implement showing app update nudges based on the priority in `PatientTabScreen`
 
 ### Features


### PR DESCRIPTION
I have noticed couple of Android tests failed with no space error. So, set the disk size to 8 GB for AVD