### PR TITLE
Remove max SDK for storage permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bump Kotlin to v1.7.21
 - Fix Tamil Nadu `google-services.json` not present in correct folder
 - Bump androidx-test-junit to v1.1.4
+- Remove max SDK version for storage permissions
 
 ## 2022-11-07-8490
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,10 +22,9 @@
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission
     android:name="android.permission.READ_EXTERNAL_STORAGE"
-    android:maxSdkVersion="32" />
+    tools:ignore="ScopedStorage" />
   <uses-permission
     android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-    android:maxSdkVersion="32"
     tools:ignore="ScopedStorage" />
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 


### PR DESCRIPTION
Reverting change from #4309, since it's effecting storage permissions in tests