### PR TITLE
Add renovate package rule for Flipper updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Bump iText to v7.2.4
 - Enable patient line list download for Indian users only
 - Bump Sentry to v6.6.0
+- Add renovate package rule for Flipper updates
 
 ## 2022-10-26-8474
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,16 @@
   "schedule": [
     "after 12am and before 2am"
   ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "com.facebook.flipper"
+      ],
+      "schedule": [
+        "after 12am and before 2am on the first day of the month"
+      ]
+    }
+  ],
   "timezone": "Asia/Kolkata",
   "ignoreDeps": [
     // Ignoring zxing update. Since update requires Java 8+ runtime.


### PR DESCRIPTION
Flipper updates much more frequently and causes a lot of noise in our PRs. That's why scheduled it to only check for update only once a month instead.
