### PR TITLE
Save overdue search history as `String` type in preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Add overdue search query validator
 - Validate search query when overdue search query is changed
 - Bump overdue sections feature flag version to v1
+- Save overdue search history as `String` type in preferences
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 
 ## 2022-06-13-8291

--- a/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchEffectHandler.kt
@@ -3,11 +3,13 @@ package org.simple.clinic.home.overdue.search
 import com.f2prateek.rx.preferences2.Preference
 import com.spotify.mobius.rx2.RxMobius
 import io.reactivex.ObservableTransformer
+import org.simple.clinic.main.TypedPreference
+import org.simple.clinic.main.TypedPreference.Type.OverdueSearchHistory
 import org.simple.clinic.util.scheduler.SchedulersProvider
 import javax.inject.Inject
 
 class OverdueSearchEffectHandler @Inject constructor(
-    private val overdueSearchHistoryPreference: Preference<Set<String>>,
+    @TypedPreference(OverdueSearchHistory) private val overdueSearchHistoryPreference: Preference<String>,
     private val overdueSearchQueryValidator: OverdueSearchQueryValidator,
     private val schedulersProvider: SchedulersProvider
 ) {
@@ -34,6 +36,10 @@ class OverdueSearchEffectHandler @Inject constructor(
       effects
           .observeOn(schedulersProvider.io())
           .switchMap { overdueSearchHistoryPreference.asObservable() }
+          .map {
+            // TODO (SM): Extract overdue search history handling to a separate class
+            it.split(", ").toSet()
+          }
           .map(::OverdueSearchHistoryLoaded)
     }
   }

--- a/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchModule.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchModule.kt
@@ -4,16 +4,19 @@ import com.f2prateek.rx.preferences2.Preference
 import com.f2prateek.rx.preferences2.RxSharedPreferences
 import dagger.Module
 import dagger.Provides
+import org.simple.clinic.main.TypedPreference
+import org.simple.clinic.main.TypedPreference.Type.OverdueSearchHistory
 import org.simple.clinic.remoteconfig.ConfigReader
 
 @Module
 object OverdueSearchModule {
 
   @Provides
-  fun overdueSearchHistory(
+  @TypedPreference(OverdueSearchHistory)
+  fun overdueSearchHistoryPreference(
       rxSharedPreferences: RxSharedPreferences
-  ): Preference<Set<String>> {
-    return rxSharedPreferences.getStringSet("preference_overdue_search_history_v1")
+  ): Preference<String> {
+    return rxSharedPreferences.getString("preference_overdue_search_history_v1")
   }
 
   @Provides

--- a/app/src/main/java/org/simple/clinic/main/TypedPreference.kt
+++ b/app/src/main/java/org/simple/clinic/main/TypedPreference.kt
@@ -17,6 +17,7 @@ annotation class TypedPreference(val value: Type) {
     IsMediumAppUpdateNotificationShown,
     DrugStockReportLastCheckedAt,
     IsDrugStockReportFilled,
-    DrugStockFormURL
+    DrugStockFormURL,
+    OverdueSearchHistory
   }
 }

--- a/app/src/test/java/org/simple/clinic/home/overdue/search/OverdueSearchEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/search/OverdueSearchEffectHandlerTest.kt
@@ -13,7 +13,7 @@ import org.simple.clinic.util.scheduler.TestSchedulersProvider
 
 class OverdueSearchEffectHandlerTest {
 
-  private val overdueSearchHistoryPreference = mock<Preference<Set<String>>>()
+  private val overdueSearchHistoryPreference = mock<Preference<String>>()
   private val overdueSearchConfig = OverdueSearchConfig(minLengthOfSearchQuery = 3)
   private val effectHandler = OverdueSearchEffectHandler(
       overdueSearchHistoryPreference = overdueSearchHistoryPreference,
@@ -30,11 +30,7 @@ class OverdueSearchEffectHandlerTest {
   @Test
   fun `when load search history effect is received, then load the search history`() {
     // given
-    val searchHistory = setOf(
-        "Babri",
-        "Narwar",
-        "Ramesh"
-    )
+    val searchHistory = "Babri, Narwar, Ramesh"
 
     whenever(overdueSearchHistoryPreference.asObservable()) doReturn Observable.just(searchHistory)
 
@@ -42,7 +38,11 @@ class OverdueSearchEffectHandlerTest {
     effectHandlerTestCase.dispatch(LoadOverdueSearchHistory)
 
     // then
-    effectHandlerTestCase.assertOutgoingEvents(OverdueSearchHistoryLoaded(searchHistory))
+    effectHandlerTestCase.assertOutgoingEvents(OverdueSearchHistoryLoaded(setOf(
+        "Babri",
+        "Narwar",
+        "Ramesh"
+    )))
   }
 
   @Test


### PR DESCRIPTION
Unfortunately, the string set preference type doesn't seem to maintain the order in which the items were inserted/added. This becomes a problem when we have to drop older searches as we save newer ones based on the search history limit. To avoid this we will save the search history as a `String` with delimiter and split it. Another potential option is to save it as a JSON array and use Moshi to parse it. Either way, we have to transform the data into a string. 


This is in preparation to extract this into a separate `OverdueSearchHistory` class that takes care of fetching, transforming and updating the overdue search history. 
