### PR TITLE
Add `updatePriorities` for security app update reminders as a Firebase remote config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bump leakcanary to v2.9.1
 - Bump facebook flipper to v0.144.0
 - Enable monthly drug stock reminder feature flag
+- Add `updatePriorities` for security app update reminders as a Firebase remote config
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effects
 
 ### Features

--- a/app/src/main/java/org/simple/clinic/appupdate/AppUpdateModule.kt
+++ b/app/src/main/java/org/simple/clinic/appupdate/AppUpdateModule.kt
@@ -12,9 +12,9 @@ import dagger.Provides
 import io.reactivex.Observable
 import org.intellij.lang.annotations.Language
 import org.simple.clinic.appconfig.Country
-import org.simple.clinic.main.TypedMap.Type.UpdatePriorities
 import org.simple.clinic.feature.Features
 import org.simple.clinic.main.TypedMap
+import org.simple.clinic.main.TypedMap.Type.UpdatePriorities
 import org.simple.clinic.main.TypedPreference
 import org.simple.clinic.main.TypedPreference.Type.IsLightAppUpdateNotificationShown
 import org.simple.clinic.main.TypedPreference.Type.IsMediumAppUpdateNotificationShown
@@ -37,13 +37,15 @@ open class AppUpdateModule {
       appUpdateConfig: Observable<AppUpdateConfig>,
       updateManager: PlayUpdateManager,
       features: Features,
-      appVersionFetcher: AppVersionFetcher
+      appVersionFetcher: AppVersionFetcher,
+      @TypedMap(UpdatePriorities) updatePriorities: Map<String, Int>
   ): CheckAppUpdateAvailability {
     return CheckAppUpdateAvailability(
         config = appUpdateConfig,
         updateManager = updateManager,
         features = features,
-        appVersionFetcher = appVersionFetcher
+        appVersionFetcher = appVersionFetcher,
+        updatePriorities = updatePriorities
     )
   }
 

--- a/app/src/main/java/org/simple/clinic/appupdate/AppUpdateModule.kt
+++ b/app/src/main/java/org/simple/clinic/appupdate/AppUpdateModule.kt
@@ -12,7 +12,9 @@ import dagger.Provides
 import io.reactivex.Observable
 import org.intellij.lang.annotations.Language
 import org.simple.clinic.appconfig.Country
+import org.simple.clinic.main.TypedMap.Type.UpdatePriorities
 import org.simple.clinic.feature.Features
+import org.simple.clinic.main.TypedMap
 import org.simple.clinic.main.TypedPreference
 import org.simple.clinic.main.TypedPreference.Type.IsLightAppUpdateNotificationShown
 import org.simple.clinic.main.TypedPreference.Type.IsMediumAppUpdateNotificationShown
@@ -76,6 +78,7 @@ open class AppUpdateModule {
     return rxSharedPreferences.getBoolean("is_medium_app_update_notification_shown", false)
   }
 
+  @TypedMap(UpdatePriorities)
   @Provides
   fun provideAppUpdatePriority(
       configReader: ConfigReader,

--- a/app/src/main/java/org/simple/clinic/appupdate/AppUpdateModule.kt
+++ b/app/src/main/java/org/simple/clinic/appupdate/AppUpdateModule.kt
@@ -10,6 +10,7 @@ import com.squareup.moshi.Types
 import dagger.Module
 import dagger.Provides
 import io.reactivex.Observable
+import org.intellij.lang.annotations.Language
 import org.simple.clinic.appconfig.Country
 import org.simple.clinic.feature.Features
 import org.simple.clinic.main.TypedPreference
@@ -73,5 +74,21 @@ open class AppUpdateModule {
       rxSharedPreferences: RxSharedPreferences
   ): Preference<Boolean> {
     return rxSharedPreferences.getBoolean("is_medium_app_update_notification_shown", false)
+  }
+
+  @Provides
+  fun provideAppUpdatePriority(
+      configReader: ConfigReader,
+      moshi: Moshi
+  ): Map<String, Int> {
+    val type = Types.newParameterizedType(Map::class.java, String::class.java, Integer::class.java)
+    val updatePrioritiesAdapter = moshi.adapter<Map<String, Int>>(type)
+
+    @Language("JSON")
+    val defaultJson = "{}"
+
+    val json = configReader.string("update_priorities", defaultJson)
+
+    return updatePrioritiesAdapter.fromJson(json)!!
   }
 }

