### PR TITLE
Ignore `ReportsModel#reportsContent` on parcel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Increase overdue search query text field debounce time
 - Add remote key for overdue search feature flag
 - Fix `JSONDataException` when parsing the drug stock response
+- Ignore `ReportsModel#reportsContent` on parcel
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 
 ## 2022-06-27-8310

--- a/app/src/main/java/org/simple/clinic/home/report/ReportsModel.kt
+++ b/app/src/main/java/org/simple/clinic/home/report/ReportsModel.kt
@@ -1,12 +1,16 @@
 package org.simple.clinic.home.report
 
 import android.os.Parcelable
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.simple.clinic.util.toNullable
 import java.util.Optional
 
 @Parcelize
-data class ReportsModel(val reportsContent: String?) : Parcelable {
+data class ReportsModel(
+    @IgnoredOnParcel
+    val reportsContent: String? = null
+) : Parcelable {
 
   companion object {
     fun create() = ReportsModel(reportsContent = null)


### PR DESCRIPTION
Since `ReportsModel#reportsContent` is a HTML string, the size can vary significantly depending on how much data it has. Since the parcel limit is shared across transactions in a process. It's not ideal to save huge data into parcel. Instead of saving and restoring the data in reports screen, we can fetch it from DB on restore to avoid this issue. 

You can use [this](git@github.com:guardian/toolargetool.git) tool to check how much space each transaction operation is taking.  

