### PR TITLE
Fix app crashing when clicking on Overdue download or share buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Bump mixpanel to v7.0.0
 - Bump mlkit barcode scanning to v18.1.0
 
+### Fixes
+
+- Fix app crashing when clicking on Overdue download or share buttons
+
 ## 2022-08-22-8375
 
 ### Internal

--- a/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/fragments/BaseDialog.kt
@@ -83,13 +83,12 @@ abstract class BaseDialog<K : ScreenKey, B : ViewBinding, M : Parcelable, E, F, 
         ) as T
       }
     }).get()
-
-    eventsDisposable.add(events().subscribe { viewModel.dispatchEvent(it!!) })
-
   }
 
   override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
     _binding = bindView(inflater, container)
+
+    eventsDisposable.add(events().subscribe { viewModel.dispatchEvent(it!!) })
 
     return _binding?.root
   }


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/8943/fix-app-is-crashing-when-clicking-on-download-or-share