### PR TITLE
Migrate `BloodPressureHistoryScreenEffectHandler` to use view effects - 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bump kotlin to v1.6.21
 - Bump Lottie to v5.1.1
 - Migrate `DeletePatientEffectHandler` to use view effects
+- [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effects 
 
 ### Features
 

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
@@ -122,6 +122,8 @@ class BloodPressureHistoryScreen : BaseScreen<
 
   override fun uiRenderer() = BloodPressureHistoryScreenUiRenderer(this)
 
+  override fun viewEffectHandler() = BloodPressureHistoryViewEffectHandler(uiActions = this)
+
   override fun bindView(
       layoutInflater: LayoutInflater,
       container: ViewGroup?

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
@@ -52,7 +52,7 @@ class BloodPressureHistoryScreen : BaseScreen<
     BloodPressureHistoryScreenModel,
     BloodPressureHistoryScreenEvent,
     BloodPressureHistoryScreenEffect,
-    Unit>(), BloodPressureHistoryScreenUi, BloodPressureHistoryScreenUiActions {
+    BloodPressureHistoryViewEffect>(), BloodPressureHistoryScreenUi, BloodPressureHistoryScreenUiActions {
 
   @Inject
   lateinit var utcClock: UtcClock
@@ -118,7 +118,7 @@ class BloodPressureHistoryScreen : BaseScreen<
 
   override fun createUpdate() = BloodPressureHistoryScreenUpdate()
 
-  override fun createEffectHandler(viewEffectsConsumer: Consumer<Unit>) = effectHandler.create(this).build()
+  override fun createEffectHandler(viewEffectsConsumer: Consumer<BloodPressureHistoryViewEffect>) = effectHandler.create(this).build()
 
   override fun uiRenderer() = BloodPressureHistoryScreenUiRenderer(this)
 

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
@@ -118,7 +118,11 @@ class BloodPressureHistoryScreen : BaseScreen<
 
   override fun createUpdate() = BloodPressureHistoryScreenUpdate()
 
-  override fun createEffectHandler(viewEffectsConsumer: Consumer<BloodPressureHistoryViewEffect>) = effectHandler.create(this).build()
+  override fun createEffectHandler(viewEffectsConsumer: Consumer<BloodPressureHistoryViewEffect>) = effectHandler
+      .create(
+          uiActions = this,
+          viewEffectsConsumer = viewEffectsConsumer
+      ).build()
 
   override fun uiRenderer() = BloodPressureHistoryScreenUiRenderer(this)
 

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffect.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffect.kt
@@ -7,10 +7,10 @@ sealed class BloodPressureHistoryScreenEffect
 
 data class LoadPatient(val patientUuid: UUID) : BloodPressureHistoryScreenEffect()
 
-data class OpenBloodPressureEntrySheet(val patientUuid: UUID) : BloodPressureHistoryScreenEffect()
-
 data class OpenBloodPressureUpdateSheet(val bloodPressureMeasurement: BloodPressureMeasurement) : BloodPressureHistoryScreenEffect()
 
 data class ShowBloodPressures(val patientUuid: UUID) : BloodPressureHistoryScreenEffect()
 
 sealed class BloodPressureHistoryViewEffect : BloodPressureHistoryScreenEffect()
+
+data class OpenBloodPressureEntrySheet(val patientUuid: UUID) : BloodPressureHistoryViewEffect()

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffect.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffect.kt
@@ -12,3 +12,5 @@ data class OpenBloodPressureEntrySheet(val patientUuid: UUID) : BloodPressureHis
 data class OpenBloodPressureUpdateSheet(val bloodPressureMeasurement: BloodPressureMeasurement) : BloodPressureHistoryScreenEffect()
 
 data class ShowBloodPressures(val patientUuid: UUID) : BloodPressureHistoryScreenEffect()
+
+sealed class BloodPressureHistoryViewEffect : BloodPressureHistoryScreenEffect()

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffect.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffect.kt
@@ -7,10 +7,10 @@ sealed class BloodPressureHistoryScreenEffect
 
 data class LoadPatient(val patientUuid: UUID) : BloodPressureHistoryScreenEffect()
 
-data class OpenBloodPressureUpdateSheet(val bloodPressureMeasurement: BloodPressureMeasurement) : BloodPressureHistoryScreenEffect()
-
 data class ShowBloodPressures(val patientUuid: UUID) : BloodPressureHistoryScreenEffect()
 
 sealed class BloodPressureHistoryViewEffect : BloodPressureHistoryScreenEffect()
 
 data class OpenBloodPressureEntrySheet(val patientUuid: UUID) : BloodPressureHistoryViewEffect()
+
+data class OpenBloodPressureUpdateSheet(val bloodPressureMeasurement: BloodPressureMeasurement) : BloodPressureHistoryViewEffect()

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffectHandler.kt
@@ -37,6 +37,7 @@ class BloodPressureHistoryScreenEffectHandler @AssistedInject constructor(
         .subtypeEffectHandler<BloodPressureHistoryScreenEffect, BloodPressureHistoryScreenEvent>()
         .addTransformer(LoadPatient::class.java, loadPatient(schedulersProvider.io()))
         .addConsumer(ShowBloodPressures::class.java, {
+          // TODO (SM): Convert this to paging source and then migrate `ShowBloodPressures` effect to view effect
           val dataSource = bloodPressureRepository.allBloodPressuresDataSource(it.patientUuid).create() as PositionalDataSource<BloodPressureMeasurement>
           val dataSourceFactory = dataSourceFactory.create(dataSource)
 

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffectHandler.kt
@@ -36,7 +36,6 @@ class BloodPressureHistoryScreenEffectHandler @AssistedInject constructor(
     return RxMobius
         .subtypeEffectHandler<BloodPressureHistoryScreenEffect, BloodPressureHistoryScreenEvent>()
         .addTransformer(LoadPatient::class.java, loadPatient(schedulersProvider.io()))
-        .addConsumer(OpenBloodPressureUpdateSheet::class.java, { uiActions.openBloodPressureUpdateSheet(it.bloodPressureMeasurement.uuid) }, schedulersProvider.ui())
         .addConsumer(ShowBloodPressures::class.java, {
           val dataSource = bloodPressureRepository.allBloodPressuresDataSource(it.patientUuid).create() as PositionalDataSource<BloodPressureMeasurement>
           val dataSourceFactory = dataSourceFactory.create(dataSource)

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffectHandler.kt
@@ -36,7 +36,6 @@ class BloodPressureHistoryScreenEffectHandler @AssistedInject constructor(
     return RxMobius
         .subtypeEffectHandler<BloodPressureHistoryScreenEffect, BloodPressureHistoryScreenEvent>()
         .addTransformer(LoadPatient::class.java, loadPatient(schedulersProvider.io()))
-        .addConsumer(OpenBloodPressureEntrySheet::class.java, { uiActions.openBloodPressureEntrySheet(it.patientUuid) }, schedulersProvider.ui())
         .addConsumer(OpenBloodPressureUpdateSheet::class.java, { uiActions.openBloodPressureUpdateSheet(it.bloodPressureMeasurement.uuid) }, schedulersProvider.ui())
         .addConsumer(ShowBloodPressures::class.java, {
           val dataSource = bloodPressureRepository.allBloodPressuresDataSource(it.patientUuid).create() as PositionalDataSource<BloodPressureMeasurement>

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffectHandler.kt
@@ -1,6 +1,7 @@
 package org.simple.clinic.bp.history
 
 import androidx.paging.PositionalDataSource
+import com.spotify.mobius.functions.Consumer
 import com.spotify.mobius.rx2.RxMobius
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -19,13 +20,15 @@ class BloodPressureHistoryScreenEffectHandler @AssistedInject constructor(
     private val patientRepository: PatientRepository,
     private val schedulersProvider: SchedulersProvider,
     private val dataSourceFactory: BloodPressureHistoryListItemDataSourceFactory.Factory,
-    @Assisted private val uiActions: BloodPressureHistoryScreenUiActions
+    @Assisted private val uiActions: BloodPressureHistoryScreenUiActions,
+    @Assisted private val viewEffectsConsumer: Consumer<BloodPressureHistoryViewEffect>
 ) {
 
   @AssistedFactory
   interface Factory {
     fun create(
-        uiActions: BloodPressureHistoryScreenUiActions
+        uiActions: BloodPressureHistoryScreenUiActions,
+        viewEffectsConsumer: Consumer<BloodPressureHistoryViewEffect>
     ): BloodPressureHistoryScreenEffectHandler
   }
 

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffectHandler.kt
@@ -44,6 +44,7 @@ class BloodPressureHistoryScreenEffectHandler @AssistedInject constructor(
 
           uiActions.showBloodPressures(dataSourceFactory)
         }, schedulersProvider.ui())
+        .addConsumer(BloodPressureHistoryViewEffect::class.java, viewEffectsConsumer::accept)
         .build()
   }
 

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryViewEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryViewEffectHandler.kt
@@ -1,0 +1,12 @@
+package org.simple.clinic.bp.history
+
+import org.simple.clinic.mobius.ViewEffectsHandler
+
+class BloodPressureHistoryViewEffectHandler(
+    private val uiActions: BloodPressureHistoryScreenUiActions
+) : ViewEffectsHandler<BloodPressureHistoryViewEffect> {
+
+  override fun handle(viewEffect: BloodPressureHistoryViewEffect) {
+    // no-op
+  }
+}

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryViewEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryViewEffectHandler.kt
@@ -10,6 +10,7 @@ class BloodPressureHistoryViewEffectHandler(
   override fun handle(viewEffect: BloodPressureHistoryViewEffect) {
     when (viewEffect) {
       is OpenBloodPressureEntrySheet -> uiActions.openBloodPressureEntrySheet(viewEffect.patientUuid)
+      is OpenBloodPressureUpdateSheet -> uiActions.openBloodPressureUpdateSheet(viewEffect.bloodPressureMeasurement.uuid)
     }.exhaustive()
   }
 }

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryViewEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryViewEffectHandler.kt
@@ -1,12 +1,15 @@
 package org.simple.clinic.bp.history
 
 import org.simple.clinic.mobius.ViewEffectsHandler
+import org.simple.clinic.util.exhaustive
 
 class BloodPressureHistoryViewEffectHandler(
     private val uiActions: BloodPressureHistoryScreenUiActions
 ) : ViewEffectsHandler<BloodPressureHistoryViewEffect> {
 
   override fun handle(viewEffect: BloodPressureHistoryViewEffect) {
-    // no-op
+    when (viewEffect) {
+      is OpenBloodPressureEntrySheet -> uiActions.openBloodPressureEntrySheet(viewEffect.patientUuid)
+    }.exhaustive()
   }
 }

--- a/app/src/test/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffectHandlerTest.kt
@@ -29,12 +29,15 @@ class BloodPressureHistoryScreenEffectHandlerTest {
   private val patientUuid = UUID.fromString("433d058f-daef-47a7-8c61-95f1a220cbcb")
   private val uiActions = mock<BloodPressureHistoryScreenUiActions>()
   private val dataSourceFactory = mock<BloodPressureHistoryListItemDataSourceFactory.Factory>()
+  private val viewEffectHandler = BloodPressureHistoryViewEffectHandler(uiActions)
   private val effectHandler = BloodPressureHistoryScreenEffectHandler(
       bloodPressureRepository,
       patientRepository,
       TrampolineSchedulersProvider(),
       dataSourceFactory,
-      uiActions).build()
+      uiActions,
+      viewEffectHandler::handle
+  ).build()
   private val testCase = EffectHandlerTestCase(effectHandler)
 
   @After


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/7985/migrate-bloodpressurehistoryscreeneffecthandler-to-use-view-effects

In order for us to finish this migration, we need to migrate `ShowBloodPressures` effect, which requires us to change the BP history data source to paging source. I will do this in a different PR and then migrate this part later. 