### PR TITLE
Ignore logback dependency updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -18,7 +18,9 @@
   "timezone": "Asia/Kolkata",
   "ignoreDeps": [
     // Ignoring zxing update. Since update requires Java 8+ runtime.
-    "com.google.zxing:core"
+    "com.google.zxing:core",
+    // We only use this to turn off logs related to Mobius#ControllerStateBase in release app
+    "ch.qos.logback:logback-classic"
   ],
   "prConcurrentLimit": 5
 }


### PR DESCRIPTION
We only use this library to turn off logs from `ControllerStateBase` from Mobius. That's why we are not actively looking to update the dependency.

