### PR TITLE
Show spanish language option in non-production builds only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Bump Gson to v2.13.0
 - Skip Sentry config during app startup in the debug mode
+- Show spanish language option in non-production builds only
 
 ### Features
 

--- a/app/src/main/java/org/simple/clinic/settings/SettingsModule.kt
+++ b/app/src/main/java/org/simple/clinic/settings/SettingsModule.kt
@@ -4,6 +4,7 @@ import com.f2prateek.rx.preferences2.Preference
 import com.f2prateek.rx.preferences2.RxSharedPreferences
 import dagger.Module
 import dagger.Provides
+import org.simple.clinic.BuildConfig
 import org.simple.clinic.appconfig.Country
 import org.simple.clinic.util.preference.LocalePreferenceConverter
 import org.simple.clinic.util.preference.getOptional
@@ -25,13 +26,18 @@ class SettingsModule {
       @Named("preference_user_selected_locale") userSelectedLocalePreference: Preference<Optional<Locale>>,
       country: Country,
   ): SettingsRepository {
+    @Suppress("KotlinConstantConditions")
+    val optionalLanguages = if (BuildConfig.FLAVOR != "production") {
+      listOf(ProvidedLanguage(displayName = "Español", languageCode = "es"))
+    } else {
+      emptyList()
+    }
     val supportedLanguages = listOf<Language>(
         ProvidedLanguage(displayName = "Afan Oromo", languageCode = "om-ET"),
         ProvidedLanguage(displayName = "አማርኛ", languageCode = "am-ET"),
         ProvidedLanguage(displayName = "বাংলা", languageCode = "bn-BD"),
         ProvidedLanguage(displayName = "বাঙালি", languageCode = "bn-IN"),
         ProvidedLanguage(displayName = "English", languageCode = "en"),
-        ProvidedLanguage(displayName = "Español", languageCode = "es"),
         ProvidedLanguage(displayName = "हिंदी", languageCode = "hi-IN"),
         ProvidedLanguage(displayName = "ಕನ್ನಡ", languageCode = "kn-IN"),
         ProvidedLanguage(displayName = "मराठी", languageCode = "mr-IN"),
@@ -43,7 +49,7 @@ class SettingsModule {
         ProvidedLanguage(displayName = "ትግርኛ", languageCode = "ti-ET"),
         ProvidedLanguage(displayName = "தமிழ் (இந்தியா)", languageCode = "ta-IN"),
         ProvidedLanguage(displayName = "தமிழ் (இலங்கை)", languageCode = "ta-LK"),
-    )
+    ) + optionalLanguages
 
     return PreferencesSettingsRepository(
         userSelectedLocalePreference = userSelectedLocalePreference,


### PR DESCRIPTION
**Story:** https://app.shortcut.com/simpledotorg/story/15317/show-spanish-language-option-in-non-production-builds
