### PR TITLE
Stop clearing view binding reference when a custom view is detached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 ### Internal
 
 - Bump AGP to v8.1.0
+- Stop clearing view binding reference when a custom view is detached
 
 ### Fixes
 
-- Fix icon not showing on questionnaire form screen.
+- Fix icon not showing on questionnaire form screen
 
 ## 2023-08-01-8815
 

--- a/app/src/main/java/org/simple/clinic/contactpatient/views/CallPatientView.kt
+++ b/app/src/main/java/org/simple/clinic/contactpatient/views/CallPatientView.kt
@@ -195,11 +195,6 @@ class CallPatientView(
     secureCallButton.setOnClickListener { secureCallButtonClicked?.invoke() }
   }
 
-  override fun onDetachedFromWindow() {
-    binding = null
-    super.onDetachedFromWindow()
-  }
-
   fun renderPatientDetails(
       patientDetails: PatientDetails,
       dateTimeFormatter: DateTimeFormatter,

--- a/app/src/main/java/org/simple/clinic/contactpatient/views/SetAppointmentReminderView.kt
+++ b/app/src/main/java/org/simple/clinic/contactpatient/views/SetAppointmentReminderView.kt
@@ -105,11 +105,6 @@ class SetAppointmentReminderView(
     nextDateStepper.isEnabled = true
   }
 
-  override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
-    binding = null
-  }
-
   interface Injector {
     fun inject(target: SetAppointmentReminderView)
   }

--- a/app/src/main/java/org/simple/clinic/facilitypicker/FacilityPickerView.kt
+++ b/app/src/main/java/org/simple/clinic/facilitypicker/FacilityPickerView.kt
@@ -134,7 +134,6 @@ class FacilityPickerView(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
-    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/medicalhistory/MedicalHistoryQuestionView.kt
+++ b/app/src/main/java/org/simple/clinic/medicalhistory/MedicalHistoryQuestionView.kt
@@ -83,9 +83,4 @@ class MedicalHistoryQuestionView(
       answerChangeListener.invoke(question, newAnswer)
     }
   }
-
-  override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
-    binding = null
-  }
 }

--- a/app/src/main/java/org/simple/clinic/security/pin/PinEntryCardView.kt
+++ b/app/src/main/java/org/simple/clinic/security/pin/PinEntryCardView.kt
@@ -148,7 +148,6 @@ class PinEntryCardView(
   override fun onDetachedFromWindow() {
     pinEntryLockedCountdown?.cancel()
     delegate.stop()
-    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/assignedfacility/AssignedFacilityView.kt
@@ -95,7 +95,6 @@ class AssignedFacilityView(
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
-    binding = null
     delegate.stop()
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/bloodpressures/view/BloodPressureItemView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/bloodpressures/view/BloodPressureItemView.kt
@@ -94,9 +94,4 @@ class BloodPressureItemView(context: Context, attrs: AttributeSet) : FrameLayout
 
     dateTimeTextView.text = dateTimeFormattedString
   }
-
-  override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
-    binding = null
-  }
 }

--- a/app/src/main/java/org/simple/clinic/summary/bloodpressures/view/BloodPressureSummaryView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/bloodpressures/view/BloodPressureSummaryView.kt
@@ -177,7 +177,6 @@ class BloodPressureSummaryView(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
-    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/bloodsugar/view/BloodSugarItemView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/bloodsugar/view/BloodSugarItemView.kt
@@ -116,9 +116,4 @@ class BloodSugarItemView(
       }
     }
   }
-
-  override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
-    binding = null
-  }
 }

--- a/app/src/main/java/org/simple/clinic/summary/bloodsugar/view/BloodSugarSummaryView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/bloodsugar/view/BloodSugarSummaryView.kt
@@ -192,7 +192,6 @@ class BloodSugarSummaryView(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
-    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/medicalhistory/MedicalHistorySummaryView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/medicalhistory/MedicalHistorySummaryView.kt
@@ -120,7 +120,6 @@ class MedicalHistorySummaryView(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
-    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/nextappointment/NextAppointmentCardView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/nextappointment/NextAppointmentCardView.kt
@@ -129,7 +129,6 @@ class NextAppointmentCardView(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
-    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/summary/prescribeddrugs/DrugSummaryItemView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/prescribeddrugs/DrugSummaryItemView.kt
@@ -37,9 +37,4 @@ class DrugSummaryItemView constructor(
     prescribedDrugName.text = drugWithDosageAndFrequency
     prescribedDrugDate.text = drugDate
   }
-
-  override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
-    binding = null
-  }
 }

--- a/app/src/main/java/org/simple/clinic/summary/prescribeddrugs/DrugSummaryView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/prescribeddrugs/DrugSummaryView.kt
@@ -117,7 +117,6 @@ class DrugSummaryView(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
-    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/prescription/doctorinfo/TeleconsultDoctorInfoView.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/prescription/doctorinfo/TeleconsultDoctorInfoView.kt
@@ -100,7 +100,6 @@ class TeleconsultDoctorInfoView(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
-    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/prescription/medicines/TeleconsultMedicinesView.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/prescription/medicines/TeleconsultMedicinesView.kt
@@ -138,7 +138,6 @@ class TeleconsultMedicinesView(
 
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
-    binding = null
     delegate.stop()
   }
 

--- a/app/src/main/java/org/simple/clinic/teleconsultlog/prescription/patientinfo/TeleconsultPatientInfoView.kt
+++ b/app/src/main/java/org/simple/clinic/teleconsultlog/prescription/patientinfo/TeleconsultPatientInfoView.kt
@@ -81,7 +81,6 @@ class TeleconsultPatientInfoView constructor(
 
   override fun onDetachedFromWindow() {
     delegate.stop()
-    binding = null
     super.onDetachedFromWindow()
   }
 

--- a/app/src/main/java/org/simple/clinic/widgets/ChipInputAutoCompleteTextView.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/ChipInputAutoCompleteTextView.kt
@@ -66,7 +66,6 @@ class ChipInputAutoCompleteTextView(
   }
 
   override fun onDetachedFromWindow() {
-    binding = null
     disposable.clear()
     super.onDetachedFromWindow()
   }

--- a/app/src/main/java/org/simple/clinic/widgets/PatientStatusView.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/PatientStatusView.kt
@@ -36,9 +36,4 @@ class PatientStatusView(context: Context, attrs: AttributeSet) : MaterialCardVie
       TextViewCompat.setTextAppearance(statusTextView, statusTextAppearance)
     }
   }
-
-  override fun onDetachedFromWindow() {
-    binding = null
-    super.onDetachedFromWindow()
-  }
 }


### PR DESCRIPTION
We initially did this because in documentation it was done for Fragments, but fragments outlive there views, so we were clearing it. Since that's not the case with views, it's not necessary.

In fact this can cause issues in scenarios where a view is detached because it's being recycled or in background, and once the view is attached again the binding is null and causes crashes
