### PR TITLE
Handle nullable inputs when removing last chip in the `ChipInputAutoCompleteTextView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Handle window insets when displaying app content in edge-to-edge
 - Enable edge-to-edge support on all versions of Android
+- Handle nullable inputs when removing last chip in the `ChipInputAutoCompleteTextView`
 
 ## 2025.05.20
 

--- a/app/src/main/java/org/simple/clinic/widgets/ChipInputAutoCompleteTextView.kt
+++ b/app/src/main/java/org/simple/clinic/widgets/ChipInputAutoCompleteTextView.kt
@@ -164,7 +164,7 @@ class ChipInputAutoCompleteTextView(
       }
 
   private fun removeLastChip() {
-    val lastInput = inputs.last()
+    val lastInput = inputs.lastOrNull() ?: return
     val lastChip = rootView
         .children
         .filterIsInstance<Chip>()


### PR DESCRIPTION
**Story:** https://app.shortcut.com/simpledotorg/story/15703/handle-nullable-inputs-when-removing-last-chip-in-the-chipinputautocompletetextview
