### PR TITLE
Hide overdue download/share actions when there are no overdue patients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Add support for database encryption
 - Add new call result option - `Refused to come back`
+- Hide overdue download/share actions when there are no overdue patients
 
 ## 2023-06-26-8772
 

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
@@ -214,8 +214,6 @@ class OverdueScreen : BaseScreen<
     super.onViewCreated(view, savedInstanceState)
     overdueRecyclerView.adapter = overdueListAdapter
     overdueRecyclerView.layoutManager = LinearLayoutManager(context)
-
-    buttonsFrame.visibleOrGone(isVisible = isOverdueListDownloadAndShareEnabled)
   }
 
   override fun onDestroyView() {

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
@@ -272,6 +272,7 @@ class OverdueScreen : BaseScreen<
         isOverdueSelectAndDownloadEnabled = features.isEnabled(OverdueSelectAndDownload) && country.isoCountryCode == Country.INDIA,
         selectedOverdueAppointments = selectedOverdueAppointments
     ))
+    if (isOverdueListDownloadAndShareEnabled) { buttonsFrame.visibility = View.VISIBLE }
   }
 
   override fun showOverdueCount(count: Int) {

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
@@ -298,6 +298,7 @@ class OverdueScreen : BaseScreen<
 
   override fun showNoOverduePatientsView() {
     viewForEmptyList.visibility = View.VISIBLE
+    if (isOverdueListDownloadAndShareEnabled) { buttonsFrame.visibility = View.GONE }
   }
 
   override fun hideNoOverduePatientsView() {

--- a/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
+++ b/app/src/main/java/org/simple/clinic/home/overdue/OverdueScreen.kt
@@ -53,6 +53,7 @@ import org.simple.clinic.sync.LastSyncedState
 import org.simple.clinic.util.RuntimeNetworkStatus
 import org.simple.clinic.util.UserClock
 import org.simple.clinic.util.UtcClock
+import org.simple.clinic.util.unsafeLazy
 import org.simple.clinic.widgets.ItemAdapter
 import org.simple.clinic.widgets.UiEvent
 import org.simple.clinic.widgets.visibleOrGone
@@ -164,6 +165,10 @@ class OverdueScreen : BaseScreen<
   private val clearSelectedOverdueAppointmentsButton
     get() = binding.clearSelectedOverdueAppointmentsButton
 
+  private val isOverdueListDownloadAndShareEnabled by unsafeLazy {
+    features.isEnabled(OverdueListDownloadAndShare) && country.isoCountryCode == Country.INDIA
+  }
+
   override fun defaultModel() = OverdueModel.create()
 
   override fun bindView(layoutInflater: LayoutInflater, container: ViewGroup?) =
@@ -210,7 +215,6 @@ class OverdueScreen : BaseScreen<
     overdueRecyclerView.adapter = overdueListAdapter
     overdueRecyclerView.layoutManager = LinearLayoutManager(context)
 
-    val isOverdueListDownloadAndShareEnabled = features.isEnabled(OverdueListDownloadAndShare) && country.isoCountryCode == Country.INDIA
     buttonsFrame.visibleOrGone(isVisible = isOverdueListDownloadAndShareEnabled)
   }
 


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/10839/hide-overdue-download-share-actions-when-there-are-no-overdue-patients