### PR TITLE
Remove benchmark plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bump Dagger to v2.44.2
 - Bump Sentry Gradle Plugin to v3.3.0
 - Bump leakcanary to v2.10
+- Remove Benchmark plugin
 
 ## 2022-11-14-8505
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,6 @@ plugins {
   id("io.sentry.android.gradle")
   id("plugins.git.install-hooks")
   id("com.datadoghq.dd-sdk-android-gradle-plugin")
-  id("androidx.benchmark")
 }
 
 sentry {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,6 @@ buildscript {
     classpath(libs.sentry.gradle.plugin)
     classpath(files("./buildTooling/room-metadata-generator-${roomMetaDataGeneratorVersion}.jar"))
     classpath(libs.datadog.gradle.plugin)
-    classpath(libs.benchmark.gradle.plugin)
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -186,8 +186,6 @@ zxing = "com.google.zxing:core:3.3.3"
 
 apache-commons-math = "org.apache.commons:commons-math3:3.6.1"
 
-benchmark-gradle-plugin = "androidx.benchmark:benchmark-gradle-plugin:1.0.0"
-
 [bundles]
 androidx-camera = ["androidx-camera-core", "androidx-camera-camera2", "androidx-camera-view", "androidx-camera-lifecycle"]
 androidx-paging = ["androidx-paging-common", "androidx-paging-runtime", "androidx-paging-rx2"]


### PR DESCRIPTION
Remove benchmark plugin as the project no longer uses it and benchmark v1.1.1 fails to generate assembleQaDebugAndroidTest task
