### PR TITLE
Remove pull reminders status from `README.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bump kotlin-coroutines to v1.6.2
 - Move shared test code to separate module
 - Remove overdue appointments list from `OverdueModel`
+- Remove pull reminder status from `README.md`
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 
 ## 2022-05-30-8273

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ![Build Status](https://github.com/simpledotorg/simple-android/workflows/CI/badge.svg)
-[![pullreminders](https://pullreminders.com/badge.svg)](https://pullreminders.com?ref=badge)
 
 # Simple
 


### PR DESCRIPTION
Pull reminders has shut down, so the status link in our README is broken. So, removing it.
