### PR TITLE
Revert AndroidX Paging to v3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Bump Lottie to v6.4.1
 - Add `eligibleForReassignment` to `PatientPayload`
 - Bump AndroidX ViewModel to v2.8.1
+- Revert AndroidX Paging to v3.2.1
 
 ### Features
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,9 @@
 
 androidx-cameraView = "1.3.3"
 androidx-camera = "1.3.3"
-androidx-paging = "3.3.0"
+# check is following issue is resolve before updating to v3.3.0 or above
+# https://issuetracker.google.com/issues/343124454
+androidx-paging = "3.2.1"
 androidx-room = "2.6.1"
 androidx-work = "2.9.0"
 androidx-security-crypto = "1.1.0-alpha06"


### PR DESCRIPTION
Paging 3.3.0 release is causing occasional crashes in the app. Probably due to KMP migration, so reverting this update, so that we can resolve those issue for the time being.

Tracking issue here: https://issuetracker.google.com/issues/343124454
