### PR TITLE
Remove marking older appointments for a patient as a side effect when scheduling an appointment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bump sentry-android to 5.7.1
 - Bump sentry gradle plugin to 3.0.1
 - Implement showing app update nudges based on the priority in `PatientTabScreen`
+- Remove marking older appointments for a patient as a side effect when scheduling an appointment
 
 ### Features
 

--- a/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/overdue/AppointmentRepositoryAndroidTest.kt
@@ -146,63 +146,6 @@ class AppointmentRepositoryAndroidTest {
   }
 
   @Test
-  fun when_creating_new_appointment_then_all_old_appointments_for_that_patient_should_be_marked_as_visited() {
-    // given
-    val firstAppointmentUuid = UUID.fromString("0bc9cdb3-bfe9-41e9-88b9-2a072c748c47")
-    val scheduledDateOfFirstAppointment = LocalDate.parse("2018-01-01")
-    val firstAppointmentScheduledAtTimestamp = Instant.now(clock)
-    appointmentRepository.schedule(
-        patientUuid = patientUuid,
-        appointmentUuid = firstAppointmentUuid,
-        appointmentDate = scheduledDateOfFirstAppointment,
-        appointmentType = Manual,
-        appointmentFacilityUuid = facility.uuid,
-        creationFacilityUuid = facility.uuid
-    )
-    markAppointmentSyncStatusAsDone(firstAppointmentUuid)
-
-    clock.advanceBy(Duration.ofHours(24))
-
-    val secondAppointmentUuid = UUID.fromString("ed31c3ae-8903-45fe-9ad3-0302dcba7fc6")
-    val scheduleDateOfSecondAppointment = LocalDate.parse("2018-02-01")
-    val secondAppointmentScheduledAtTimestamp = Instant.now(clock)
-
-    // when
-    appointmentRepository.schedule(
-        patientUuid = patientUuid,
-        appointmentUuid = secondAppointmentUuid,
-        appointmentDate = scheduleDateOfSecondAppointment,
-        appointmentType = Manual,
-        appointmentFacilityUuid = facility.uuid,
-        creationFacilityUuid = facility.uuid
-    )
-
-    // then
-    val firstAppointment = getAppointmentByUuid(firstAppointmentUuid)
-    with(firstAppointment) {
-      assertThat(patientUuid).isEqualTo(this@AppointmentRepositoryAndroidTest.patientUuid)
-      assertThat(scheduledDate).isEqualTo(scheduledDateOfFirstAppointment)
-      assertThat(status).isEqualTo(Visited)
-      assertThat(cancelReason).isEqualTo(null)
-      assertThat(syncStatus).isEqualTo(PENDING)
-      assertThat(createdAt).isEqualTo(firstAppointmentScheduledAtTimestamp)
-      assertThat(createdAt).isLessThan(secondAppointmentScheduledAtTimestamp)
-      assertThat(updatedAt).isEqualTo(secondAppointmentScheduledAtTimestamp)
-    }
-
-    val secondAppointment = getAppointmentByUuid(secondAppointmentUuid)
-    with(secondAppointment) {
-      assertThat(patientUuid).isEqualTo(this@AppointmentRepositoryAndroidTest.patientUuid)
-      assertThat(scheduledDate).isEqualTo(scheduleDateOfSecondAppointment)
-      assertThat(status).isEqualTo(Scheduled)
-      assertThat(cancelReason).isEqualTo(null)
-      assertThat(syncStatus).isEqualTo(PENDING)
-      assertThat(createdAt).isEqualTo(secondAppointmentScheduledAtTimestamp)
-      assertThat(updatedAt).isEqualTo(secondAppointmentScheduledAtTimestamp)
-    }
-  }
-
-  @Test
   fun deleted_blood_pressure_measurements_should_not_be_considered_when_fetching_overdue_appointments() {
     fun createBloodPressure(
         bpUuid: UUID,

--- a/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
@@ -279,6 +279,9 @@ data class Appointment(
     @Query(""" SELECT * FROM Appointment """)
     fun getAllAppointments(): List<Appointment>
 
+    @Query(""" SELECT * FROM Appointment WHERE patientUuid = :patientUuid """)
+    fun getAllAppointmentsForPatient(patientUuid: UUID): List<Appointment>
+
     @Query("""
         DELETE FROM Appointment
         WHERE 

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
@@ -37,7 +37,6 @@ class AppointmentRepository @Inject constructor(
       appointmentFacilityUuid: UUID,
       creationFacilityUuid: UUID
   ): Appointment {
-
     val appointment = Appointment(
         uuid = appointmentUuid,
         patientUuid = patientUuid,
@@ -55,8 +54,6 @@ class AppointmentRepository @Inject constructor(
         creationFacilityUuid = creationFacilityUuid
     )
 
-    // TODO (vs) 20/05/20: Remove this side effect from this method
-    markOlderAppointmentsAsVisited(patientUuid)
     appointmentDao.save(listOf(appointment))
     return appointment
   }

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.overdue
 
+import androidx.annotation.VisibleForTesting
 import androidx.paging.PagingSource
 import io.reactivex.Observable
 import org.simple.clinic.home.overdue.OverdueAppointment
@@ -60,7 +61,7 @@ class AppointmentRepository @Inject constructor(
     return appointment
   }
 
-  private fun markOlderAppointmentsAsVisited(patientUuid: UUID) {
+  fun markOlderAppointmentsAsVisited(patientUuid: UUID) {
     appointmentDao.markOlderAppointmentsAsVisited(
         patientUuid = patientUuid,
         updatedStatus = Visited,

--- a/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/AppointmentRepository.kt
@@ -228,4 +228,9 @@ class AppointmentRepository @Inject constructor(
             pendingStatus = PENDING
         )
   }
+
+  @VisibleForTesting
+  fun getAllAppointmentsForPatient(patientUuid: UUID): List<Appointment> {
+    return appointmentDao.getAllAppointmentsForPatient(patientUuid)
+  }
 }

--- a/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentEffectHandler.kt
@@ -143,6 +143,9 @@ class ScheduleAppointmentEffectHandler @AssistedInject constructor(
     return ObservableTransformer { effects ->
       effects
           .doOnNext { scheduleAppointment ->
+            appointmentRepository.markOlderAppointmentsAsVisited(scheduleAppointment.patientUuid)
+          }
+          .doOnNext { scheduleAppointment ->
             appointmentRepository.schedule(
                 patientUuid = scheduleAppointment.patientUuid,
                 appointmentUuid = uuidGenerator.v4(),

--- a/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentEffectHandler.kt
@@ -66,6 +66,9 @@ class ScheduleAppointmentEffectHandler @AssistedInject constructor(
     return ObservableTransformer { effects ->
       effects
           .doOnNext { scheduleAppointment ->
+            appointmentRepository.markOlderAppointmentsAsVisited(scheduleAppointment.patientUuid)
+          }
+          .doOnNext { scheduleAppointment ->
             appointmentRepository.schedule(
                 patientUuid = scheduleAppointment.patientUuid,
                 appointmentUuid = uuidGenerator.v4(),

--- a/app/src/test/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentEffectHandlerTest.kt
@@ -12,6 +12,7 @@ import org.junit.Test
 import org.simple.clinic.TestData
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.mobius.EffectHandlerTestCase
+import org.simple.clinic.overdue.Appointment.AppointmentType.Automatic
 import org.simple.clinic.overdue.Appointment.AppointmentType.Manual
 import org.simple.clinic.overdue.AppointmentConfig
 import org.simple.clinic.overdue.AppointmentRepository
@@ -163,6 +164,36 @@ class ScheduleAppointmentEffectHandlerTest {
         appointmentUuid = appointmentUuid,
         appointmentDate = scheduleDate,
         appointmentType = Manual,
+        appointmentFacilityUuid = facility.uuid,
+        creationFacilityUuid = facility.uuid
+    )
+    verifyNoMoreInteractions(repository)
+
+    verifyZeroInteractions(uiActions)
+  }
+
+  @Test
+  fun `when schedule appointment for patient effect is received, then schedule appointment`() {
+    // given
+    val scheduleDate = LocalDate.parse("2018-01-01")
+
+    // when
+    effectHandlerTestCase.dispatch(ScheduleAppointmentForPatient(
+        patientUuid = patientUuid,
+        scheduledForDate = scheduleDate,
+        scheduledAtFacility = facility,
+        type = Automatic
+    ))
+
+    // then
+    effectHandlerTestCase.assertOutgoingEvents(AppointmentScheduled)
+
+    verify(repository).markOlderAppointmentsAsVisited(patientUuid)
+    verify(repository).schedule(
+        patientUuid = patientUuid,
+        appointmentUuid = appointmentUuid,
+        appointmentDate = scheduleDate,
+        appointmentType = Automatic,
         appointmentFacilityUuid = facility.uuid,
         creationFacilityUuid = facility.uuid
     )

--- a/app/src/test/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentEffectHandlerTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 import org.simple.clinic.TestData
 import org.simple.clinic.facility.FacilityRepository
 import org.simple.clinic.mobius.EffectHandlerTestCase
-import org.simple.clinic.overdue.Appointment
+import org.simple.clinic.overdue.Appointment.AppointmentType.Manual
 import org.simple.clinic.overdue.AppointmentConfig
 import org.simple.clinic.overdue.AppointmentRepository
 import org.simple.clinic.overdue.TimeToAppointment
@@ -142,20 +142,32 @@ class ScheduleAppointmentEffectHandlerTest {
   }
 
   @Test
-  fun `when schedule sppointment for patient from next is received then schedule appointment`() {
+  fun `when schedule appointment for patient from next effect is received, then schedule appointment`() {
     // given
-    val facility = TestData.facility(uuid = UUID.fromString("e4a1f4d7-2444-4686-a6ae-3d15ddb42916"))
+    val scheduleDate = LocalDate.parse("2018-01-01")
 
     // when
     effectHandlerTestCase.dispatch(ScheduleAppointmentForPatientFromNext(
         patientUuid = patientUuid,
-        scheduledForDate = LocalDate.now(),
+        scheduledForDate = scheduleDate,
         scheduledAtFacility = facility,
-        type = Appointment.AppointmentType.Manual
+        type = Manual
     ))
 
     // then
     effectHandlerTestCase.assertOutgoingEvents(AppointmentScheduledForPatientFromNext)
+
+    verify(repository).markOlderAppointmentsAsVisited(patientUuid)
+    verify(repository).schedule(
+        patientUuid = patientUuid,
+        appointmentUuid = appointmentUuid,
+        appointmentDate = scheduleDate,
+        appointmentType = Manual,
+        appointmentFacilityUuid = facility.uuid,
+        creationFacilityUuid = facility.uuid
+    )
+    verifyNoMoreInteractions(repository)
+
     verifyZeroInteractions(uiActions)
   }
 

--- a/app/src/test/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/scheduleappointment/ScheduleAppointmentEffectHandlerTest.kt
@@ -143,7 +143,7 @@ class ScheduleAppointmentEffectHandlerTest {
   }
 
   @Test
-  fun `when schedule appointment for patient from next effect is received, then schedule appointment`() {
+  fun `when schedule appointment for patient from next effect is received, then mark older appointments as visited and schedule appointment`() {
     // given
     val scheduleDate = LocalDate.parse("2018-01-01")
 
@@ -173,7 +173,7 @@ class ScheduleAppointmentEffectHandlerTest {
   }
 
   @Test
-  fun `when schedule appointment for patient effect is received, then schedule appointment`() {
+  fun `when schedule appointment for patient effect is received, then mark older appointments as visited and schedule appointment`() {
     // given
     val scheduleDate = LocalDate.parse("2018-01-01")
 


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/7763/remove-marking-older-appointments-for-a-patient-as-a-side-effect-when-scheduling-an-appointment