### PR TITLE
Use personal access token when checking out repo in `cut_release_branch` workflow

### DIFF
--- a/.github/workflows/cut_release_branch.yml
+++ b/.github/workflows/cut_release_branch.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
+          token: ${{ secrets.SERVICES_ACCESS_TOKEN }}
 
       - name: Cut release branch
         run: kotlinc -script ".github/scripts/CutReleaseBranch.main.kts"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Add Hindi translations for CDS alert
 - Add remote config key for `NotifyAppUpdateAvailableV2` feature flag 
 - Add GitHub action to cut a release branch
+- Use personal access token when checking out repo in `cut_release_branch` workflow
 
 ### Features
 


### PR DESCRIPTION
Since we want the release branch creation to run a different workflow (triggering demo release). We need to use PAT (Personal Access Token) instead of GITHUB_TOKEN in GH Actions to do that.