### PR TITLE
Opt-out of edge to edge enforcement on Android 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Bump Sentry Android to v8.0.0
 - Bump Gradle to v8.12.1
 - Bump Sentry Gradle plugin to v5
+- Opt out of edge-to-edge enforcement in Android 15
 
 ### Fixes
 

--- a/common-ui/src/main/res/values-v35/theme.xml
+++ b/common-ui/src/main/res/values-v35/theme.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <style name="Base.Theme.Simple" parent="Base.Theme.Simple.Global">
+    <!-- Platform -->
+    <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+  </style>
+</resources>

--- a/common-ui/src/main/res/values/theme.xml
+++ b/common-ui/src/main/res/values/theme.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-  <style name="Base.Theme.Simple" parent="Theme.MaterialComponents.Light.NoActionBar">
+  <style name="Base.Theme.Simple.Global" parent="Theme.MaterialComponents.Light.NoActionBar">
     <!-- Dialog Themes -->
     <item name="alertDialogTheme">@style/ThemeOverlay.Simple.Dialog.Alert</item>
     <item name="android:datePickerDialogTheme">@style/ThemeOverlay.Simple.Dialog</item>
@@ -52,6 +52,8 @@
     <item name="shapeAppearanceMediumComponent">@style/ShapeAppearance.Simple.MediumComponent</item>
     <item name="shapeAppearanceLargeComponent">@style/ShapeAppearance.Simple.LargeComponent</item>
   </style>
+
+  <style name="Base.Theme.Simple" parent="Base.Theme.Simple.Global" />
 
   <style name="Theme.Simple" parent="Base.Theme.Simple">
     <item name="colorPrimary">@color/simple_light_blue_500</item>


### PR DESCRIPTION
**Story:** https://app.shortcut.com/simpledotorg/story/14491/handle-edge-to-edge-enforcement-in-android-15

## Description

Stop-gap until we handle window insets properly in all screens and components
