### PR TITLE
Replace `android-database-sqlcipher` library with `sqlcipher-android`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Migrate patient status view to Jetpack Compose
 - Migrate clinical decision support alert to Jetpack Compose
 - Bump sqlite-android version to 3.49.0
+- Replace `android-database-sqlcipher` library with `sqlcipher-android`
 
 ## 2025.05.20
 

--- a/app/src/main/java/org/simple/clinic/storage/DatabaseEncryptor.kt
+++ b/app/src/main/java/org/simple/clinic/storage/DatabaseEncryptor.kt
@@ -6,8 +6,8 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import io.reactivex.Observable
 import io.reactivex.subjects.BehaviorSubject
-import net.sqlcipher.database.SQLiteDatabase
-import net.sqlcipher.database.SQLiteStatement
+import net.zetetic.database.sqlcipher.SQLiteDatabase
+import net.zetetic.database.sqlcipher.SQLiteStatement
 import org.simple.clinic.di.AppScope
 import org.simple.clinic.storage.DatabaseEncryptor.State.ENCRYPTED
 import org.simple.clinic.storage.DatabaseEncryptor.State.SKIPPED
@@ -45,7 +45,7 @@ class DatabaseEncryptor @Inject constructor(
       .distinctUntilChanged()
 
   init {
-    SQLiteDatabase.loadLibs(appContext)
+    System.loadLibrary("sqlcipher");
   }
 
   fun execute(databaseName: String) {
@@ -79,7 +79,7 @@ class DatabaseEncryptor @Inject constructor(
     val databasePath = appContext.getDatabasePath(databaseName)
     if (databasePath.exists()) {
       val newFile = File.createTempFile("simple_database_encryption", "tmp", appContext.cacheDir)
-      var db = SQLiteDatabase.openDatabase(databasePath.absolutePath, "", null, SQLiteDatabase.OPEN_READWRITE)
+      var db = SQLiteDatabase.openDatabase(databasePath.absolutePath, null, SQLiteDatabase.OPEN_READWRITE)
       val version = db.version
 
       db.close()
@@ -123,8 +123,7 @@ class DatabaseEncryptor @Inject constructor(
     if (databasePath.exists()) {
       var db: SQLiteDatabase? = null
       return try {
-        db = SQLiteDatabase.openDatabase(databasePath.absolutePath, "",
-            null, SQLiteDatabase.OPEN_READONLY)
+        db = SQLiteDatabase.openDatabase(databasePath.absolutePath, null, SQLiteDatabase.OPEN_READONLY)
         db.version
         State.UNENCRYPTED
       } catch (e: Exception) {

--- a/app/src/main/java/org/simple/clinic/storage/StorageModule.kt
+++ b/app/src/main/java/org/simple/clinic/storage/StorageModule.kt
@@ -8,7 +8,7 @@ import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
 import io.requery.android.database.sqlite.SQLiteGlobal
-import net.sqlcipher.database.SupportFactory
+import net.zetetic.database.sqlcipher.SupportOpenHelperFactory
 import org.simple.clinic.AppDatabase
 import org.simple.clinic.DATABASE_NAME
 import org.simple.clinic.di.AppScope
@@ -51,7 +51,7 @@ class StorageModule {
 
     val helperFactory = if (minimumMemoryChecker.hasMinimumRequiredMemory()) {
       val passphrase = databaseEncryptor.passphrase
-      SupportFactory(passphrase)
+      SupportOpenHelperFactory(passphrase)
     } else {
       factory
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ composeThemeAdapter = "0.36.0"
 
 ksp = "2.1.20-1.0.31"
 
-sqlCipher = "4.5.4"
+sqlCipher = "4.9.0"
 
 [libraries]
 android-desugaring = "com.android.tools:desugar_jdk_libs:2.1.5"
@@ -220,7 +220,7 @@ androidx-compose-livedata = { module = "androidx.compose.runtime:runtime-livedat
 androidx-compose-test-junit = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-compose-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 
-sqlCipher = { module = "net.zetetic:android-database-sqlcipher", version.ref = "sqlCipher" }
+sqlCipher = { module = "net.zetetic:sqlcipher-android", version.ref = "sqlCipher" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
https://app.shortcut.com/simpledotorg/story/16100/migrate-deprecated-sqlcipher-library?team_id=1&iteration_ids=15786&iteration_ids=16015