### PR TITLE
Increase minimum required memory for encryption to 5.5GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Add missing SQLCipher proguard rules for R8
 - Add minimum memory checker to run database encryption
+- Bump AGP to v8.1.1
+- Increase minimum required memory for encryption to 5.5GB
 
 ### Changes
 

--- a/app/src/main/java/org/simple/clinic/util/MinimumMemoryChecker.kt
+++ b/app/src/main/java/org/simple/clinic/util/MinimumMemoryChecker.kt
@@ -10,7 +10,7 @@ interface MinimumMemoryChecker {
 class RealMinimumMemoryChecker(context: Context) : MinimumMemoryChecker {
 
   companion object {
-    private const val MIN_REQUIRED_MEMORY = 3.5 // GB
+    private const val MIN_REQUIRED_MEMORY = 5.5 // GB
   }
 
   private val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager


### PR DESCRIPTION
Based on conversation with Jon and Daniel, we increased the minimum required memory for encryption to 5.5 GB (essentially devices that are advertised as having 6 GB or more memory)