### PR TITLE
Remove `ConfigReader` injection from `ReleaseClinicApp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Enable tracking automatic events from Mixpanel
 - Sample events sent to Mixpanel
 - Bump AGP to v7.3.0
+- Remove `ConfigReader` injection from `ReleaseClinicApp`
 
 ## 2022-09-12-8414
 

--- a/app/src/main/java/org/simple/clinic/ReleaseClinicApp.kt
+++ b/app/src/main/java/org/simple/clinic/ReleaseClinicApp.kt
@@ -8,20 +8,15 @@ import org.simple.clinic.analytics.swallowErrors
 import org.simple.clinic.di.AppComponent
 import org.simple.clinic.di.AppModule
 import org.simple.clinic.di.DaggerAppComponent
-import org.simple.clinic.remoteconfig.ConfigReader
 import org.simple.clinic.storage.monitoring.Sampler
 import org.simple.clinic.util.unsafeLazy
 import org.slf4j.LoggerFactory
-import javax.inject.Inject
 
 @SuppressLint("Registered")
 class ReleaseClinicApp : ClinicApp() {
 
-  @Inject
-  lateinit var configReader: ConfigReader
-
   override val analyticsReporters by unsafeLazy {
-    val mixpanelSamplingRate = configReader.double("mixpanel_sampling_rate", 0.0)
+    val mixpanelSamplingRate = remoteConfig.double("mixpanel_sampling_rate", 0.0)
     val sampler = Sampler(mixpanelSamplingRate.toFloat())
 
     listOf(MixpanelAnalyticsReporter(


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/9175/fix-app-crashing-when-injecting-config-reader-in-release-builds
