### PR TITLE
Load overdue search history when overdue search screen is opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Provide overdue search history string set from preferences
 - Add effect to load overdue search history
 - Show overdue search history when search query is empty
+- Load overdue search history when overdue search screen is opened
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 
 ## 2022-06-13-8291

--- a/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchInit.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchInit.kt
@@ -1,0 +1,12 @@
+package org.simple.clinic.home.overdue.search
+
+import com.spotify.mobius.First
+import com.spotify.mobius.Init
+import org.simple.clinic.mobius.first
+
+class OverdueSearchInit : Init<OverdueSearchModel, OverdueSearchEffect> {
+
+  override fun init(model: OverdueSearchModel): First<OverdueSearchModel, OverdueSearchEffect> {
+    return first(model, LoadOverdueSearchHistory)
+  }
+}

--- a/app/src/test/java/org/simple/clinic/home/overdue/search/OverdueSearchInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/search/OverdueSearchInitTest.kt
@@ -1,0 +1,22 @@
+package org.simple.clinic.home.overdue.search
+
+import com.spotify.mobius.test.FirstMatchers.hasEffects
+import com.spotify.mobius.test.FirstMatchers.hasModel
+import com.spotify.mobius.test.InitSpec
+import com.spotify.mobius.test.InitSpec.assertThatFirst
+import org.junit.Test
+
+class OverdueSearchInitTest {
+
+  @Test
+  fun `when overdue search screen is created, then load search history`() {
+    val defaultModel = OverdueSearchModel.create()
+
+    InitSpec(OverdueSearchInit())
+        .whenInit(defaultModel)
+        .then(assertThatFirst(
+            hasModel(defaultModel),
+            hasEffects(LoadOverdueSearchHistory)
+        ))
+  }
+}


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/8520/display-search-history-in-overdue-search-screen
