### PR TITLE
Remove overdue search v2 feature flag key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Load village and patient names when overdue search screen is created
 - Don't show search history when overdue search v2 is enabled
 - Bump room to 2.4.3
+- Remove overdue search v2 feature flag key
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 
 ## 2022-07-25-8342

--- a/app/src/main/java/org/simple/clinic/feature/Feature.kt
+++ b/app/src/main/java/org/simple/clinic/feature/Feature.kt
@@ -38,6 +38,6 @@ enum class Feature(
   MonthlyDrugStockReportReminder(false, "monthly_drug_stock_report_reminders_v1"),
   OverdueSections(false, "overdue_section_improvements_v1"),
   OverdueInstantSearch(false, "overdue_instant_search_v1"),
-  OverdueSearchV2(false, "overdue_search_v2"),
+  OverdueSearchV2(false),
   OverdueSelectAndDownload(false, "overdue_select_and_download_v1")
 }


### PR DESCRIPTION
Since it's possible we might not finish the overdue search v2 work before next release. Having this key is not backward compatible safe when turning on. So, for now changed it into a developer flag. We add the key back once this entire feature is dev complete.
