### PR TITLE
Load clinical decision support info when the patient summary screen is created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Bump datadog to v1.3.0
 - Update flipper to v0.141.0
 - Add a query to check whether the latest BP entry is high for the patient
+- Load clinical decision support info when the patient summary screen is created
 
 ### Features
 

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffect.kt
@@ -33,6 +33,8 @@ object LoadMedicalOfficers : PatientSummaryEffect()
 
 data class LoadPatientRegistrationData(val patientUuid: UUID) : PatientSummaryEffect()
 
+data class LoadClinicalDecisionSupport(val patientUuid: UUID) : PatientSummaryEffect()
+
 sealed class PatientSummaryViewEffect : PatientSummaryEffect()
 
 data class HandleEditClick(

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEvent.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEvent.kt
@@ -94,3 +94,5 @@ object NextAppointmentActionClicked : PatientSummaryEvent() {
 }
 
 object AssignedFacilityChanged : PatientSummaryEvent()
+
+data class ClinicalDecisionSupportInfoLoaded(val isNewestBpEntryHigh: Boolean) : PatientSummaryEvent()

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryInit.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryInit.kt
@@ -7,7 +7,10 @@ import com.spotify.mobius.Init
 class PatientSummaryInit : Init<PatientSummaryModel, PatientSummaryEffect> {
 
   override fun init(model: PatientSummaryModel): First<PatientSummaryModel, PatientSummaryEffect> {
-    val effects = mutableSetOf<PatientSummaryEffect>(LoadPatientSummaryProfile(model.patientUuid))
+    val effects = mutableSetOf(
+        LoadPatientSummaryProfile(model.patientUuid),
+        LoadClinicalDecisionSupport(model.patientUuid)
+    )
 
     if (!model.hasUserLoggedInStatus || !model.hasLoadedCurrentFacility) {
       effects.add(LoadCurrentUserAndFacility)

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
@@ -62,6 +62,7 @@ class PatientSummaryUpdate : Update<PatientSummaryModel, PatientSummaryEvent, Pa
           model.currentFacility!!
       ))
       AssignedFacilityChanged -> dispatch(RefreshNextAppointment)
+      is ClinicalDecisionSupportInfoLoaded -> noChange()
     }
   }
 

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
@@ -524,4 +524,19 @@ class PatientSummaryEffectHandlerTest {
     verify(uiActions).refreshNextAppointment()
     verifyNoMoreInteractions(uiActions)
   }
+
+  @Test
+  fun `when load clinical decision support effect is received, then load clinical decision support info`() {
+    // given
+    val patientUuid = UUID.fromString("44daeb85-de4c-4807-8b31-6a88bf597cc7")
+
+    whenever(bloodPressureRepository.isNewestBpEntryHigh(patientUuid)).doReturn(Observable.just(true))
+
+    // when
+    testCase.dispatch(LoadClinicalDecisionSupport(patientUuid))
+
+    // then
+    testCase.assertOutgoingEvents(ClinicalDecisionSupportInfoLoaded(isNewestBpEntryHigh = true))
+    verifyZeroInteractions(uiActions)
+  }
 }

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryInitTest.kt
@@ -29,7 +29,8 @@ class PatientSummaryInitTest {
                     LoadCurrentUserAndFacility,
                     CheckForInvalidPhone(patientUuid),
                     LoadMedicalOfficers,
-                    LoadPatientRegistrationData(patientUuid)
+                    LoadPatientRegistrationData(patientUuid),
+                    LoadClinicalDecisionSupport(patientUuid)
                 )
             )
         )
@@ -60,7 +61,10 @@ class PatientSummaryInitTest {
         .then(
             assertThatFirst(
                 hasModel(model),
-                hasEffects(LoadPatientSummaryProfile(patientUuid) as PatientSummaryEffect)
+                hasEffects(
+                    LoadPatientSummaryProfile(patientUuid) as PatientSummaryEffect,
+                    LoadClinicalDecisionSupport(patientUuid)
+                )
             )
         )
   }

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenLogicTest.kt
@@ -76,6 +76,7 @@ class PatientSummaryScreenLogicTest {
 
   @Before
   fun setUp() {
+    whenever(bpRepository.isNewestBpEntryHigh(patientUuid)) doReturn Observable.just(true)
     whenever(patientRepository.patientProfile(patientUuid)) doReturn Observable.just<Optional<PatientProfile>>(Optional.of(patientProfile))
     whenever(patientRepository.latestPhoneNumberForPatient(patientUuid)) doReturn Optional.empty()
     whenever(appointmentRepository.lastCreatedAppointmentForPatient(patientUuid)) doReturn Optional.empty()


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/7768/load-clinical-decision-support-info-when-the-patient-summary-screen-is-created

To be merged in after #3666 