### PR TITLE
Fix app crashing when viewing BP history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@
 - Bump AndroidX Paging to v3.3.1
 - Bump Lottie to v6.5.0
 
+### Fixes
+
+- Fix app crashing when viewing BP history 
+
 ## 2024-06-27-9140
 
 ### Internal

--- a/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
+++ b/app/src/main/java/org/simple/clinic/bp/history/BloodPressureHistoryScreen.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import androidx.paging.PagingData
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.spotify.mobius.functions.Consumer
@@ -110,7 +111,10 @@ class BloodPressureHistoryScreen : BaseScreen<
   override fun createUpdate() = BloodPressureHistoryScreenUpdate()
 
   override fun createEffectHandler(viewEffectsConsumer: Consumer<BloodPressureHistoryViewEffect>) = effectHandler
-      .create(viewEffectsConsumer = viewEffectsConsumer)
+      .create(
+          viewEffectsConsumer = viewEffectsConsumer,
+          pagingCacheScope = { lifecycleScope }
+      )
       .build()
 
   override fun uiRenderer() = BloodPressureHistoryScreenUiRenderer(this)

--- a/app/src/test/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/bp/history/BloodPressureHistoryScreenEffectHandlerTest.kt
@@ -2,6 +2,7 @@ package org.simple.clinic.bp.history
 
 import androidx.paging.PagingData
 import io.reactivex.Observable
+import kotlinx.coroutines.test.TestScope
 import org.junit.After
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -36,6 +37,7 @@ class BloodPressureHistoryScreenEffectHandlerTest {
   private val uiActions = mock<BloodPressureHistoryScreenUiActions>()
   private val viewEffectHandler = BloodPressureHistoryViewEffectHandler(uiActions)
   private val pagerFactory = mock<PagerFactory>()
+  private val pagingCacheScope = TestScope()
   private val effectHandler = BloodPressureHistoryScreenEffectHandler(
       bloodPressureRepository,
       patientRepository,
@@ -46,7 +48,8 @@ class BloodPressureHistoryScreenEffectHandlerTest {
           bpEditableDuration = Duration.ofMinutes(10),
           numberOfMeasurementsForTeleconsultation = 0,
       ),
-      viewEffectHandler::handle
+      viewEffectsConsumer = viewEffectHandler::handle,
+      pagingCacheScope = { pagingCacheScope }
   ).build()
   private val testCase = EffectHandlerTestCase(effectHandler)
 
@@ -148,7 +151,7 @@ class BloodPressureHistoryScreenEffectHandlerTest {
         pageSize = eq(25),
         enablePlaceholders = eq(false),
         initialKey = eq(null),
-        cacheScope = eq(null),
+        cacheScope = eq(pagingCacheScope),
     )) doReturn Observable.just(bloodPressures)
 
     // when


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/13418/app-crashing-when-displaying-blood-pressure-history-list