--- a/app/src/main/java/org/simple/clinic/appupdate/CheckAppUpdateAvailability.kt
+++ b/app/src/main/java/org/simple/clinic/appupdate/CheckAppUpdateAvailability.kt
@@ -31,6 +31,10 @@ class CheckAppUpdateAvailability @Inject constructor(
     private val appVersionFetcher: AppVersionFetcher
 ) {
 
+  companion object {
+    const val UPDATE_PRIORITIES_DEFAULT_VALUE = 0
+  }
+
   fun listen(): Observable<AppUpdateState> {
     return updateManager
         .updateInfo()
@@ -68,13 +72,15 @@ class CheckAppUpdateAvailability @Inject constructor(
 
   @VisibleForTesting(otherwise = PRIVATE)
   fun shouldNudgeForUpdate(updateInfo: UpdateInfo): Observable<AppUpdateState> {
-    val appStaleness = appVersionStaleness(updateInfo.availableVersionCode)
+    val availableVersionCode = updateInfo.availableVersionCode
+    val appStaleness = appVersionStaleness(availableVersionCode)
+
     val appUpdatePriority = config
         .map {
           appUpdateNudgePriority(
               appStaleness = appStaleness,
               config = it,
-              appUpdatePriority = updateInfo.appUpdatePriority
+              appUpdatePriority = updatePriorities.getOrDefault(availableVersionCode.toString(), UPDATE_PRIORITIES_DEFAULT_VALUE)
           )
         }
 

--- a/app/src/main/java/org/simple/clinic/appupdate/CheckAppUpdateAvailability.kt
+++ b/app/src/main/java/org/simple/clinic/appupdate/CheckAppUpdateAvailability.kt
@@ -32,7 +32,7 @@ class CheckAppUpdateAvailability @Inject constructor(
 ) {
 
   companion object {
-    const val UPDATE_PRIORITIES_DEFAULT_VALUE = 0
+    const val DEFAULT_UPDATE_PRIORITY = 0
   }
 
   fun listen(): Observable<AppUpdateState> {
@@ -80,7 +80,7 @@ class CheckAppUpdateAvailability @Inject constructor(
           appUpdateNudgePriority(
               appStaleness = appStaleness,
               config = it,
-              appUpdatePriority = updatePriorities.getOrDefault(availableVersionCode.toString(), UPDATE_PRIORITIES_DEFAULT_VALUE)
+              appUpdatePriority = updatePriorities.getOrDefault(availableVersionCode.toString(), DEFAULT_UPDATE_PRIORITY)
           )
         }
 

--- a/app/src/main/java/org/simple/clinic/appupdate/CheckAppUpdateAvailability.kt
+++ b/app/src/main/java/org/simple/clinic/appupdate/CheckAppUpdateAvailability.kt
@@ -15,6 +15,8 @@ import org.simple.clinic.appupdate.AppUpdateState.ShowAppUpdate
 import org.simple.clinic.feature.Feature.NotifyAppUpdateAvailable
 import org.simple.clinic.feature.Feature.NotifyAppUpdateAvailableV2
 import org.simple.clinic.feature.Features
+import org.simple.clinic.main.TypedMap
+import org.simple.clinic.main.TypedMap.Type.UpdatePriorities
 import org.simple.clinic.settings.AppVersionFetcher
 import org.simple.clinic.util.toOptional
 import java.util.Optional
@@ -25,6 +27,7 @@ class CheckAppUpdateAvailability @Inject constructor(
     private val updateManager: UpdateManager,
     private val versionUpdateCheck: (Int, Int, AppUpdateConfig) -> Boolean = isVersionApplicableForUpdate,
     private val features: Features,
+    @TypedMap(UpdatePriorities) private val updatePriorities: Map<String, Int>,
     private val appVersionFetcher: AppVersionFetcher
 ) {
 

--- a/app/src/main/java/org/simple/clinic/appupdate/UpdateInfo.kt
+++ b/app/src/main/java/org/simple/clinic/appupdate/UpdateInfo.kt
@@ -2,6 +2,5 @@ package org.simple.clinic.appupdate
 
 data class UpdateInfo(
     val availableVersionCode: Int,
-    val isUpdateAvailable: Boolean,
-    val appUpdatePriority: Int
+    val isUpdateAvailable: Boolean
 )

--- a/app/src/main/java/org/simple/clinic/appupdate/UpdateManager.kt
+++ b/app/src/main/java/org/simple/clinic/appupdate/UpdateManager.kt
@@ -33,7 +33,6 @@ class PlayUpdateManager @Inject constructor(
 
   private fun createUpdateInfo(appUpdateInfo: AppUpdateInfo) = UpdateInfo(
       availableVersionCode = appUpdateInfo.availableVersionCode(),
-      isUpdateAvailable = appUpdateInfo.updateAvailability() == UPDATE_AVAILABLE,
-      appUpdatePriority = appUpdateInfo.updatePriority()
+      isUpdateAvailable = appUpdateInfo.updateAvailability() == UPDATE_AVAILABLE
   )
 }

--- a/app/src/main/java/org/simple/clinic/main/TypedMap.kt
+++ b/app/src/main/java/org/simple/clinic/main/TypedMap.kt
@@ -1,0 +1,11 @@
+package org.simple.clinic.main
+
+import javax.inject.Qualifier
+
+@Qualifier
+annotation class TypedMap(val type: Type) {
+
+  enum class Type {
+    UpdatePriorities
+  }
+}

--- a/app/src/test/java/org/simple/clinic/appupdate/CheckAppUpdateAvailabilityTest.kt
+++ b/app/src/test/java/org/simple/clinic/appupdate/CheckAppUpdateAvailabilityTest.kt
@@ -47,8 +47,7 @@ class CheckAppUpdateAvailabilityTest {
     val isUpdateAvailable = updateAvailabilityState == UpdateAvailability.UPDATE_AVAILABLE
     val updateInfo = UpdateInfo(
         availableVersionCode = availableVersionCode,
-        isUpdateAvailable = isUpdateAvailable,
-        appUpdatePriority = 0
+        isUpdateAvailable = isUpdateAvailable
     )
 
     setup(isInAppUpdateEnabled = isInAppUpdateEnabled, isInAppUpdateEnabledV2 = false)
@@ -121,8 +120,7 @@ class CheckAppUpdateAvailabilityTest {
     val isUpdateAvailable = updateAvailabilityState == UpdateAvailability.UPDATE_AVAILABLE
     val updateInfo = UpdateInfo(
         availableVersionCode = availableVersionCode,
-        isUpdateAvailable = isUpdateAvailable,
-        appUpdatePriority = appUpdatePriority
+        isUpdateAvailable = isUpdateAvailable
     )
 
     setup(isInAppUpdateEnabled = false, isInAppUpdateEnabledV2 = isInAppUpdateEnabled)
@@ -228,7 +226,7 @@ class CheckAppUpdateAvailabilityTest {
   fun `app staleness should be loaded correctly`() {
     // given
     setup(isInAppUpdateEnabled = false, isInAppUpdateEnabledV2 = false)
-    val updateInfo = UpdateInfo(isUpdateAvailable = true, availableVersionCode = 150, appUpdatePriority = 0)
+    val updateInfo = UpdateInfo(isUpdateAvailable = true, availableVersionCode = 150)
     whenever(updateManager.updateInfo()).doReturn(Observable.just(updateInfo))
 
     // then

--- a/app/src/test/java/org/simple/clinic/appupdate/CheckAppUpdateAvailabilityTest.kt
+++ b/app/src/test/java/org/simple/clinic/appupdate/CheckAppUpdateAvailabilityTest.kt
@@ -254,12 +254,16 @@ class CheckAppUpdateAvailabilityTest {
             Feature.NotifyAppUpdateAvailableV2 to isInAppUpdateEnabledV2
         )
     )
+
+    val updatePriorities = mapOf(Pair("125", 5), Pair("35", 1))
+
     checkUpdateAvailable = CheckAppUpdateAvailability(
         config = config,
         updateManager = updateManager,
         versionUpdateCheck = versionCodeCheck,
         features = features,
-        appVersionFetcher = appVersionFetcher
+        appVersionFetcher = appVersionFetcher,
+        updatePriorities = updatePriorities
     )
   }
 }

--- a/app/src/test/java/org/simple/clinic/appupdate/CheckAppUpdateAvailabilityTest.kt
+++ b/app/src/test/java/org/simple/clinic/appupdate/CheckAppUpdateAvailabilityTest.kt
@@ -208,14 +208,14 @@ class CheckAppUpdateAvailabilityTest {
             appUpdatePriority = 0
         ),
         testCase(
-            versionCode = 120,
+            versionCode = 125,
             updateAvailabilityState = UpdateAvailability.UPDATE_AVAILABLE,
             isInAppUpdateEnabled = true,
             appUpdateState = ShowAppUpdate(appUpdateNudgePriority = AppUpdateNudgePriority.CRITICAL_SECURITY),
             appUpdatePriority = 5
         ),
         testCase(
-            versionCode = 33,
+            versionCode = 35,
             updateAvailabilityState = UpdateAvailability.UPDATE_AVAILABLE,
             isInAppUpdateEnabled = true,
             appUpdateState = ShowAppUpdate(appUpdateNudgePriority = AppUpdateNudgePriority.LIGHT),


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/8037/add-updatepriority-for-security-app-update-reminders-as-a-firebase-remote-config