### PR TITLE
Enable tracking automatic events from Mixpanel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Next Release
+
+### Internal
+
+- Enable tracking automatic events from Mixpanel
+
 ## 2022-09-12-8414
 
 ### Internal

--- a/app/src/main/java/org/simple/clinic/analytics/MixpanelAnalyticsReporter.kt
+++ b/app/src/main/java/org/simple/clinic/analytics/MixpanelAnalyticsReporter.kt
@@ -8,7 +8,7 @@ import org.simple.clinic.platform.analytics.AnalyticsUser
 
 class MixpanelAnalyticsReporter(app: ClinicApp) : AnalyticsReporter {
 
-  private val mixpanel: MixpanelAPI = MixpanelAPI.getInstance(app, BuildConfig.MIXPANEL_TOKEN, false)
+  private val mixpanel: MixpanelAPI = MixpanelAPI.getInstance(app, BuildConfig.MIXPANEL_TOKEN, true)
 
   override fun setLoggedInUser(user: AnalyticsUser, isANewRegistration: Boolean) {
     synchronized(mixpanel) {


### PR DESCRIPTION
We need this to track `AppSession` and `AppUpdated` events that are required for some of the reports we have
