### PR TITLE
Don't show pending overdue list footer if there are no pending overdue appointments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Handle see all/see less button clicks for pending overdue list section
 - Fix views flashing in the overdue list
 - When overdue appointments are loaded or are loading, render appropriate views
+- Don't show pending overdue list footer if there are no pending overdue appointments
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 - [In Progress: 03 Jun 2022] Implement `OverdueAppointmentListItemNew` adapter
 

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueAppointmentListItemNew.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueAppointmentListItemNew.kt
@@ -87,9 +87,12 @@ sealed class OverdueAppointmentListItemNew : ItemAdapter.Item<UiEvent> {
         clock: UserClock,
         pendingListState: PendingListState
     ): List<OverdueAppointmentListItemNew> {
-      val pendingToCallHeader = listOf(OverdueSectionHeader(R.string.overdue_pending_to_call_header, overdueAppointmentSections.pendingAppointments.size))
+      val pendingAppointments = overdueAppointmentSections.pendingAppointments
+      val pendingToCallHeader = listOf(OverdueSectionHeader(R.string.overdue_pending_to_call_header, pendingAppointments.size))
       val pendingAppointmentsContent = generatePendingAppointmentsContent(overdueAppointmentSections, clock, pendingListState)
-      val pendingListFooterItem = listOf(PendingListFooter(pendingListState))
+
+      val showPendingListFooter = pendingAppointments.size > 10 && pendingAppointments.isNotEmpty()
+      val pendingListFooterItem = if(showPendingListFooter) listOf(PendingListFooter(pendingListState)) else emptyList()
 
       return pendingToCallHeader + pendingAppointmentsContent + pendingListFooterItem
     }


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/8465/fix-see-all-button-being-shown-when-there-are-no-overdue-patients
