### PR TITLE
Fix `RetentionType` getting obfuscated by R8/Proguard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Show progress bar when loading all overdue appointments
 - Implement minor overdue section layout improvements
 - Bump core-ktx to 1.8.0
+- Fix `RetentionType` getting obfuscated by R8/Proguard
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 
 ### Changes

--- a/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/RetentionType.kt
+++ b/app/src/main/java/org/simple/clinic/patient/onlinelookup/api/RetentionType.kt
@@ -1,7 +1,9 @@
 package org.simple.clinic.patient.onlinelookup.api
 
 import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
 
+@JsonClass(generateAdapter = false)
 enum class RetentionType {
 
   @Json(name = "temporary")


### PR DESCRIPTION
Moshi requires us to annotate the enums with `@JsonClass(generateAdapter  = false)` to prevent obfuscation by R8/ProGuard
https://github.com/square/moshi#enums

This fixes a crash
https://sentry.io/organizations/resolve-to-save-lives/issues/2579117871/?project=1212614&referrer=slack
