### PR TITLE
Remove android.r8.optimizedResourceShrinking compatibility flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Remove `android.enableAppCompileTimeRClass` compatibility flag
 - Bump KSP to v2.3.11
 - Remove `android.uniquePackageNames` compatibility flag
+- Remove `android.r8.optimizedResourceShrinking` compatibility flag
 
 ## 2026.08.03
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,5 +49,4 @@ maestroTests=false
 org.gradle.unsafe.configuration-cache=true
 # AGP 9 compatibility flags (temporary)
 # Remove gradually before AGP 10
-android.r8.optimizedResourceShrinking=false
 


### PR DESCRIPTION
## Summary

This PR removes the temporary `android.r8.optimizedResourceShrinking` compatibility flag as part of the AGP 10 migration.

## Jira

**Ticket:** SIMPLEMOB-44
https://rtsl.atlassian.net/browse/SIMPLEMOB-46

## Changes

* Removed `android.r8.optimizedResourceShrinking=false` from `gradle.properties`.

## Validation

* Verified the project builds successfully by running:

  ```bash
  ./gradlew assembleQaDebug
  ```
* Verified the project builds successfully for the production release using the optimized resource shrinker (with release signing temporarily bypassed for local validation).

## Outcome

The project builds successfully without relying on the temporary `android.r8.optimizedResourceShrinking` compatibility flag.
