### PR TITLE
Load overdue appointments when current facility is loaded and overdue sections feature is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bump lottie to v5.2.0
 - Render overdue appointments when appointments are loaded and overdue sections feature is enabled
 - Add feature flag for overdue section improvements
+- Load overdue appointments when current facility is loaded and overdue sections feature is enabled
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 
 ### Changes

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
@@ -35,6 +35,7 @@ import org.simple.clinic.databinding.ScreenOverdueBinding
 import org.simple.clinic.di.injector
 import org.simple.clinic.feature.Feature
 import org.simple.clinic.feature.Feature.OverdueListDownloadAndShare
+import org.simple.clinic.feature.Feature.OverdueSections
 import org.simple.clinic.feature.Features
 import org.simple.clinic.home.HomeScreen
 import org.simple.clinic.navigation.v2.Router
@@ -163,7 +164,11 @@ class OverdueScreen : BaseScreen<
   override fun createUpdate(): Update<OverdueModel, OverdueEvent, OverdueEffect> {
     val date = LocalDate.now(userClock)
     val canGeneratePdf = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
-    return OverdueUpdate(date, canGeneratePdf)
+    return OverdueUpdate(
+        date = date,
+        canGeneratePdf = canGeneratePdf,
+        isOverdueSectionsFeatureEnabled = features.isEnabled(OverdueSections)
+    )
   }
 
   override fun createInit() = OverdueInit()

--- a/app/src/test/java/org/simple/clinic/home/overdue/OverdueLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/OverdueLogicTest.kt
@@ -109,7 +109,11 @@ class OverdueLogicTest {
     testFixture = MobiusTestFixture(
         events = uiEvents.ofType(),
         defaultModel = OverdueModel.create(),
-        update = OverdueUpdate(dateOnClock, true),
+        update = OverdueUpdate(
+            date = dateOnClock,
+            canGeneratePdf = true,
+            isOverdueSectionsFeatureEnabled = false
+        ),
         effectHandler = effectHandler.build(),
         modelUpdateListener = { /* Nothing to do here */ },
         init = OverdueInit()

--- a/app/src/test/java/org/simple/clinic/home/overdue/OverdueUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/OverdueUpdateTest.kt
@@ -20,7 +20,9 @@ import java.util.UUID
 class OverdueUpdateTest {
 
   private val dateOnClock = LocalDate.parse("2018-01-01")
-  private val updateSpec = UpdateSpec(OverdueUpdate(date = dateOnClock, canGeneratePdf = true))
+  private val updateSpec = UpdateSpec(OverdueUpdate(date = dateOnClock,
+      canGeneratePdf = true,
+      isOverdueSectionsFeatureEnabled = false))
   private val defaultModel = OverdueModel.create()
 
   @Test
@@ -62,7 +64,7 @@ class OverdueUpdateTest {
   }
 
   @Test
-  fun `when current facility is loaded and overdue list changes feature is enabled, then load overdue appointments with patients with no phone numbers`() {
+  fun `when current facility is loaded and overdue sections feature is disabled, then load pending overdue appointments`() {
     val facility = TestData.facility(
         uuid = UUID.fromString("6d66fda7-7ca6-4431-ac3b-b570f1123624"),
         facilityConfig = FacilityConfig(
@@ -77,6 +79,31 @@ class OverdueUpdateTest {
         .then(assertThatNext(
             hasModel(defaultModel.currentFacilityLoaded(facility)),
             hasEffects(LoadOverdueAppointments_old(dateOnClock, facility))
+        ))
+  }
+
+  @Test
+  fun `when current facility is loaded and overdue sections feature is enabled, then load overdue appointments`() {
+    val facility = TestData.facility(
+        uuid = UUID.fromString("6d66fda7-7ca6-4431-ac3b-b570f1123624"),
+        facilityConfig = FacilityConfig(
+            diabetesManagementEnabled = true,
+            teleconsultationEnabled = false
+        )
+    )
+
+    val updateSpec = UpdateSpec(OverdueUpdate(
+        date = dateOnClock,
+        canGeneratePdf = true,
+        isOverdueSectionsFeatureEnabled = true
+    ))
+
+    updateSpec
+        .given(defaultModel)
+        .whenEvent(CurrentFacilityLoaded(facility))
+        .then(assertThatNext(
+            hasModel(defaultModel.currentFacilityLoaded(facility)),
+            hasEffects(LoadOverdueAppointments(dateOnClock, facility))
         ))
   }
 
@@ -104,7 +131,7 @@ class OverdueUpdateTest {
 
   @Test
   fun `when download overdue list button is clicked, network is connected and pdf can not be generated, then schedule download`() {
-    val updateSpec = UpdateSpec(OverdueUpdate(date = dateOnClock, canGeneratePdf = false))
+    val updateSpec = UpdateSpec(OverdueUpdate(date = dateOnClock, canGeneratePdf = false, isOverdueSectionsFeatureEnabled = false))
 
     updateSpec
         .given(defaultModel)
@@ -139,7 +166,7 @@ class OverdueUpdateTest {
 
   @Test
   fun `when share overdue list button is clicked, network is connected but pdf can not be generated, then open progress for share dialog`() {
-    val updateSpec = UpdateSpec(OverdueUpdate(date = dateOnClock, canGeneratePdf = false))
+    val updateSpec = UpdateSpec(OverdueUpdate(date = dateOnClock, canGeneratePdf = false, isOverdueSectionsFeatureEnabled = false))
 
     updateSpec
         .given(defaultModel)


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/8346/render-ui-for-all-overdue-sections-when-feature-flag-is-enabled
