### PR TITLE
Report last key name when removing last key fails in `History`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Migrate Dagger from KAPT to KSP
 - Bump AndroidX Preferences to v1.2.1
 - Setup fragment result listener in `onCreate` instead of `onViewCreated`
+- Report last key name when removing last key fails in `History`
 
 ### Changes
 

--- a/app/src/main/java/org/simple/clinic/navigation/v2/History.kt
+++ b/app/src/main/java/org/simple/clinic/navigation/v2/History.kt
@@ -21,7 +21,10 @@ data class History(val requests: List<NavRequest>) : Parcelable {
   }
 
   fun removeLast(): History {
-    require(requests.size > 1) { "Cannot remove last when there is only one key left" }
+    require(requests.size > 1) {
+      val lastKey = requests.lastOrNull()?.key
+      "Cannot remove last key ($lastKey) when there is only one key left"
+    }
 
     return copy(requests = requests.dropLast(1))
   }


### PR DESCRIPTION
We are getting quite a few errors when trying to remove the last key. Adding the key name to help debug this issue further.