### PR TITLE
Run overdue appointment queries in a transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Bump mixpanel to v7.2.0
 - Bump auto request review to v0.8.0
 - Bump Fragment to v1.5.4
+- Run overdue appointment queries in a transaction
 
 ### Fixes
 

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueAppointment.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueAppointment.kt
@@ -5,6 +5,7 @@ import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Embedded
 import androidx.room.Query
+import androidx.room.Transaction
 import io.reactivex.Observable
 import kotlinx.parcelize.Parcelize
 import org.intellij.lang.annotations.Language
@@ -93,6 +94,7 @@ data class OverdueAppointment(
     """
     }
 
+    @Transaction
     @Query(""" 
       $OVERDUE_APPOINTMENTS_QUERY 
       WHERE
@@ -109,6 +111,7 @@ data class OverdueAppointment(
         scheduledBefore: LocalDate
     ): Observable<List<OverdueAppointment>>
 
+    @Transaction
     @Query("""
       $OVERDUE_APPOINTMENTS_QUERY
       WHERE
@@ -128,6 +131,7 @@ data class OverdueAppointment(
         scheduledBefore: LocalDate
     ): PagingSource<Int, OverdueAppointment>
 
+    @Transaction
     @Query("""
       $OVERDUE_APPOINTMENTS_QUERY
       WHERE


### PR DESCRIPTION
Since we are using observable streams of data on a query that relies on table joins. Without transaction it can cause crashes when the table that are joined has changes.
