### PR TITLE
update PROGUARD file to keep material icon class

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -118,3 +118,6 @@
   native <methods>;
   public <init>(...);
 }
+
+## Compose icon with reflection
+-keep class androidx.compose.material.icons.filled.** { *; }


### PR DESCRIPTION
Material Icons were not shown in the dynamic questionnaire form.
**Reason**:

1. We use reflection to generate image vector by name.
2. Because of proguard rules, classes were getting obfuscated.

**Solution**

1. Add proguard rule to not obfuscate class names that extend `androidx.compose.material.icons.filled`