### PR TITLE
Show notification permission rationale dialog when user doesn’t allow notification permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bump google play services location to v21.0.1
 - Bump Sentry Gradle Plugin to v3.2.1
 - Move splash screen lottie config to XML
+- Show notification permission rationale dialog when user doesn’t allow notification permission
 
 ## 2022-10-31-8480
 

--- a/app/src/main/java/org/simple/clinic/home/HomeScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomeScreen.kt
@@ -1,11 +1,14 @@
 package org.simple.clinic.home
 
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.os.Parcelable
+import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -219,6 +222,17 @@ class HomeScreen :
     router.pushExpectingResult(ChangeCurrentFacility, FacilityChangeScreen.Key())
   }
 
+  override fun showNotificationPermissionDeniedDialog() {
+    MaterialAlertDialogBuilder(requireContext())
+        .setTitle(R.string.notification_permission_denied_title)
+        .setMessage(R.string.notification_permission_denied_message)
+        .setPositiveButton(R.string.notification_permission_denied_positive_button) { _, _ ->
+          openAppInfo()
+        }
+        .setNegativeButton(R.string.notification_permission_denied_negetive_button, null)
+        .show()
+  }
+
   override fun showOverdueAppointmentCount(count: Int) {
     val overdueTabIndex = tabs.indexOf(OVERDUE)
     val overdueTab = homeTabLayout.getTabAt(overdueTabIndex)
@@ -298,6 +312,12 @@ class HomeScreen :
         .setMessage(R.string.deeplink_please_check_with_your_supervisor)
         .setPositiveButton(R.string.deeplink_okay_positive_action, null)
         .show()
+  }
+
+  private fun openAppInfo() {
+    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+    intent.data = Uri.fromParts("package", requireContext().packageName, null)
+    startActivity(intent)
   }
 
   interface Injector {

--- a/app/src/main/java/org/simple/clinic/home/HomeScreenEffect.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomeScreenEffect.kt
@@ -7,3 +7,5 @@ object LoadCurrentFacility : HomeScreenEffect()
 sealed class HomeScreenViewEffect : HomeScreenEffect()
 
 object OpenFacilitySelection : HomeScreenViewEffect()
+
+object ShowNotificationPermissionDenied : HomeScreenViewEffect()

--- a/app/src/main/java/org/simple/clinic/home/HomeScreenUiActions.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomeScreenUiActions.kt
@@ -2,4 +2,5 @@ package org.simple.clinic.home
 
 interface HomeScreenUiActions {
   fun openFacilitySelection()
+  fun showNotificationPermissionDeniedDialog()
 }

--- a/app/src/main/java/org/simple/clinic/home/HomeScreenUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomeScreenUpdate.kt
@@ -16,7 +16,16 @@ class HomeScreenUpdate : Update<HomeScreenModel, HomeScreenEvent, HomeScreenEffe
       HomeFacilitySelectionClicked -> dispatch(OpenFacilitySelection)
       is CurrentFacilityLoaded -> next(model.facilityLoaded(event.facility))
       is OverdueAppointmentCountUpdated -> next(model.overdueAppointmentCountUpdated(event.overdueAppointmentCount))
-      is RequestNotificationPermission -> if (event.isPermissionGranted) noChange() else dispatch(ShowNotificationPermissionDenied)
+      is RequestNotificationPermission -> notificationPermissionDenied(event)
     }
+  }
+
+  private fun notificationPermissionDenied(
+      event: RequestNotificationPermission
+  ): Next<HomeScreenModel, HomeScreenEffect> {
+    return if (event.isPermissionGranted)
+      noChange()
+    else
+      dispatch(ShowNotificationPermissionDenied)
   }
 }

--- a/app/src/main/java/org/simple/clinic/home/HomeScreenUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomeScreenUpdate.kt
@@ -16,7 +16,7 @@ class HomeScreenUpdate : Update<HomeScreenModel, HomeScreenEvent, HomeScreenEffe
       HomeFacilitySelectionClicked -> dispatch(OpenFacilitySelection)
       is CurrentFacilityLoaded -> next(model.facilityLoaded(event.facility))
       is OverdueAppointmentCountUpdated -> next(model.overdueAppointmentCountUpdated(event.overdueAppointmentCount))
-      is RequestNotificationPermission -> noChange()
+      is RequestNotificationPermission -> if (event.isPermissionGranted) noChange() else dispatch(ShowNotificationPermissionDenied)
     }
   }
 }

