### PR TITLE
Replace deprecated `set-output` command in GH Actions

### DIFF
--- a/.github/scripts/compute_node_dependency_hash.sh
+++ b/.github/scripts/compute_node_dependency_hash.sh
@@ -12,4 +12,4 @@ hashed=$(shasum <<< stringToHash | cut -f 1 -d ' ')
 
 echo "Hashed \"${stringToHash}\" -> \"${hashed}\""
 
-echo "::set-output name=node_dep_hash::${hashed}"
+echo "node_dep_hash=$hashed" >> $GITHUB_OUTPUT

--- a/.github/scripts/generate_heroku_app_name.sh
+++ b/.github/scripts/generate_heroku_app_name.sh
@@ -11,4 +11,4 @@ fi
 
 echo "Heroku app name: ${herokuAppName}"
 
-echo "::set-output name=heroku_app_name::${herokuAppName}"
+echo "heroku_app_name=$herokuAppName" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Remove `app_name` form translated strings and make it untranslatable
 - Updated translations: `so_ET`
 - Remove `CommitAndPush` script
+- Replace deprecated `set-output` command in GH Actions 
 
 ## 2022-12-12-8539
 


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/