### PR TITLE
 Fix crash when displaying large statin risk percentage text 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@
 
 - Display only languages supported by the selected country in the settings screen
 
+### Fixes
+
+- Fix crash when displaying large statin risk percentage text
+
 ## 2025.04.07
 
 ### Internal

--- a/app/src/main/java/org/simple/clinic/summary/compose/StatinNudgeView.kt
+++ b/app/src/main/java/org/simple/clinic/summary/compose/StatinNudgeView.kt
@@ -157,10 +157,13 @@ fun RiskText(
   val totalTextWidth = textWidth + with(LocalDensity.current) { 8.dp.toPx() * 2 }
 
   val calculatedOffsetX = midpoint - (totalTextWidth / 2)
-  val clampedOffsetX = calculatedOffsetX.coerceIn(
-      0f,
-      parentWidth - totalTextWidth - parentPadding
-  )
+  val maxOffsetX = parentWidth - totalTextWidth - parentPadding
+  val clampedOffsetX = if (maxOffsetX >= 0f) {
+    calculatedOffsetX.coerceIn(0f, maxOffsetX)
+  } else {
+    0f
+  }
+
 
   Text(
       modifier = Modifier


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/15517/fix-crash-when-displaying-large-statin-risk-percentage-text