--- a/app/src/main/java/org/simple/clinic/home/HomeScreenViewEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/home/HomeScreenViewEffectHandler.kt
@@ -10,6 +10,7 @@ class HomeScreenViewEffectHandler(
   override fun handle(viewEffect: HomeScreenViewEffect) {
     when (viewEffect) {
       OpenFacilitySelection -> uiActions.openFacilitySelection()
+      ShowNotificationPermissionDenied -> uiActions.showNotificationPermissionDeniedDialog()
     }.exhaustive()
   }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1017,7 +1017,7 @@
 
   <!--Notification permission denied dialog-->
   <string name="notification_permission_denied_title">Turn on notifications</string>
-  <string name="notification_permission_denied_message">Simple needs permission to show you important reminders.Turn on under Permissions > Notifications</string>
+  <string name="notification_permission_denied_message">Simple needs permission to show you important reminders.Turn on under Permissions &gt; Notifications</string>
   <string name="notification_permission_denied_positive_button">GO TO APP SETTINGS</string>
   <string name="notification_permission_denied_negetive_button">NOT NOW</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1015,4 +1015,10 @@
   <string name="patient_line_list_download_card_desc">List of all patients registered or assigned to %1$s</string>
   <string name="patient_line_list_download_card_button">Download</string>
 
+  <!--Notification permission denied dialog-->
+  <string name="notification_permission_denied_title">Turn on notifications</string>
+  <string name="notification_permission_denied_message">Simple needs permission to show you important reminders.Turn on under Permissions > Notifications</string>
+  <string name="notification_permission_denied_positive_button">GO TO APP SETTINGS</string>
+  <string name="notification_permission_denied_negetive_button">NOT NOW</string>
+
 </resources>

--- a/app/src/test/java/org/simple/clinic/home/HomeScreenEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/HomeScreenEffectHandlerTest.kt
@@ -12,7 +12,7 @@ import org.simple.clinic.util.scheduler.TestSchedulersProvider
 import org.simple.sharedTestCode.TestData
 import java.util.UUID
 
-class HomeScreenViewEffectHandlerTest {
+class HomeScreenEffectHandlerTest {
 
   private val facility = TestData.facility(
       uuid = UUID.fromString("251deca2-d219-4863-80fc-e7d48cb22b1b"),

--- a/app/src/test/java/org/simple/clinic/home/HomeScreenUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/HomeScreenUpdateTest.kt
@@ -1,5 +1,6 @@
 package org.simple.clinic.home
 
+import com.spotify.mobius.test.NextMatchers.hasEffects
 import com.spotify.mobius.test.NextMatchers.hasNoEffects
 import com.spotify.mobius.test.NextMatchers.hasNoModel
 import com.spotify.mobius.test.UpdateSpec
@@ -24,14 +25,14 @@ class HomeScreenUpdateTest {
   }
 
   @Test
-  fun `when notification permission is not granted, then do nothing`() {
+  fun `when notification permission is not granted, then show notification permission denied dialog`() {
     val defaultModel = HomeScreenModel.create()
     UpdateSpec(HomeScreenUpdate())
         .given(defaultModel)
         .whenEvent(RequestNotificationPermission(permission = Optional.of(DENIED)))
         .then(assertThatNext(
             hasNoModel(),
-            hasNoEffects()
+            hasEffects(ShowNotificationPermissionDenied)
         ))
   }
 }

--- a/app/src/test/java/org/simple/clinic/home/HomeScreenViewEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/home/HomeScreenViewEffectHandlerTest.kt
@@ -1,0 +1,46 @@
+package org.simple.clinic.home
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import io.reactivex.Observable
+import org.junit.Test
+import org.simple.clinic.facility.FacilityConfig
+import org.simple.clinic.mobius.EffectHandlerTestCase
+import org.simple.clinic.patient.PatientRepository
+import org.simple.clinic.util.scheduler.TestSchedulersProvider
+import org.simple.sharedTestCode.TestData
+import java.util.UUID
+
+class HomeScreenViewEffectHandlerTest {
+
+  private val facility = TestData.facility(
+      uuid = UUID.fromString("251deca2-d219-4863-80fc-e7d48cb22b1b"),
+      name = "PHC Obvious",
+      facilityConfig = FacilityConfig(
+          diabetesManagementEnabled = true,
+          teleconsultationEnabled = false
+      )
+  )
+  private val patientRepository = mock<PatientRepository>()
+  private val uiActions = mock<HomeScreenUiActions>()
+  private val effectHandler = HomeScreenEffectHandler(
+      patientRepository = patientRepository,
+      schedulersProvider = TestSchedulersProvider.trampoline(),
+      viewEffectsConsumer = HomeScreenViewEffectHandler(uiActions)::handle,
+      currentFacilityStream = Observable.just(facility)
+  ).build()
+  private val effectHandlerTestCase = EffectHandlerTestCase(
+      effectHandler = effectHandler
+  )
+
+  @Test
+  fun `when notification permission denied effect is received, then show notification permission denied dialog`() {
+    // when
+    effectHandlerTestCase.dispatch(ShowNotificationPermissionDenied)
+
+    // then
+    verify(uiActions).showNotificationPermissionDeniedDialog()
+    verifyNoMoreInteractions(uiActions)
+  }
+}


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/9424/show-notification-permission-rationale-dialog-when-user-doesn-t-allow-notification-permission
