### PR TITLE
Move splash screen lottie config to XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add a product flavor for TamilNadu app
 - Bump google play services location to v21.0.1
 - Bump Sentry Gradle Plugin to v3.2.1
+- Move splash screen lottie config to XML
 
 ## 2022-10-31-8480
 

--- a/app/src/main/java/org/simple/clinic/splash/SplashScreen.kt
+++ b/app/src/main/java/org/simple/clinic/splash/SplashScreen.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import com.airbnb.lottie.LottieDrawable
 import kotlinx.parcelize.Parcelize
 import org.simple.clinic.databinding.ScreenSplashBinding
 import org.simple.clinic.di.injector
@@ -24,9 +23,6 @@ class SplashScreen : Fragment() {
 
   private var binding: ScreenSplashBinding? = null
 
-  private val splashLottieView
-    get() = binding!!.splashLottieView
-
   private val nextButton
     get() = binding!!.nextButton
 
@@ -42,12 +38,6 @@ class SplashScreen : Fragment() {
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
-    with(splashLottieView) {
-      setAnimation("splash_animation.json")
-      repeatCount = LottieDrawable.INFINITE
-      playAnimation()
-    }
-
     nextButton.setOnClickListener {
       router.clearHistoryAndPush(OnboardingScreen.Key())
     }

--- a/app/src/main/res/layout/screen_splash.xml
+++ b/app/src/main/res/layout/screen_splash.xml
@@ -25,7 +25,11 @@
     android:adjustViewBounds="true"
     app:layout_constraintBottom_toTopOf="@+id/nextButtonFrame"
     app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent" />
+    app:layout_constraintStart_toStartOf="parent"
+    app:lottie_autoPlay="true"
+    app:lottie_fileName="splash_animation.json"
+    app:lottie_repeatCount="@integer/lottie_repeat_infinite"
+    app:lottie_repeatMode="restart" />
 
   <FrameLayout
     android:id="@+id/nextButtonFrame"

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <integer name="lottie_repeat_infinite">-1</integer>
+</resources>


### PR DESCRIPTION
This will allow us to safely replace the layout for states without having to worry much about the `SplashScreen` class as we are only accessing the next button reference
