### PR TITLE
Move `bpCreatedAfter` and `bpCreatedBefore` date calculation to `PatientLineListCsvGenerator#generate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bump Flipper to v0.169.0
 - Use paginated data for generating patient line list CSV
 - Enable large table support when converting CSV to PDF
+- Move `bpCreatedAfter` and `bpCreatedBefore` date calculation to `PatientLineListCsvGenerator#generate`
 
 ## 2022-10-11-8452
 

--- a/app/src/androidTest/java/org/simple/clinic/patient/download/PatientLineListCsvGeneratorTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/patient/download/PatientLineListCsvGeneratorTest.kt
@@ -44,7 +44,7 @@ class PatientLineListCsvGeneratorTest {
   fun setup() {
     TestClinicApp.appComponent().inject(this)
 
-    userClock.setDate(LocalDate.parse("2018-01-01"))
+    userClock.setDate(LocalDate.parse("2018-04-15"))
   }
 
   @Test
@@ -200,9 +200,7 @@ class PatientLineListCsvGeneratorTest {
 
     // when
     val generatedCsv = patientLineListCsvGenerator.generate(
-        facilityId = facilityId,
-        bpCreatedAfter = LocalDate.parse("2018-01-01"),
-        bpCreatedBefore = LocalDate.parse("2018-03-31")
+        facilityId = facilityId
     ).toString()
 
     // then

--- a/app/src/androidTest/java/org/simple/clinic/patient/download/PatientLineListDownloaderTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/patient/download/PatientLineListDownloaderTest.kt
@@ -11,7 +11,6 @@ import org.simple.clinic.TestClinicApp
 import org.simple.clinic.patient.download.PatientLineListDownloadResult.DownloadSuccessful
 import org.simple.clinic.rules.LocalAuthenticationRule
 import org.simple.sharedTestCode.util.Rules
-import java.time.LocalDate
 import javax.inject.Inject
 
 class PatientLineListDownloaderTest {
@@ -32,15 +31,9 @@ class PatientLineListDownloaderTest {
 
   @Test
   fun downloading_a_csv_should_work_correctly() {
-    // given
-    val bpCreatedAfter = LocalDate.parse("2018-01-01")
-    val bpCreatedBefore = LocalDate.parse("2018-03-01")
-
     // when
     val result = patientLineListDownloader
         .download(
-            bpCreatedAfter = bpCreatedAfter,
-            bpCreatedBefore = bpCreatedBefore,
             fileFormat = PatientLineListFileFormat.CSV
         )
         .blockingGet()
@@ -51,15 +44,9 @@ class PatientLineListDownloaderTest {
 
   @Test
   fun downloading_a_pdf_should_work_correctly() {
-    // given
-    val bpCreatedAfter = LocalDate.parse("2018-01-01")
-    val bpCreatedBefore = LocalDate.parse("2018-03-01")
-
     // when
     val result = patientLineListDownloader
         .download(
-            bpCreatedAfter = bpCreatedAfter,
-            bpCreatedBefore = bpCreatedBefore,
             fileFormat = PatientLineListFileFormat.PDF
         )
         .blockingGet()

--- a/app/src/main/java/org/simple/clinic/patient/PatientConfig.kt
+++ b/app/src/main/java/org/simple/clinic/patient/PatientConfig.kt
@@ -1,9 +1,11 @@
 package org.simple.clinic.patient
 
 import org.simple.clinic.remoteconfig.ConfigReader
+import java.time.Period
 
 data class PatientConfig(
-    val recentPatientLimit: Int
+    val recentPatientLimit: Int,
+    val periodForCalculatingLineListHtnControl: Period
 ) {
 
   companion object {
@@ -15,7 +17,8 @@ data class PatientConfig(
           .toInt()
 
       return PatientConfig(
-          recentPatientLimit = numberOfRecentPatients
+          recentPatientLimit = numberOfRecentPatients,
+          periodForCalculatingLineListHtnControl = Period.ofMonths(2)
       )
     }
   }

--- a/app/src/main/java/org/simple/clinic/patient/download/PatientLineListDownloader.kt
+++ b/app/src/main/java/org/simple/clinic/patient/download/PatientLineListDownloader.kt
@@ -44,8 +44,6 @@ class PatientLineListDownloader @Inject constructor(
   }
 
   fun download(
-      bpCreatedAfter: LocalDate,
-      bpCreatedBefore: LocalDate,
       fileFormat: PatientLineListFileFormat
   ): Single<PatientLineListDownloadResult> {
     if (!hasMinReqSpace()) {
@@ -58,11 +56,7 @@ class PatientLineListDownloader @Inject constructor(
       val facilityName = facility.name
 
       try {
-        val csvOutputStream = patientLineListCsvGenerator.generate(
-            facilityId = facilityId,
-            bpCreatedAfter = bpCreatedAfter,
-            bpCreatedBefore = bpCreatedBefore
-        )
+        val csvOutputStream = patientLineListCsvGenerator.generate(facilityId = facilityId)
         val csvInputStream = ByteArrayInputStream(csvOutputStream.toByteArray())
 
         it.onSuccess(saveFileToDisk(fileFormat, facilityName, csvInputStream))

--- a/app/src/main/java/org/simple/clinic/patient/download/PatientLineListScheduler.kt
+++ b/app/src/main/java/org/simple/clinic/patient/download/PatientLineListScheduler.kt
@@ -15,8 +15,6 @@ class PatientLineListScheduler @Inject constructor(
       bpCreatedBefore: LocalDate
   ) {
     val workRequest = PatientLinetListDownloadWorker.workRequest(
-        bpCreatedAfter = bpCreatedAfter,
-        bpCreatedBefore = bpCreatedBefore,
         fileFormat = fileFormat
     )
 

--- a/app/src/main/java/org/simple/clinic/patient/download/PatientLinetListDownloadWorker.kt
+++ b/app/src/main/java/org/simple/clinic/patient/download/PatientLinetListDownloadWorker.kt
@@ -26,7 +26,6 @@ import org.simple.clinic.patient.download.PatientLineListDownloadResult.NotEnoug
 import org.simple.clinic.patient.download.PatientLineListFileFormat.CSV
 import org.simple.clinic.patient.download.PatientLineListFileFormat.PDF
 import org.simple.clinic.util.scheduler.SchedulersProvider
-import java.time.LocalDate
 import javax.inject.Inject
 
 class PatientLinetListDownloadWorker(
@@ -38,8 +37,6 @@ class PatientLinetListDownloadWorker(
     const val TAG = "patient_line_list_download_worker"
 
     private const val KEY_DOWNLOAD_FORMAT = "download_format"
-    private const val KEY_BP_CREATED_AFTER = "bp_created_after"
-    private const val KEY_BP_CREATED_BEFORE = "bp_created_before"
 
     private const val NOTIFICATION_CHANNEL_ID = "org.simple.clinic.Downloads"
     private const val NOTIFICATION_CHANNEL_NAME = "Downloads"
@@ -54,15 +51,11 @@ class PatientLinetListDownloadWorker(
     private const val GOOGLE_SHEETS_PACKAGE_NAME = "com.google.android.apps.docs.editors.sheets"
 
     fun workRequest(
-        fileFormat: PatientLineListFileFormat,
-        bpCreatedAfter: LocalDate,
-        bpCreatedBefore: LocalDate
+        fileFormat: PatientLineListFileFormat
     ): OneTimeWorkRequest {
       return OneTimeWorkRequestBuilder<PatientLinetListDownloadWorker>()
           .setInputData(workDataOf(
-              KEY_DOWNLOAD_FORMAT to fileFormat.toString(),
-              KEY_BP_CREATED_AFTER to bpCreatedAfter.toString(),
-              KEY_BP_CREATED_BEFORE to bpCreatedBefore.toString()
+              KEY_DOWNLOAD_FORMAT to fileFormat.toString()
           ))
           .build()
     }
@@ -94,13 +87,8 @@ class PatientLinetListDownloadWorker(
     val downloadFormatString = inputData.getString(KEY_DOWNLOAD_FORMAT)!!
     val downloadFormat = PatientLineListFileFormat.valueOf(downloadFormatString)
 
-    val bpCreatedAfter = LocalDate.parse(inputData.getString(KEY_BP_CREATED_AFTER))
-    val bpCreatedBefore = LocalDate.parse(inputData.getString(KEY_BP_CREATED_BEFORE))
-
     return downloader
         .download(
-            bpCreatedAfter = bpCreatedAfter,
-            bpCreatedBefore = bpCreatedBefore,
             fileFormat = downloadFormat
         )
         .map { result ->

--- a/app/src/test/java/org/simple/clinic/recentpatientsview/LatestRecentPatientsLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/recentpatientsview/LatestRecentPatientsLogicTest.kt
@@ -13,7 +13,6 @@ import io.reactivex.subjects.Subject
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
-import org.simple.sharedTestCode.TestData
 import org.simple.clinic.patient.Gender.Female
 import org.simple.clinic.patient.Gender.Male
 import org.simple.clinic.patient.Gender.Transgender
@@ -21,13 +20,15 @@ import org.simple.clinic.patient.PatientAgeDetails
 import org.simple.clinic.patient.PatientConfig
 import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.patient.RecentPatient
-import org.simple.sharedTestCode.util.RxErrorsRule
-import org.simple.sharedTestCode.util.TestUserClock
 import org.simple.clinic.util.scheduler.TestSchedulersProvider
 import org.simple.clinic.widgets.UiEvent
 import org.simple.mobius.migration.MobiusTestFixture
+import org.simple.sharedTestCode.TestData
+import org.simple.sharedTestCode.util.RxErrorsRule
+import org.simple.sharedTestCode.util.TestUserClock
 import java.time.Instant
 import java.time.LocalDate
+import java.time.Period
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.UUID
@@ -298,7 +299,8 @@ class LatestRecentPatientsLogicTest {
     whenever(patientRepository.recentPatients(facility.uuid, recentPatientLimitPlusOne)) doReturn Observable.just(recentPatients)
 
     val config = PatientConfig(
-        recentPatientLimit = recentPatientLimit
+        recentPatientLimit = recentPatientLimit,
+        periodForCalculatingLineListHtnControl = Period.ofMonths(2)
     )
 
     val effectHandler = LatestRecentPatientsEffectHandler(


### PR DESCRIPTION
Since the HTN control status are not changeable by user from UI and the period is fixed. There is no point exposing the values to be configurable until effect handler. Instead we are creating the start and end date for calculating HTN control status in the `PatientLineListCsvGenerator`
