### PR TITLE
Hide clinical decision support alert banner when edit medicines are clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Bump coroutines to v1.6.0
 - Implemented the support for DrugStockReminder API
 - Show the clinical decision support banner in summary screen when newest BP entry is high for the patient
+- Hide clinical decision support alert banner when edit medicines are clicked
 
 ### Features
 

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -658,11 +658,19 @@ class PatientSummaryScreen :
     clinicalDecisionSupportAlertView.translationY = clinicalDecisionSupportAlertView.height.unaryMinus().toFloat()
 
     val spring = clinicalDecisionSupportAlertView.spring(DynamicAnimation.TRANSLATION_Y)
+
+    val transition = AutoTransition().apply {
+      excludeChildren(clinicalDecisionSupportAlertView, true)
+      excludeTarget(R.id.newBPItemContainer, true)
+      excludeTarget(R.id.bloodSugarItemContainer, true)
+      excludeTarget(R.id.drugsSummaryContainer, true)
+    }
     val transitionListener = object : Transition.TransitionListener {
       override fun onTransitionStart(transition: Transition) {
       }
 
       override fun onTransitionEnd(transition: Transition) {
+        transition.removeListener(this)
         spring.animateToFinalPosition(0f)
       }
 
@@ -675,11 +683,8 @@ class PatientSummaryScreen :
       override fun onTransitionResume(transition: Transition) {
       }
     }
-
-    TransitionManager.beginDelayedTransition(summaryViewsContainer, AutoTransition().apply {
-      excludeChildren(clinicalDecisionSupportAlertView, true)
-      addListener(transitionListener)
-    })
+    transition.addListener(transitionListener)
+    TransitionManager.beginDelayedTransition(summaryViewsContainer, transition)
 
     clinicalDecisionSupportAlertView.visibility = VISIBLE
   }
@@ -702,30 +707,15 @@ class PatientSummaryScreen :
     spring.addEndListener(listener)
     clinicalDecisionSupportAlertView.setTag(R.id.tag_clinical_decision_pending_end_listener, listener)
 
-    val transitionListener = object : Transition.TransitionListener {
-      override fun onTransitionStart(transition: Transition) {
-      }
-
-      override fun onTransitionEnd(transition: Transition) {
-        spring.animateToFinalPosition(clinicalDecisionSupportAlertView.height.unaryMinus().toFloat())
-      }
-
-      override fun onTransitionCancel(transition: Transition) {
-      }
-
-      override fun onTransitionPause(transition: Transition) {
-      }
-
-      override fun onTransitionResume(transition: Transition) {
-      }
-    }
-
-    TransitionManager.beginDelayedTransition(summaryViewsContainer, AutoTransition().apply {
+    val transition = AutoTransition().apply {
       excludeChildren(clinicalDecisionSupportAlertView, true)
-      addListener(transitionListener)
-    })
+      excludeTarget(R.id.newBPItemContainer, true)
+      excludeTarget(R.id.bloodSugarItemContainer, true)
+      excludeTarget(R.id.drugsSummaryContainer, true)
+    }
+    TransitionManager.beginDelayedTransition(summaryViewsContainer, transition)
 
-    clinicalDecisionSupportAlertView.visibility = VISIBLE
+    spring.animateToFinalPosition(clinicalDecisionSupportAlertView.height.unaryMinus().toFloat())
   }
 
   interface Injector {

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -424,8 +424,8 @@ class PatientSummaryScreen :
       labelRegistered.visibility = VISIBLE
       facilityNameAndDateTextView.text = facilityNameAndDate
     } else {
-      facilityNameAndDateTextView.visibility = View.GONE
-      labelRegistered.visibility = View.GONE
+      facilityNameAndDateTextView.visibility = GONE
+      labelRegistered.visibility = GONE
     }
   }
 
