### PR TITLE
Fix text cursor jumping to end when editing patient details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 - Show ongoing hypertension treatment question for Sri Lanka
 - Redesign `ContactPatientBottomSheet` UI
 
+### Fixes
+
+- Fix text cursor jumping to end when editing patient details
+
 ## 2022-05-16-8253
 
 ### Internal

--- a/app/src/main/java/org/simple/clinic/widgets/Views.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/Views.kt
@@ -71,12 +71,15 @@ fun ViewGroup.hideKeyboard() {
 }
 
 fun EditText.setTextWithWatcher(textToSet: CharSequence?, textWatcher: TextWatcher) {
+  val selection = if (selectionStart > 0) {
+    selectionStart
+  } else {
+    text.length
+  }
+
   removeTextChangedListener(textWatcher)
   setText(textToSet)
-
-  // Cannot rely on textToSet. It's possible that the
-  // EditText modifies the text using InputFilters.
-  setSelection(text.length)
+  setSelection(selection)
   addTextChangedListener(textWatcher)
 }
 


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/8291/text-cursor-jumping-to-end-in-edit-patient-screen-when-making-changes-in-the-middle-of-text
