### PR TITLE
Add rules to prevent Retrofit & GSON types being stripped in R8 full mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix `Monthly supplies report` icon
 - Update Questionnaire form radio button styling
 - Remove firebase remote config `questionnaires_enabled` logic for loading questionnaire's api.
+- Add rules to prevent Retrofit & GSON types being stripped in R8 full mode
 
 ### Changes
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -106,3 +106,8 @@
 # https://github.com/square/retrofit/pull/3886
 -if interface * { @retrofit2.http.* public *** *(...); }
 -keep,allowoptimization,allowshrinking,allowobfuscation class <3>
+
+# GSON
+-keepattributes Signature
+-keep class com.google.gson.reflect.TypeToken { *; }
+-keep class * extends com.google.gson.reflect.TypeToken

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -99,3 +99,10 @@
 -dontwarn org.codehaus.commons.compiler.CompileException
 -dontwarn org.codehaus.janino.ClassBodyEvaluator
 -dontwarn sun.reflect.Reflection
+
+# R8 full mode strips generic signatures from return types if not kept.
+# This fix is not available in a Retrofit release yet. Once Retrofit is updated
+# we can remove this
+# https://github.com/square/retrofit/pull/3886
+-if interface * { @retrofit2.http.* public *** *(...); }
+-keep,allowoptimization,allowshrinking,allowobfuscation class <3>


### PR DESCRIPTION
https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md#r8-full-mode