### PR TITLE
Bump Compose BOM to latest alpha versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Add missing SQLCipher proguard rules for R8
 - Show progress indicator when logging out
+- Bump to latest alpha/beta version of Compose libraries
 
 ### Changes
 

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/shareprescription/TeleconsultSharePrescriptionRepository.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/shareprescription/TeleconsultSharePrescriptionRepository.kt
@@ -37,9 +37,9 @@ class TeleconsultSharePrescriptionRepository @Inject constructor(
       getFileOutputStream(fileName)
     }
 
-    imageOutputStream.use { outputStream ->
-      bitmap?.compress(Bitmap.CompressFormat.PNG, 100, imageOutputStream)
-      outputStream?.flush()
+    imageOutputStream?.use { outputStream ->
+      bitmap?.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+      outputStream.flush()
     }
     return fileName
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 buildscript {
   extra.apply {
-    set("compileSdkVersion", 33)
+    set("compileSdkVersion", 34)
     set("minSdkVersion", 21)
-    set("targetSdkVersion", 33)
+    set("targetSdkVersion", 34)
   }
 
   repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ coroutines = "1.6.4"
 
 compose-compiler = "1.4.0"
 
-androidx-compose-bom = "2023.05.01"
+androidx-compose-bom = "2023.07.00-alpha01"
 
 composeThemeAdapter = "0.31.3-beta"
 
@@ -201,7 +201,7 @@ apache-commons-math = "org.apache.commons:commons-math3:3.6.1"
 
 benchmark-gradle-plugin = "androidx.benchmark:benchmark-gradle-plugin:1.1.1"
 
-androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-compose-bom" }
+androidx-compose-bom = { module = "dev.chrisbanes.compose:compose-bom", version.ref = "androidx-compose-bom" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui" }
 androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }


### PR DESCRIPTION
Since Jetpack Compose BOM doesn't support using alpha/beta version BOM, we are switching to using a different maven path for that.

https://app.shortcut.com/simpledotorg/story/10889/add-date-picker-component-to-questionnaire-forms