### PR TITLE
Move existing search history item to the top when clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Highlight search results with the matched search query
 - Fix old synced appointments not getting deleted on purge
 - Bump datadog sdk to v1.13.0
+- Move existing search history item to the top when clicked
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 
 ## 2022-06-27-8307

--- a/app/src/androidTest/java/org/simple/clinic/home/overdue/search/OverdueSearchHistoryTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/home/overdue/search/OverdueSearchHistoryTest.kt
@@ -65,4 +65,26 @@ class OverdueSearchHistoryTest {
         "Tandi"
     ))
   }
+
+  @Test
+  fun adding_already_existing_search_query_to_history_should_move_it_to_top() {
+    // given
+    val searchQuery = "Mehta"
+    val existingSearchHistory = "Babri, Ramesh, Mehta, Tandi, Narwar"
+
+    overdueSearchHistoryPreference.set(existingSearchHistory)
+
+    // when
+    overdueSearchHistory.add(searchQuery)
+
+    // then
+    val searchHistory = overdueSearchHistory.fetch().blockingFirst()
+    assertThat(searchHistory).isEqualTo(setOf(
+        "Mehta",
+        "Babri",
+        "Ramesh",
+        "Tandi",
+        "Narwar"
+    ))
+  }
 }

--- a/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchHistory.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchHistory.kt
@@ -22,7 +22,10 @@ class OverdueSearchHistory @Inject constructor(
 
   fun add(searchQuery: String) {
     val searchHistory = overdueSearchHistoryPreference.get().splitToSet()
-    val searchHistoryLimit = if (searchHistory.size >= searchConfig.searchHistoryLimit) {
+    val searchHistoryLimit = if (
+        searchHistory.size >= searchConfig.searchHistoryLimit &&
+        !searchHistory.contains(searchQuery)
+    ) {
       // We are subtracting 1 to ensure our search history is within the specified limit.
       // To avoid having saving all the search queries, we are dropping older search queries that are
       // outside the limit


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/8616/move-existing-search-history-item-to-the-top-when-clicked
