### PR TITLE
Remove AGP compatibility flags for non-final R IDs and Kotlin test fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Remove `android.uniquePackageNames` compatibility flag
 - Remove `android.r8.optimizedResourceShrinking` compatibility flag
 - Remove `android.nonFinalResIds=false` compatibility flag
+- Remove `android.experimental.enableTestFixturesKotlinSupport=true` compatibility flag
 
 ## 2026.08.03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bump KSP to v2.3.11
 - Remove `android.uniquePackageNames` compatibility flag
 - Remove `android.r8.optimizedResourceShrinking` compatibility flag
+- Remove `android.nonFinalResIds=false` compatibility flag
 
 ## 2026.08.03
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,6 @@ defaultProguardFile=proguard-android-optimize.txt
 android.useAndroidX=true
 android.enableJetifier=true
 android.nonTransitiveRClass=false
-android.nonFinalResIds=false
 android.suppressUnsupportedCompileSdk=34
 android.experimental.enableTestFixturesKotlinSupport=true
 # Manifest URL endpoint
@@ -47,6 +46,4 @@ disableScreenshot=false
 allowRootedDevice=true
 maestroTests=false
 org.gradle.unsafe.configuration-cache=true
-# AGP 9 compatibility flags (temporary)
-# Remove gradually before AGP 10
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.nonTransitiveRClass=false
 android.suppressUnsupportedCompileSdk=34
-android.experimental.enableTestFixturesKotlinSupport=true
 # Manifest URL endpoint
 # These are currently the same as the API endpoints declared earlier. Those will be removed later
 # once the country selection feature is complete.
@@ -41,7 +40,7 @@ sentryOrg=do_not_change_here
 sentryProject=do_not_change_here
 sentryAuthToken=do_not_change_here
 sentryUploadProguard=true
-# App behaviour
+# App behavior
 disableScreenshot=false
 allowRootedDevice=true
 maestroTests=false


### PR DESCRIPTION
## Summary

This PR removes two deprecated/experimental Android Gradle Plugin compatibility flags as part of the AGP 10 migration.

## Jira

**Ticket:** SIMPLEMOB-44
https://rtsl.atlassian.net/browse/SIMPLEMOB-47

## Changes

* Removed `android.nonFinalResIds=false` from `gradle.properties`.
* Removed `android.experimental.enableTestFixturesKotlinSupport=true` from `gradle.properties`.

## Validation

* Verified the application builds successfully with:

  ```bash
  ./gradlew assembleQaDebug
  ```
* Verified Kotlin test fixtures compile successfully without the experimental flag:

  ```bash
  ./gradlew :app:compileQaDebugTestFixturesKotlin
  ```
* Verified KSP processing for Kotlin test fixtures succeeds without the experimental flag:

  ```bash
  ./gradlew :app:kspQaDebugTestFixturesKotlin
  ```

## Outcome

The project no longer relies on the deprecated `android.nonFinalResIds` compatibility flag or the experimental Kotlin test fixtures support flag, bringing the project closer to AGP 10 compatibility.