@@ -572,7 +572,7 @@ class PatientSummaryScreen :
   }
 
   override fun hideTeleconsultButton() {
-    teleconsultButton.visibility = View.GONE
+    teleconsultButton.visibility = GONE
   }
 
   override fun showAssignedFacilityView() {
@@ -580,7 +580,7 @@ class PatientSummaryScreen :
   }
 
   override fun hideAssignedFacilityView() {
-    assignedFacilityView.visibility = View.GONE
+    assignedFacilityView.visibility = GONE
   }
 
   override fun registerSummaryModelUpdateCallback(callback: PatientSummaryModelUpdateCallback?) {
@@ -588,7 +588,7 @@ class PatientSummaryScreen :
   }
 
   override fun hideDoneButton() {
-    doneButtonFrame.visibility = View.GONE
+    doneButtonFrame.visibility = GONE
   }
 
   override fun showTeleconsultLogButton() {
@@ -664,6 +664,50 @@ class PatientSummaryScreen :
 
       override fun onTransitionEnd(transition: Transition) {
         spring.animateToFinalPosition(0f)
+      }
+
+      override fun onTransitionCancel(transition: Transition) {
+      }
+
+      override fun onTransitionPause(transition: Transition) {
+      }
+
+      override fun onTransitionResume(transition: Transition) {
+      }
+    }
+
+    TransitionManager.beginDelayedTransition(summaryViewsContainer, AutoTransition().apply {
+      excludeChildren(clinicalDecisionSupportAlertView, true)
+      addListener(transitionListener)
+    })
+
+    clinicalDecisionSupportAlertView.visibility = VISIBLE
+  }
+
+  override fun hideClinicalDecisionSupportAlert() {
+    if (clinicalDecisionSupportAlertView.visibility != VISIBLE) return
+
+    val spring = clinicalDecisionSupportAlertView.spring(DynamicAnimation.TRANSLATION_Y)
+    (clinicalDecisionSupportAlertView.getTag(R.id.tag_clinical_decision_pending_end_listener) as?
+        DynamicAnimation.OnAnimationEndListener)?.let {
+      spring.removeEndListener(it)
+    }
+
+    val listener = object : DynamicAnimation.OnAnimationEndListener {
+      override fun onAnimationEnd(animation: DynamicAnimation<*>?, canceled: Boolean, value: Float, velocity: Float) {
+        spring.removeEndListener(this)
+        clinicalDecisionSupportAlertView.visibility = GONE
+      }
+    }
+    spring.addEndListener(listener)
+    clinicalDecisionSupportAlertView.setTag(R.id.tag_clinical_decision_pending_end_listener, listener)
+
+    val transitionListener = object : Transition.TransitionListener {
+      override fun onTransitionStart(transition: Transition) {
+      }
+
+      override fun onTransitionEnd(transition: Transition) {
+        spring.animateToFinalPosition(clinicalDecisionSupportAlertView.height.unaryMinus().toFloat())
       }
 
       override fun onTransitionCancel(transition: Transition) {

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -720,6 +720,10 @@ class PatientSummaryScreen :
     spring.animateToFinalPosition(clinicalDecisionSupportAlertView.height.unaryMinus().toFloat())
   }
 
+  override fun hideClinicalDecisionSupportAlertWithoutAnimation() {
+    clinicalDecisionSupportAlertView.visibility = GONE
+  }
+
   interface Injector {
     fun inject(target: PatientSummaryScreen)
   }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreen.kt
@@ -664,6 +664,8 @@ class PatientSummaryScreen :
       excludeTarget(R.id.newBPItemContainer, true)
       excludeTarget(R.id.bloodSugarItemContainer, true)
       excludeTarget(R.id.drugsSummaryContainer, true)
+      // We are doing this to wait for the router transitions to be done before we start this.
+      startDelay = 500
     }
     val transitionListener = object : Transition.TransitionListener {
       override fun onTransitionStart(transition: Transition) {

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreenUi.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreenUi.kt
@@ -17,4 +17,5 @@ interface PatientSummaryScreenUi {
   fun hideNextAppointmentCard()
   fun showClinicalDecisionSupportAlert()
   fun hideClinicalDecisionSupportAlert()
+  fun hideClinicalDecisionSupportAlertWithoutAnimation()
 }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreenUi.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryScreenUi.kt
@@ -16,4 +16,5 @@ interface PatientSummaryScreenUi {
   fun showNextAppointmentCard()
   fun hideNextAppointmentCard()
   fun showClinicalDecisionSupportAlert()
+  fun hideClinicalDecisionSupportAlert()
 }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryViewRenderer.kt
@@ -39,6 +39,8 @@ class PatientSummaryViewRenderer(
   private fun renderClinicalDecisionSupportAlert(isNewestBpEntryHigh: Boolean) {
     if (isNewestBpEntryHigh) {
       ui.showClinicalDecisionSupportAlert()
+    } else {
+      ui.hideClinicalDecisionSupportAlert()
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryViewRenderer.kt
@@ -28,21 +28,23 @@ class PatientSummaryViewRenderer(
       }
 
       renderNextAppointmentCard(model)
-
-      val canShowClinicalDecisionSupportAlert = model.hasPatientRegistrationData == true && model.readyToRender()
-      if (canShowClinicalDecisionSupportAlert) {
-        clinicalDecisionSupportCallback.pass(model.isNewestBpEntryHigh == true, ::renderClinicalDecisionSupportAlert)
-      } else {
-        ui.hideClinicalDecisionSupportAlertWithoutAnimation()
-      }
+      renderClinicalDecisionSupportAlert(model)
     }
   }
 
-  private fun renderClinicalDecisionSupportAlert(isNewestBpEntryHigh: Boolean) {
-    if (isNewestBpEntryHigh) {
-      ui.showClinicalDecisionSupportAlert()
-    } else {
-      ui.hideClinicalDecisionSupportAlert()
+  private fun renderClinicalDecisionSupportAlert(model: PatientSummaryModel) {
+    val canShowClinicalDecisionSupportAlert = model.hasPatientRegistrationData == true && model.readyToRender()
+    if (!canShowClinicalDecisionSupportAlert) {
+      ui.hideClinicalDecisionSupportAlertWithoutAnimation()
+      return
+    }
+
+    clinicalDecisionSupportCallback.pass(model.isNewestBpEntryHigh == true) { isNewestBpEntryHigh ->
+      if (isNewestBpEntryHigh) {
+        ui.showClinicalDecisionSupportAlert()
+      } else {
+        ui.hideClinicalDecisionSupportAlert()
+      }
     }
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryViewRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryViewRenderer.kt
@@ -32,6 +32,8 @@ class PatientSummaryViewRenderer(
       val canShowClinicalDecisionSupportAlert = model.hasPatientRegistrationData == true && model.readyToRender()
       if (canShowClinicalDecisionSupportAlert) {
         clinicalDecisionSupportCallback.pass(model.isNewestBpEntryHigh == true, ::renderClinicalDecisionSupportAlert)
+      } else {
+        ui.hideClinicalDecisionSupportAlertWithoutAnimation()
       }
     }
   }

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -14,4 +14,5 @@
   <item name="spring_animation_alpha" type="id" />
   <item name="spring_animation_scrollx" type="id" />
   <item name="spring_animation_scrollY" type="id" />
+  <item name="tag_clinical_decision_pending_end_listener" type="id" />
 </resources>

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryViewRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryViewRendererTest.kt
@@ -51,6 +51,7 @@ class PatientSummaryViewRendererTest {
     verify(ui).showDiabetesView()
     verify(ui).hideTeleconsultButton()
     verify(ui).hideNextAppointmentCard()
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verifyNoMoreInteractions(ui)
   }
 
@@ -66,6 +67,7 @@ class PatientSummaryViewRendererTest {
     verify(ui).hideDiabetesView()
     verify(ui).hideTeleconsultButton()
     verify(ui).hideNextAppointmentCard()
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verifyNoMoreInteractions(ui)
   }
 
@@ -104,6 +106,7 @@ class PatientSummaryViewRendererTest {
     verify(ui).hideAssignedFacilityView()
     verify(ui).hidePatientDiedStatus()
     verify(ui).hideNextAppointmentCard()
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verifyNoMoreInteractions(ui)
   }
 
@@ -121,6 +124,7 @@ class PatientSummaryViewRendererTest {
     verify(ui).showDiabetesView()
     verify(ui).hideTeleconsultButton()
     verify(ui).hideNextAppointmentCard()
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verifyNoMoreInteractions(ui)
   }
 
@@ -142,6 +146,7 @@ class PatientSummaryViewRendererTest {
     verify(ui).showDiabetesView()
     verify(ui).showTeleconsultButton()
     verify(ui).hideNextAppointmentCard()
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verifyNoMoreInteractions(ui)
   }
 
@@ -159,6 +164,7 @@ class PatientSummaryViewRendererTest {
     verify(ui).showDiabetesView()
     verify(ui).hideTeleconsultButton()
     verify(ui).hideNextAppointmentCard()
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verifyNoMoreInteractions(ui)
   }
 
@@ -198,6 +204,7 @@ class PatientSummaryViewRendererTest {
     verify(ui).showAssignedFacilityView()
     verify(ui).hidePatientDiedStatus()
     verify(ui).hideNextAppointmentCard()
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verifyNoMoreInteractions(ui)
   }
 
@@ -237,6 +244,7 @@ class PatientSummaryViewRendererTest {
     verify(ui).hideAssignedFacilityView()
     verify(ui).hidePatientDiedStatus()
     verify(ui).hideNextAppointmentCard()
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verifyNoMoreInteractions(ui)
   }
 
@@ -260,6 +268,7 @@ class PatientSummaryViewRendererTest {
     verify(ui).hideDoneButton()
     verify(ui).showTeleconsultLogButton()
     verify(ui).hideNextAppointmentCard()
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verifyNoMoreInteractions(ui)
   }
 
@@ -297,6 +306,7 @@ class PatientSummaryViewRendererTest {
     verify(ui).hideAssignedFacilityView()
     verify(ui).hidePatientDiedStatus()
     verify(ui).hideNextAppointmentCard()
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verifyNoMoreInteractions(ui)
   }
 
@@ -334,6 +344,7 @@ class PatientSummaryViewRendererTest {
     verify(ui).hideAssignedFacilityView()
     verify(ui).showPatientDiedStatus()
     verify(ui).hideNextAppointmentCard()
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verifyNoMoreInteractions(ui)
   }
 
@@ -348,6 +359,7 @@ class PatientSummaryViewRendererTest {
 
     // then
     verify(ui).showNextAppointmentCard()
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verifyNoMoreInteractions(ui)
   }
 
@@ -362,6 +374,7 @@ class PatientSummaryViewRendererTest {
 
     // then
     verify(ui).hideNextAppointmentCard()
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verifyNoMoreInteractions(ui)
   }
 
@@ -376,6 +389,7 @@ class PatientSummaryViewRendererTest {
 
     // then
     verify(ui).hideNextAppointmentCard()
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verifyNoMoreInteractions(ui)
   }
 
@@ -463,6 +477,21 @@ class PatientSummaryViewRendererTest {
     verify(ui).hideDiabetesView()
     verify(ui).hideTeleconsultButton()
     verify(ui).hideClinicalDecisionSupportAlert()
+    verify(ui).hideNextAppointmentCard()
+    verifyNoMoreInteractions(ui)
+  }
+
+  @Test
+  fun `when clinical decision support alert cannot be shown, then hide the clinical decision support view without animation`() {
+    // given
+    val updatedModel = defaultModel
+        .clinicalDecisionSupportInfoLoaded(isNewestBpEntryHigh = false)
+
+    // when
+    uiRenderer.render(updatedModel)
+
+    // then
+    verify(ui).hideClinicalDecisionSupportAlertWithoutAnimation()
     verify(ui).hideNextAppointmentCard()
     verifyNoMoreInteractions(ui)
   }

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryViewRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryViewRendererTest.kt
@@ -422,4 +422,48 @@ class PatientSummaryViewRendererTest {
     verify(ui).hideNextAppointmentCard()
     verifyNoMoreInteractions(ui)
   }
+
+  @Test
+  fun `when newest BP entry for the patient is not high, then hide the clinical decision support view`() {
+    // given
+    val patientUuid = UUID.fromString("6274ca08-2432-43fe-ae04-35f623e5325c")
+    val patient = TestData.patient(
+        uuid = patientUuid,
+        status = PatientStatus.Dead
+    )
+    val patientAddress = TestData.patientAddress(patient.addressUuid)
+    val phoneNumber = TestData.patientPhoneNumber(patientUuid = patientUuid)
+    val bpPassport = TestData.businessId(patientUuid = patientUuid, identifier = Identifier("526 780", Identifier.IdentifierType.BpPassport))
+    val bangladeshNationalId = TestData.businessId(patientUuid = patientUuid, identifier = Identifier("123456789012", Identifier.IdentifierType.BangladeshNationalId))
+    val facility = TestData.facility(uuid = UUID.fromString("744ac1b1-8352-4793-876c-538fc1129239"))
+
+    val patientSummaryProfile = PatientSummaryProfile(
+        patient = patient,
+        address = patientAddress,
+        phoneNumber = phoneNumber,
+        bpPassport = bpPassport,
+        alternativeId = bangladeshNationalId,
+        facility = facility
+    )
+
+    val updatedModel = defaultModel
+        .patientRegistrationDataLoaded(hasPatientRegistrationData = true)
+        .currentFacilityLoaded(facility = facility)
+        .patientSummaryProfileLoaded(patientSummaryProfile = patientSummaryProfile)
+        .clinicalDecisionSupportInfoLoaded(isNewestBpEntryHigh = false)
+
+    // when
+    uiRenderer.render(updatedModel)
+
+    // then
+    verify(ui).populatePatientProfile(patientSummaryProfile)
+    verify(ui).showEditButton()
+    verify(ui).hideAssignedFacilityView()
+    verify(ui).showPatientDiedStatus()
+    verify(ui).hideDiabetesView()
+    verify(ui).hideTeleconsultButton()
+    verify(ui).hideClinicalDecisionSupportAlert()
+    verify(ui).hideNextAppointmentCard()
+    verifyNoMoreInteractions(ui)
+  }
 }


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/7770/hide-clinical-decision-support-alert-banner-when-edit-medicines-are-clicked