### PR TITLE
Fix secure call button showing when securing calling is disabled for the facility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Bump firebase config to v21.1.1
 - Bump Coroutines to v1.6.4
 - Update overdue patient card spacings
+- Fix secure call button showing when securing calling is disabled for the facility
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 
 ### Changes

--- a/app/src/main/res/layout/contactpatient_callpatient.xml
+++ b/app/src/main/res/layout/contactpatient_callpatient.xml
@@ -405,7 +405,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:visibility="gone"
-    app:constraint_referenced_ids="phoneNumberLabel, phoneNumberTextView, normalCallButton, secureCallingGroup" />
+    app:constraint_referenced_ids="phoneNumberLabel, phoneNumberTextView, normalCallButton" />
 
   <androidx.constraintlayout.widget.Group
     android:id="@+id/patientWithNoPhoneNumberGroup"


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/8484/fix-secure-call-button-showing-when-securing-calling-is-disabled-for-the-facility
