### PR TITLE
Add multiple search inputs support in overdue search screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Show chip input text view in overdue search when overdue v2 search is enabled
 - Add overdue search query for supporting multiple search inputs
 - Fix overdue search history and results not showing in overdue search screen
+- Add multiple search inputs support in overdue search screen
 - [In Progress: 27 Apr 2022] Migrate `BloodPressureHistoryScreenEffectHandler` to use view effect
 
 ## 2022-08-01-8350

--- a/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchEffect.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchEffect.kt
@@ -13,7 +13,7 @@ data class ValidateOverdueSearchQuery(val searchQuery: String) : OverdueSearchEf
 
 data class AddQueryToOverdueSearchHistory(val searchQuery: String) : OverdueSearchEffect()
 
-data class SearchOverduePatients(val searchQuery: String, val since: LocalDate) : OverdueSearchEffect()
+data class SearchOverduePatients_Old(val searchQuery: String, val since: LocalDate) : OverdueSearchEffect()
 
 data class ToggleOverdueAppointmentSelection(val appointmentId: UUID) : OverdueSearchEffect()
 
@@ -34,6 +34,11 @@ data class LoadSearchResultsAppointmentIds(
 ) : OverdueSearchEffect()
 
 object LoadVillageAndPatientNames : OverdueSearchEffect()
+
+data class SearchOverduePatients(
+    val searchInputs: List<String>,
+    val since: LocalDate
+) : OverdueSearchEffect()
 
 sealed class OverdueSearchViewEffect : OverdueSearchEffect()
 

--- a/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchEvent.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchEvent.kt
@@ -72,3 +72,5 @@ data class SearchResultsAppointmentIdsLoaded(
 data class VillagesAndPatientNamesLoaded(
     val villagesAndPatientNames: List<String>
 ) : OverdueSearchEvent()
+
+data class OverdueSearchInputsChanged(val searchInputs: List<String>) : OverdueSearchEvent()

--- a/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchModel.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchModel.kt
@@ -16,11 +16,15 @@ data class OverdueSearchModel(
     val overdueSearchResults: PagingData<OverdueAppointment> = PagingData.empty(),
     @IgnoredOnParcel
     val selectedOverdueAppointments: Set<UUID> = emptySet(),
-    val villageAndPatientNames: List<String>?
+    val villageAndPatientNames: List<String>?,
+    val searchInputs: List<String>
 ) : Parcelable {
 
   val hasSearchQuery: Boolean
     get() = !searchQuery.isNullOrBlank()
+
+  val hasSearchInputs: Boolean
+    get() = searchInputs.isNotEmpty()
 
   val hasVillageAndPatientNames: Boolean
     get() = !villageAndPatientNames.isNullOrEmpty()
@@ -33,7 +37,8 @@ data class OverdueSearchModel(
           searchQuery = null,
           overdueSearchProgressState = null,
           selectedOverdueAppointments = emptySet(),
-          villageAndPatientNames = null
+          villageAndPatientNames = null,
+          searchInputs = emptyList()
       )
     }
   }
@@ -62,5 +67,9 @@ data class OverdueSearchModel(
 
   fun villagesAndPatientNamesLoaded(villageAndPatientNames: List<String>): OverdueSearchModel {
     return copy(villageAndPatientNames = villageAndPatientNames)
+  }
+
+  fun overdueSearchInputsChanged(searchInputs: List<String>): OverdueSearchModel {
+    return copy(searchInputs = searchInputs)
   }
 }

--- a/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchScreen.kt
@@ -214,7 +214,8 @@ class OverdueSearchScreen : BaseScreen<
           overdueSearchQueryTextChanges(),
           clearSelectedOverdueAppointmentClicks(),
           downloadButtonClicks(),
-          shareButtonClicks()
+          shareButtonClicks(),
+          overdueSearchInputsChanges()
       )
       .compose(RequestPermissions(runtimePermissions, screenResults.streamResults().ofType()))
       .compose(runtimeNetworkStatus::apply)
@@ -433,6 +434,13 @@ class OverdueSearchScreen : BaseScreen<
         .map {
           OverdueSearchQueryChanged(it.toString())
         }
