### PR TITLE
Move test login details into Maestro login flow

### DIFF
--- a/.github/workflows/maestro_tests.yml
+++ b/.github/workflows/maestro_tests.yml
@@ -72,10 +72,6 @@ jobs:
             -PmanifestEndpoint=${{ secrets.MANIFEST_ENDPOINT }}
             :app:installStagingRelease
             
-            maestro test
-            -e number=${{ secrets.TEST_LOGIN_PHONE_NUMBER }}
-            -e pin=${{ secrets.TEST_LOGIN_PIN }}
-            -e otp=${{ secrets.TEST_LOGIN_OTP }}
-            maestroUiFlows/login_flow.yaml
+            maestro test maestroUiFlows/login_flow.yaml
             
             adb uninstall org.simple.clinic.staging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Bump sentry to v.6.8.0
 - Cache AVD when running Maestro tests in GH Actions
 - Bump google play services auth to v20.4.0
+- Move test login details into Maestro login flow
 
 ## 2022-11-14-8505
 

--- a/maestroUiFlows/login_flow.yaml
+++ b/maestroUiFlows/login_flow.yaml
@@ -10,11 +10,11 @@ appId: org.simple.clinic.staging
 - tapOn:
     below:
       id: "select_state_title"
-- inputText: ${number}
+- inputText: "6664266642"
 - tapOn: "Next"
 - assertVisible:
     text: "Your security PIN"
-- inputText: ${pin}
+- inputText: "1712"
 - tapOn: "Enter code"
-- inputText: ${otp}
+- inputText: "000000"
 - tapOn: "Got it"


### PR DESCRIPTION
We are already providing this information publicly as part of test data in `TestDataModule`. So, I don't see any point in keep these as secrets. This will also allow us to eventually have a Gradle task to run the maestro tests without having to pass command params.

