### PR TITLE
Run CI on every pull request

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - release/*
   pull_request:
-    branches:
-      - master
   workflow_dispatch:
   workflow_call:
 


### PR DESCRIPTION
Instead of running CI on pull requests that are opened onto `master`, this will enable us to run it on all the PRs within branches as well
