### PR TITLE
Bump Material Design Components to v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Add support for select and download in overdue search screen
 - Add support for select and share in overdue search screen
 - Show no internet connection dialog when download/share button is clicked
+- Bump Material Design Components to v1.6.1
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 
 ### Changes

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -118,7 +118,7 @@ logback-classic = "ch.qos.logback:logback-classic:1.2.11"
 
 lottie = "com.airbnb.android:lottie:5.2.0"
 
-material = "com.google.android.material:material:1.4.0"
+material = "com.google.android.material:material:1.6.1"
 
 mixpanel-android = "com.mixpanel.android:mixpanel-android:6.4.0"
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -8,10 +8,7 @@
   "timezone": "Asia/Kolkata",
   "ignoreDeps": [
     // Ignoring zxing update. Since update requires Java 8+ runtime.
-    "com.google.zxing:core",
-
-    // Ignoring this version because it introduces Material 3 specs
-    "com.google.android.material:material"
+    "com.google.zxing:core"
   ],
   "prConcurrentLimit": 5
 }


### PR DESCRIPTION
Previously we didn't update the Material library as Material 3 spec was just introduced and there were some backward compatability issues for us. With recent version it seems much more stable and those issues were addressed. So we are updating Material library again.

But we are not switching to using Material3 or Material You. We will continue using `Theme.MaterialComponents.*` and as such all the components are themed to Material 2 specs.
