### PR TITLE
heroku setup: pass through seed exit status

### DIFF
--- a/.github/scripts/setup_heroku_instance.sh
+++ b/.github/scripts/setup_heroku_instance.sh
@@ -32,7 +32,7 @@ resultOfServerPush=$?
 resultOfSeedDataSetup=0
 if [ ${serverAppAlreadyExists} = false ]; then
   echo "Setting up initial seed data"
-  (cd $serverAppDirectory && heroku run rails db:structure:load:with_data db:seed --app=$herokuAppName)
+  (cd $serverAppDirectory && heroku run --exit-code rails db:structure:load:with_data db:seed --app=$herokuAppName)
   resultOfSeedDataSetup=$?
 fi
 


### PR DESCRIPTION
We fix a bug in the setup script that always causes the exit code of the rails db setup and seeding to be successful because it used the exit code of `heroku run` itself. We add a flag that will instead pass through the exit code of the underlying run, in this case, the `rails` command.