### PR TITLE
Fix trigger_release GH action

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -128,6 +128,7 @@ jobs:
           android-app/.github/scripts/setup_heroku_instance.sh \
           ${{ steps.generate-server-app-name.outputs.heroku_app_name }} \
           ${{ env.HEROKU_API_KEY }} \
+          master \
           server-app \
           android-app \
           ${{ secrets.HEROKU_SECRET_PROPERTIES }}


### PR DESCRIPTION
[sc-9976](https://app.shortcut.com/simpledotorg/story/9976/user-enumeration-through-api-endpoints)

The `trigger_release` action was broken due to changes introduced in https://github.com/simpledotorg/simple-android/pull/4645.

This fixes usage of the `setup_heroku_instance` script, which takes a branch name that needs to be explicitly passed in.