+  }
+
+  private fun overdueSearchInputsChanges(): Observable<UiEvent> {
+    return overdueSearchChipInputTextView
+        .inputChanges
+        .debounce(500, TimeUnit.MILLISECONDS)
+        .map(::OverdueSearchInputsChanged)
   }
 
   interface Injector {

--- a/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchUiRenderer.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchUiRenderer.kt
@@ -18,7 +18,7 @@ class OverdueSearchUiRenderer(
       ui.setOverdueSearchSuggestions(model.villageAndPatientNames!!)
     }
 
-    if (model.hasSearchQuery) {
+    if (model.hasSearchQuery || model.hasSearchInputs) {
       renderSearchResults(model)
     } else {
       ui.hideNoSearchResults()

--- a/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/search/OverdueSearchUpdate.kt
@@ -47,7 +47,18 @@ class OverdueSearchUpdate(
       is SelectAllButtonClicked -> selectAllButtonClicked(model)
       is SearchResultsAppointmentIdsLoaded -> searchResultsAppointmentIdsLoaded(model, event)
       is VillagesAndPatientNamesLoaded -> next(model.villagesAndPatientNamesLoaded(event.villagesAndPatientNames))
+      is OverdueSearchInputsChanged -> searchInputsChanged(model, event)
     }
+  }
+
+  private fun searchInputsChanged(model: OverdueSearchModel, event: OverdueSearchInputsChanged): Next<OverdueSearchModel, OverdueSearchEffect> {
+    return next(
+        model.overdueSearchInputsChanged(event.searchInputs),
+        SearchOverduePatients(
+            searchInputs = event.searchInputs,
+            since = date
+        )
+    )
   }
 
   private fun selectAllButtonClicked(model: OverdueSearchModel): Next<OverdueSearchModel, OverdueSearchEffect> {
@@ -127,7 +138,7 @@ class OverdueSearchUpdate(
 
   private fun searchQueryValidated(event: OverdueSearchQueryValidated): Next<OverdueSearchModel, OverdueSearchEffect> {
     return when (val result = event.result) {
-      is Valid -> dispatch(AddQueryToOverdueSearchHistory(result.searchQuery), SearchOverduePatients(result.searchQuery, date))
+      is Valid -> dispatch(AddQueryToOverdueSearchHistory(result.searchQuery), SearchOverduePatients_Old(result.searchQuery, date))
       Empty,
       LengthTooShort -> noChange()
     }

--- a/app/src/test/java/org/simple/clinic/home/overdue/search/OverdueSearchUiRendererTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/search/OverdueSearchUiRendererTest.kt
@@ -24,6 +24,7 @@ class OverdueSearchUiRendererTest {
     // given
     val model = defaultModel
         .overdueSearchQueryChanged("Ani")
+        .overdueSearchInputsChanged(searchInputs = listOf("Ani"))
         .loadStateChanged(IN_PROGRESS)
 
     // when
@@ -62,6 +63,7 @@ class OverdueSearchUiRendererTest {
     val searchHistory = setOf("Babri")
     val model = defaultModel
         .overdueSearchQueryChanged("Ani")
+        .overdueSearchInputsChanged(searchInputs = listOf("Ani"))
         .overdueSearchHistoryLoaded(searchHistory)
         .loadStateChanged(NO_RESULTS)
 
@@ -98,6 +100,7 @@ class OverdueSearchUiRendererTest {
     val searchQuery = "Ani"
     val model = defaultModel
         .overdueSearchQueryChanged(searchQuery)
+        .overdueSearchInputsChanged(listOf(searchQuery))
         .overdueSearchResultsLoaded(searchResults)
         .loadStateChanged(DONE)
         .selectedOverdueAppointmentsChanged(selectedAppointments)
@@ -136,6 +139,7 @@ class OverdueSearchUiRendererTest {
     val searchQuery = "Ani"
     val model = defaultModel
         .overdueSearchQueryChanged(searchQuery)
+        .overdueSearchInputsChanged(listOf(searchQuery))
         .overdueSearchResultsLoaded(searchResults)
         .loadStateChanged(DONE)
         .selectedOverdueAppointmentsChanged(selectedAppointments)
@@ -173,6 +177,7 @@ class OverdueSearchUiRendererTest {
     val searchQuery = "Ani"
     val model = defaultModel
         .overdueSearchQueryChanged(searchQuery)
+        .overdueSearchInputsChanged(listOf(searchQuery))
         .overdueSearchResultsLoaded(searchResults)
         .loadStateChanged(DONE)
 

--- a/app/src/test/java/org/simple/clinic/home/overdue/search/OverdueSearchUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/overdue/search/OverdueSearchUpdateTest.kt
@@ -66,7 +66,7 @@ class OverdueSearchUpdateTest {
         .whenEvent(OverdueSearchQueryValidated(Valid(searchQuery)))
         .then(assertThatNext(
             hasNoModel(),
-            hasEffects(AddQueryToOverdueSearchHistory(searchQuery), SearchOverduePatients(searchQuery, date))
+            hasEffects(AddQueryToOverdueSearchHistory(searchQuery), SearchOverduePatients_Old(searchQuery, date))
         ))
   }
 
@@ -448,5 +448,21 @@ class OverdueSearchUpdateTest {
                 hasNoEffects()
             )
         )
+  }
+
+  @Test
+  fun `when overdue search inputs are changed, then update model and search overdue patients`() {
+    val searchInputs = listOf("Anand", "Anup", "Asia", "Earth")
+
+    updateSpec
+        .given(defaultModel)
+        .whenEvent(OverdueSearchInputsChanged(searchInputs))
+        .then(assertThatNext(
+            hasModel(defaultModel.overdueSearchInputsChanged(searchInputs)),
+            hasEffects(SearchOverduePatients(
+                searchInputs = searchInputs,
+                since = date
+            ))
+        ))
   }
 }


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/8837/add-support-for-searching-with-multiple-village-or-patient-names-in-overdue-search-screen
