### PR TITLE
Don't show empty search history items in overdue search screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Bump mixpanel to v6.3.0
 - Bump Google Services plugin to v4.3.12
 - Don't show no patients found error view when search query is empty
+- Don't show empty search history items in overdue search screen
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 
 ## 2022-06-20-8300

--- a/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchHistory.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchHistory.kt
@@ -36,6 +36,6 @@ class OverdueSearchHistory @Inject constructor(
   }
 
   private fun String.splitToSet(): Set<String> {
-    return split(SEARCH_HISTORY_SEPARATOR).toSet()
+    return split(SEARCH_HISTORY_SEPARATOR).filter { it.isNotBlank() }.toSet()
   }
 }


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/8604/don-t-show-empty-search-history-items-in-overdue-search-screen
