### PR TITLE
Hide footer when the pending section is collapsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bump Sentry Gradle plugin to v3.1.1
 - Bump Sentry to v6.1.0
 - Bump Kotlin to v1.7.0
+- Hide footer when the pending section is collapsed
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 
 ## 2022-06-13-8291

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueAppointmentListItemNew.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueAppointmentListItemNew.kt
@@ -156,7 +156,7 @@ sealed class OverdueAppointmentListItemNew : ItemAdapter.Item<UiEvent> {
           ))
       val pendingAppointmentsContent = generatePendingAppointmentsContent(overdueAppointmentSections, clock, pendingListDefaultStateSize, overdueListSectionStates)
 
-      val showPendingListFooter = pendingAppointments.size > pendingListDefaultStateSize && pendingAppointments.isNotEmpty()
+      val showPendingListFooter = pendingAppointments.size > pendingListDefaultStateSize && overdueListSectionStates.isPendingHeaderExpanded
       val pendingListFooterItem = if (showPendingListFooter) listOf(PendingListFooter(overdueListSectionStates.pendingListState)) else emptyList()
 
       return pendingToCallHeader + pendingAppointmentsContent + pendingListFooterItem


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/8526/hide-footer-when-the-pending-section-is-collapsed
