### PR TITLE
Disable R8 full mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Remove firebase remote config `questionnaires_enabled` logic for loading questionnaire's api.
 - Add rules to prevent Retrofit & GSON types being stripped in R8 full mode
 - Remove DPH/TamilNadu build variant
+- Disable R8 full mode
 
 ### Changes
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,7 @@ android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.enableR8.fullMode=false
 # Mixpanel project tokens are declared here so they can be configured on CI
 mixpanelToken=do_not_change_here
 # Manifest URL endpoint

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -164,8 +164,8 @@ rx-java = "io.reactivex.rxjava2:rxjava:2.2.21"
 rx-kotlin = "io.reactivex.rxjava2:rxkotlin:2.4.0"
 rx-preferences = "com.f2prateek.rx.preferences2:rx-preferences:2.0.1"
 
-sentry-android = "io.sentry:sentry-android:6.9.1"
-sentry-gradle-plugin = "io.sentry:sentry-android-gradle-plugin:3.3.0"
+sentry-android = "io.sentry:sentry-android:6.21.0"
+sentry-gradle-plugin = "io.sentry:sentry-android-gradle-plugin:3.8.0"
 
 signaturepad = "com.github.gcacace:signature-pad:1.3.1"
 


### PR DESCRIPTION
Going back to R8 compatibility mode. Looks like classes are getting stripped which is making the release variants crash. We can get back to enabling R8 full mode later.