### PR TITLE
Remove build status from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-![Build Status](https://github.com/simpledotorg/simple-android/workflows/CI/badge.svg)
-
 # Simple
 
 An Android app for recording blood pressure measurements.


### PR DESCRIPTION
This build status is for CI runs, but we don't run CI runs on push on main branch, so the indicator is showing it for the last finished PR CI run. It doesn't make sense to include that in the README. So, removing it.

PS: Since it doesn't impact project in anyway, haven't update the CHANGELOG