### PR TITLE
Fix app crashing when overdue search screen is opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Bump AppCompat to v1.5.0
 - Migrate `LoggedOutOfDeviceDialog` to `BaseDialog`
 - Bump flipper to v0.157.0
+- Fix app crashing when overdue search screen is opened
 
 ## 2022-08-08-8359
 

--- a/app/src/main/java/org/simple/clinic/widgets/ChipInputAutoCompleteTextView.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/ChipInputAutoCompleteTextView.kt
@@ -16,6 +16,7 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import androidx.annotation.IdRes
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.res.use
 import androidx.core.os.bundleOf
 import androidx.core.view.children
 import com.google.android.material.chip.Chip
@@ -55,7 +56,7 @@ class ChipInputAutoCompleteTextView(
   init {
     binding = ViewChipTextInputBinding.inflate(LayoutInflater.from(context), this, true)
 
-    val hint: String
+    var hint: String? = null
     context.obtainStyledAttributes(attrs, R.styleable.ChipInputAutoCompleteTextView).use { typedArray ->
       hint = typedArray.getString(R.styleable.ChipInputAutoCompleteTextView_hint).orEmpty()
     }
@@ -154,7 +155,7 @@ class ChipInputAutoCompleteTextView(
     }
   }
 
-  private fun inputChanges(hint: String) = _inputChanges
+  private fun inputChanges(hint: String?) = _inputChanges
       .subscribe {
         if (it.isEmpty()) {
           autoCompleteTextView.hint = hint


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/8924/fix-app-crashing-when-overdue-search-screen-is-opened
