### PR TITLE
Limit instant search to alphanumeric characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@
 
 - Bump flipper to v0.146.0
 - Fix test name in `PatientSummaryUpdateTest`
-- Bump mixpanel to v6.2.2  
-- Bump datadog plugin to v1.4.0  
+- Bump mixpanel to v6.2.2
+- Bump datadog plugin to v1.4.0
 - Show call result status for the appointment in `ContactPatientBottomSheet`
+- Limit instant search to alphanumeric characters
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
+
+### Fixes
+
+- Fix search crashing when searching with special characters
 
 ## 2022-05-23-8262
 

--- a/app/src/main/res/layout/screen_instant_search.xml
+++ b/app/src/main/res/layout/screen_instant_search.xml
@@ -46,6 +46,7 @@
             android:textAppearance="?attr/textAppearanceBody0"
             android:textColor="?attr/colorOnSurface"
             android:textColorHint="@color/color_on_surface_67"
+            android:digits="@string/instantsearch_allowed_characters"
             tools:ignore="UnusedAttribute" />
 
         </com.google.android.material.textfield.TextInputLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
 
   <!-- Patient search -->
   <string name="instantsearch_hint">Name, phone, or ID</string>
+  <string name="instantsearch_allowed_characters">abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ 0123456789</string>
 
   <!-- Patient search results -->
   <string name="patientsearchresults_register_patient_rationale">Can’t find the patient in this list?</string>


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/8260/handle-special-characters-when-searching-for-patient

Another potential option we can take is replacing the special characters with a "safe" character. But that would require 
us to 

1. Either change the characters saved in DB or
2. Replace them while fetching and do transformations

Both of them felt like a complex solutions for the use case. So, we can go ahead with the alphanumeric search for now and 
based on user feedback take the call
