### PR TITLE
Ignore deleted and old phone numbers when generating overdue CSV from database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Handle nullable fields when generating overdue CSV from database
 - Add support for selected download and share in overdue screen
 - Bump Sentry to v6.2.1
+- Ignore deleted and old phone numbers when generating overdue CSV from database
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 
 ### Fixes

--- a/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
+++ b/app/src/main/java/org/simple/clinic/overdue/Appointment.kt
@@ -382,7 +382,11 @@ data class Appointment(
       FROM Appointment A
       INNER JOIN Patient P ON P.uuid = A.patientUuid
       LEFT JOIN PatientAddress PA ON PA.uuid = P.addressUuid
-      LEFT JOIN PatientPhoneNumber PPN ON PPN.patientUuid = P.uuid AND PPN.deletedAt IS NULL
+      LEFT JOIN (
+        SELECT * FROM PatientPhoneNumber
+        WHERE deletedAt IS NULL
+        GROUP BY patientUuid HAVING MAX(createdAt)
+      ) PPN ON PPN.patientUuid = P.uuid AND PPN.deletedAt IS NULL
       LEFT JOIN (
         SELECT * FROM BusinessId
         WHERE identifierType = "simple_bp_passport" AND deletedAt IS NULL


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/8680/ignore-deleted-and-old-phone-numbers-when-generating-overdue-csv-from-database
