### PR TITLE
Test heroku android review apps

### DIFF
--- a/.github/scripts/setup_heroku_instance.sh
+++ b/.github/scripts/setup_heroku_instance.sh
@@ -28,8 +28,8 @@ if [ $serverAppAlreadyExists = false ]; then
   $androidAppDirectory/.github/scripts/server_heroku_env_setup.py $serverAppDirectory/app.json $herokuAppName $herokuApiKey "$decodedHerokuEnvProperties"
 
   heroku stack:set --app=$herokuAppName heroku-20
-  heroku addons:create --app=$herokuAppName --wait --name="${herokuAppName}-redis" heroku-redis:hobby-dev
-  heroku addons:create --app=$herokuAppName --wait --name="${herokuAppName}-postgres" heroku-postgresql:hobby-dev
+  heroku addons:create --app=$herokuAppName --wait --name="${herokuAppName}-redis" heroku-redis:mini
+  heroku addons:create --app=$herokuAppName --wait --name="${herokuAppName}-postgres" heroku-postgresql:mini
   heroku buildpacks:add --index 1 --app=$herokuAppName heroku/nodejs
   heroku buildpacks:add --index 2 --app=$herokuAppName heroku/ruby
   heroku buildpacks:add --index 3 --app=$herokuAppName https://github.com/weibeld/heroku-buildpack-run.git

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -91,6 +91,20 @@ jobs:
       - name: Link Heroku CLI globally
         run: heroku plugins:install buildpacks
 
+      - name: Generate server app name
+        id: generate-server-app-name
+        run: android-app/.github/scripts/generate_heroku_app_name.sh ${{ github.ref }}
+
+      - name: Deploy the server on Heroku
+        id: start-simple-server
+        run: |
+          android-app/.github/scripts/setup_heroku_instance.sh \
+          ${{ steps.generate-server-app-name.outputs.heroku_app_name }} \
+          ${{ env.HEROKU_API_KEY }} \
+          server-app \
+          android-app \
+          ${{ secrets.HEROKU_SECRET_PROPERTIES }}
+
       - name: Cache AVD
         uses: actions/cache@v3
         id: avd-cache
@@ -118,20 +132,6 @@ jobs:
           distribution: 'zulu'
           java-version: 11
           cache: 'gradle'
-
-      - name: Generate server app name
-        id: generate-server-app-name
-        run: android-app/.github/scripts/generate_heroku_app_name.sh ${{ github.ref }}
-
-      - name: Deploy the server on Heroku
-        id: start-simple-server
-        run: |
-          android-app/.github/scripts/setup_heroku_instance.sh \
-          ${{ steps.generate-server-app-name.outputs.heroku_app_name }} \
-          ${{ env.HEROKU_API_KEY }} \
-          server-app \
-          android-app \
-          ${{ secrets.HEROKU_SECRET_PROPERTIES }}
 
       - name: QA Android Tests
         id: run-instrumented-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 ### Changes
+- Bump heroku review app resources
 - Updated translations: `te_IN`, `kn_IN`, `hi_IN`, `bn_BD`, `sid_ET`, `si_LK`, `bn_IN`, `ta_IN`, `pa_IN`
 - Bump Facebook.soloader to v0.10.5
 - Bump sentry to v6.9.1


### PR DESCRIPTION
**Story card:** [sc-9029](https://app.shortcut.com/simpledotorg/story/9029/investigate-heroku-ending-free-tier-services-and-potential-non-profit-benefits)

## Because

Heroku has stopped supporting hobby (free) dynos. 

## This addresses

This bumps up our heroku review app configuration to use the basic paid tier to unblock android review apps while we figure out alternatives.