### PR TITLE
Questionnaire sync resource removed from sync list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bump fragment-ktx to v1.5.5
 - Bump threeten-extra to v1.7.2
 - Add Questionnaire sync resource
+- Remove Questionnaire sync resource from syncs
 
 ### Internal
 

--- a/app/src/main/java/org/simple/clinic/sync/SyncModule.kt
+++ b/app/src/main/java/org/simple/clinic/sync/SyncModule.kt
@@ -27,7 +27,6 @@ import org.simple.clinic.medicalhistory.MedicalHistoryModule
 import org.simple.clinic.medicalhistory.MedicalHistoryRepository
 import org.simple.clinic.medicalhistory.sync.MedicalHistorySync
 import org.simple.clinic.monthlyReports.questionnaire.di.QuestionnaireModule
-import org.simple.clinic.monthlyReports.questionnaire.sync.QuestionnaireSync
 import org.simple.clinic.overdue.AppointmentModule
 import org.simple.clinic.overdue.AppointmentRepository
 import org.simple.clinic.overdue.AppointmentSync
@@ -85,8 +84,7 @@ class SyncModule {
       teleconsultationMedicalOfficersSync: TeleconsultationSync,
       teleconsultRecordSync: TeleconsultRecordSync,
       drugSync: DrugSync,
-      callResultSync: CallResultSync,
-      questionnaireSync: QuestionnaireSync
+      callResultSync: CallResultSync
   ): List<ModelSync> {
     val optionalSyncs = if (features.isEnabled(Feature.CallResultSyncEnabled)) listOf(callResultSync) else emptyList()
 
@@ -94,7 +92,7 @@ class SyncModule {
         facilitySync, protocolSync, reportsSync, helpSync,
         patientSync, bloodPressureSync, medicalHistorySync, appointmentSync, prescriptionSync,
         bloodSugarSync, teleconsultationMedicalOfficersSync,
-        teleconsultRecordSync, drugSync, questionnaireSync
+        teleconsultRecordSync, drugSync
     ) + optionalSyncs
   }
 


### PR DESCRIPTION
Questionnaire sync resource removed from the sync list as the feature is still in development mode.

https://app.shortcut.com/simpledotorg/story/9558/add-sync-resource-for-questionnaire-responseapi