### PR TITLE
Display only languages supported by the selected country in the settings screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Auto-select country when only one option is available
 
+### Changes
+
+- Display only languages supported by the selected country in the settings screen
+
 ## 2025.04.07
 
 ### Internal

--- a/app/src/main/java/org/simple/clinic/settings/Language.kt
+++ b/app/src/main/java/org/simple/clinic/settings/Language.kt
@@ -2,6 +2,7 @@ package org.simple.clinic.settings
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import org.simple.clinic.appconfig.Country
 import java.util.Locale
 
 sealed class Language : Parcelable
@@ -13,6 +14,15 @@ data class ProvidedLanguage(val displayName: String, val languageCode: String) :
     val languageTag = locale.toLanguageTag()
 
     return languageCode.equals(languageTag, ignoreCase = true)
+  }
+
+  fun isApplicableToCountry(country: Country): Boolean {
+    val parts = languageCode.split("-")
+    return when (parts.size) {
+      1 -> true
+      2 -> languageCode.contains(country.isoCountryCode, ignoreCase = true)
+      else -> true
+    }
   }
 
   fun toLocale(): Locale {

--- a/app/src/main/java/org/simple/clinic/settings/Language.kt
+++ b/app/src/main/java/org/simple/clinic/settings/Language.kt
@@ -19,7 +19,6 @@ data class ProvidedLanguage(val displayName: String, val languageCode: String) :
   fun isApplicableToCountry(country: Country): Boolean {
     val parts = languageCode.split("-")
     return when (parts.size) {
-      1 -> true
       2 -> languageCode.contains(country.isoCountryCode, ignoreCase = true)
       else -> true
     }

--- a/app/src/main/java/org/simple/clinic/settings/PreferencesSettingsRepository.kt
+++ b/app/src/main/java/org/simple/clinic/settings/PreferencesSettingsRepository.kt
@@ -4,6 +4,7 @@ import com.f2prateek.rx.preferences2.Preference
 import io.reactivex.Completable
 import io.reactivex.Maybe
 import io.reactivex.Single
+import org.simple.clinic.appconfig.Country
 import org.simple.clinic.util.filterAndUnwrapJust
 import org.simple.clinic.util.ofType
 import java.util.Locale
@@ -11,7 +12,8 @@ import java.util.Optional
 
 class PreferencesSettingsRepository(
     private val userSelectedLocalePreference: Preference<Optional<Locale>>,
-    private val supportedLanguages: List<Language>
+    private val supportedLanguages: List<Language>,
+    private val country: Country,
 ) : SettingsRepository {
 
   override fun getCurrentLanguage(): Single<Language> {
@@ -30,7 +32,11 @@ class PreferencesSettingsRepository(
   }
 
   override fun getSupportedLanguages(): Single<List<Language>> {
-    return Single.just(supportedLanguages)
+    val filteredLanguages = supportedLanguages
+        .filterIsInstance<ProvidedLanguage>()
+        .filter { language -> language.isApplicableToCountry(country) }
+
+    return Single.just(filteredLanguages)
   }
 
   override fun setCurrentLanguage(newLanguage: Language): Completable {

--- a/app/src/main/java/org/simple/clinic/settings/SettingsModule.kt
+++ b/app/src/main/java/org/simple/clinic/settings/SettingsModule.kt
@@ -4,6 +4,7 @@ import com.f2prateek.rx.preferences2.Preference
 import com.f2prateek.rx.preferences2.RxSharedPreferences
 import dagger.Module
 import dagger.Provides
+import org.simple.clinic.appconfig.Country
 import org.simple.clinic.util.preference.LocalePreferenceConverter
 import org.simple.clinic.util.preference.getOptional
 import java.util.Locale
@@ -21,14 +22,15 @@ class SettingsModule {
 
   @Provides
   fun provideSettingsRepository(
-      @Named("preference_user_selected_locale") userSelectedLocalePreference: Preference<Optional<Locale>>
+      @Named("preference_user_selected_locale") userSelectedLocalePreference: Preference<Optional<Locale>>,
+      country: Country,
   ): SettingsRepository {
     val supportedLanguages = listOf<Language>(
         ProvidedLanguage(displayName = "Afan Oromo", languageCode = "om-ET"),
         ProvidedLanguage(displayName = "አማርኛ", languageCode = "am-ET"),
         ProvidedLanguage(displayName = "বাংলা", languageCode = "bn-BD"),
         ProvidedLanguage(displayName = "বাঙালি", languageCode = "bn-IN"),
-        ProvidedLanguage(displayName = "English", languageCode = "en-IN"),
+        ProvidedLanguage(displayName = "English", languageCode = "en"),
         ProvidedLanguage(displayName = "Español", languageCode = "es"),
         ProvidedLanguage(displayName = "हिंदी", languageCode = "hi-IN"),
         ProvidedLanguage(displayName = "ಕನ್ನಡ", languageCode = "kn-IN"),
@@ -45,7 +47,8 @@ class SettingsModule {
 
     return PreferencesSettingsRepository(
         userSelectedLocalePreference = userSelectedLocalePreference,
-        supportedLanguages = supportedLanguages
+        supportedLanguages = supportedLanguages,
+        country = country
     )
   }
 }

--- a/app/src/test/java/org/simple/clinic/settings/PreferencesSettingsRepositoryTest.kt
+++ b/app/src/test/java/org/simple/clinic/settings/PreferencesSettingsRepositoryTest.kt
@@ -1,11 +1,13 @@
 package org.simple.clinic.settings
 
 import com.f2prateek.rx.preferences2.Preference
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.junit.Test
+import org.simple.clinic.TestData
 import java.util.Locale
 import java.util.Optional
 
@@ -13,10 +15,14 @@ class PreferencesSettingsRepositoryTest {
 
   private val preference = mock<Preference<Optional<Locale>>>()
 
-  private val english = ProvidedLanguage(displayName = "English", languageCode = "en-IN")
+  private val english = ProvidedLanguage(displayName = "English", languageCode = "en")
   private val kannada = ProvidedLanguage(displayName = "ಕನ್ನಡ", languageCode = "kn-IN")
+  private val sidama = ProvidedLanguage(displayName = "Sidama", languageCode = "sid-ET")
+  private val country = TestData.country(
+      isoCountryCode = "IN",
+  )
 
-  private val repository = PreferencesSettingsRepository(preference, listOf(english, kannada))
+  private val repository = PreferencesSettingsRepository(preference, listOf(english, kannada, sidama), country)
 
   @Test
   fun `if user selected locale is not set, fetching the current language should return the default language`() {
@@ -66,5 +72,14 @@ class PreferencesSettingsRepositoryTest {
 
     // then
     verify(preference).set(Optional.of(locale))
+  }
+
+  @Test
+  fun `getting supported languages should only fetch languages applicable for the selected country or languages applicable to all countries`() {
+    // when
+    val supportedLanguages = repository.getSupportedLanguages().blockingGet()
+
+    // then
+    assertThat(supportedLanguages).containsExactly(english, kannada)
   }
 }


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/15301/display-only-languages-supported-by-the-selected-country-in-the-settings-screen