### PR TITLE
Use heroku generated app url for manifest endpoint in CI

### DIFF
--- a/.github/scripts/setup_heroku_instance.sh
+++ b/.github/scripts/setup_heroku_instance.sh
@@ -49,6 +49,8 @@ if [ $serverAppAlreadyExists = false ]; then
   resultOfSeedDataSetup=$?
 fi
 
+echo "heroku_app_url=$(heroku apps:info --app "${herokuAppName}" --json | jq -r '.app.web_url')" >> "$GITHUB_OUTPUT"
+
 echo "Result of starting server: ${resultOfServerPush}, seed data push ${resultOfSeedDataSetup}"
 
 finalExitCode=$((resultOfServerPush | resultOfSeedDataSetup))

--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -150,7 +150,7 @@ jobs:
           script: |
             adb root
             mkdir -p android-app/app/build/outputs/test-artifacts
-            android-app/gradlew -p android-app --build-cache --no-daemon -PmanifestEndpoint=https://${{ steps.generate-server-app-name.outputs.heroku_app_name }}.herokuapp.com/api/ installQaDebug installQaDebugAndroidTest
+            android-app/gradlew -p android-app --build-cache --no-daemon -PmanifestEndpoint=${{ steps.start-simple-server.outputs.heroku_app_url }}api/ installQaDebug installQaDebugAndroidTest
             adb shell am instrument -w -e filter org.simple.clinic.benchmark.SelectBenchmarkTests -e benchmark_app_performance false  org.simple.clinic.qa.debug.test/org.simple.clinic.AndroidTestJUnitRunner >android-app/app/build/outputs/test-artifacts/logs.txt 2>android-app/app/build/outputs/test-artifacts/logs.txt
             cat android-app/app/build/outputs/test-artifacts/logs.txt
             adb pull /storage/emulated/0/Android/data/org.simple.clinic.qa.debug/ android-app/app/build/outputs/test-artifacts/ || true

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -146,7 +146,7 @@ jobs:
           script: |
             adb root
             mkdir -p android-app/app/build/outputs/test-artifacts
-            android-app/gradlew -p android-app --build-cache --no-daemon -PmanifestEndpoint=https://${{ steps.generate-server-app-name.outputs.heroku_app_name }}.herokuapp.com/api/ installQaDebug installQaDebugAndroidTest
+            android-app/gradlew -p android-app --build-cache --no-daemon -PmanifestEndpoint=${{ steps.start-simple-server.outputs.heroku_app_url }}api/ installQaDebug installQaDebugAndroidTest
             adb shell am instrument -w -e filter org.simple.clinic.benchmark.SelectBenchmarkTests -e benchmark_app_performance false  org.simple.clinic.qa.debug.test/org.simple.clinic.AndroidTestJUnitRunner >android-app/app/build/outputs/test-artifacts/logs.txt 2>android-app/app/build/outputs/test-artifacts/logs.txt
             cat android-app/app/build/outputs/test-artifacts/logs.txt
             adb pull /storage/emulated/0/Android/data/org.simple.clinic.qa.debug/ android-app/app/build/outputs/test-artifacts/ || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Enable Configuration cache
 - Migrate `BloodSugarEntryEffectHandler` to use view effect
 - Remove old overdue appointments view
+- Use heroku generated app url for manifest endpoint in CI
 
 ## 2023-06-12-8756
 


### PR DESCRIPTION
This will fix the failing integration tests on CI