### PR TITLE
Fix overdue list showing older scheduled appointments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 - [In Progress: 03 Jun 2022] Implement `OverdueAppointmentListItemNew` adapter
 
+### Fixes
+
+- Fix overdue list showing older scheduled appointments
+
 ## 2022-06-06-8284
 
 ### Internal

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueAppointment_Old.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueAppointment_Old.kt
@@ -70,7 +70,11 @@ data class OverdueAppointment_Old(
 
       FROM Patient P
       
-      INNER JOIN Appointment A ON A.patientUuid = P.uuid
+      INNER JOIN (
+        SELECT *
+        FROM Appointment
+        GROUP BY patientUuid HAVING MAX(createdAt)
+      ) A ON A.patientUuid = P.uuid
       LEFT JOIN PatientPhoneNumber PPN ON PPN.patientUuid = P.uuid
       LEFT JOIN MedicalHistory MH ON MH.patientUuid = P.uuid
       LEFT JOIN PatientAddress PA ON PA.uuid = P.addressUuid


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/7644/overdue-list-is-loading-patients-with-older-appointments-even-though-there-are-recent-visits
