### PR TITLE
Remove android.uniquePackageNames compatibility flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bump Sentry Android to v6.17.0
 - Remove `android.enableAppCompileTimeRClass` compatibility flag
 - Bump KSP to v2.3.11
+- Remove `android.uniquePackageNames` compatibility flag
 
 ## 2026.08.03
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,6 +49,5 @@ maestroTests=false
 org.gradle.unsafe.configuration-cache=true
 # AGP 9 compatibility flags (temporary)
 # Remove gradually before AGP 10
-android.uniquePackageNames=false
 android.r8.optimizedResourceShrinking=false
 


### PR DESCRIPTION
## Summary

This PR removes the temporary `android.uniquePackageNames` compatibility flag as part of the AGP 10 migration.

## Jira

**Ticket:** SIMPLEMOB-44
https://rtsl.atlassian.net/browse/SIMPLEMOB-45

## Changes

* Removed `android.uniquePackageNames=false` from `gradle.properties`.

## Validation

* Verified the project builds successfully by running:

  ```bash
  ./gradlew assembleQaDebug
  ```
* Confirmed the project builds successfully without the `android.uniquePackageNames` compatibility flag.
