### PR TITLE
Migrate project property delegates to explicit property access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Bump Lint to v32.3.2
 - Bump Gradle to v9.7.1
 - Update GH Actions `setup-jdk` to v6
+- Replaced deprecated Gradle Kotlin DSL by project property delegates with explicit project.property(...) access to improve Gradle 10 compatibility.
 
 ## 2026.08.31
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,10 +16,10 @@ plugins {
 }
 
 sentry {
-  val sentryOrg: String by project
-  val sentryProject: String by project
-  val sentryAuthToken: String by project
-  val sentryUploadProguard: String by project
+  val sentryOrg: String = project.property("sentryOrg") as String
+  val sentryProject: String = project.property("sentryProject") as String
+  val sentryAuthToken: String = project.property("sentryAuthToken") as String
+  val sentryUploadProguard: String = project.property("sentryUploadProguard") as String
 
   org = sentryOrg
   projectName = sentryProject
@@ -39,10 +39,10 @@ sentry {
 android {
   namespace = "org.simple.clinic"
 
-  val androidNdkVersion: String by project
-  val compileSdkVersion: Int by rootProject.extra
-  val minSdkVersion: Int by rootProject.extra
-  val targetSdkVersion: Int by rootProject.extra
+  val androidNdkVersion: String = project.property("androidNdkVersion") as String
+  val compileSdkVersion: Int = rootProject.extra["compileSdkVersion"] as Int
+  val minSdkVersion: Int = rootProject.extra["minSdkVersion"] as Int
+  val targetSdkVersion: Int = rootProject.extra["targetSdkVersion"] as Int
 
   compileSdk = compileSdkVersion
   // Needed to switch NDK versions on the CI server since they have different
@@ -63,8 +63,8 @@ android {
     minSdk = minSdkVersion
     targetSdk = targetSdkVersion
 
-    val versionCode = (project.properties["VERSION_CODE"] as? String)?.toInt() ?: 1
-    val versionName = (project.properties["VERSION_NAME"] as? String) ?: "0.1"
+    val versionCode = (project.findProperty("VERSION_CODE") as? String)?.toInt() ?: 1
+    val versionName = (project.findProperty("VERSION_NAME") as? String) ?: "0.1"
 
     this.versionCode = versionCode
     this.versionName = versionName
@@ -73,7 +73,7 @@ android {
 
     testInstrumentationRunner = "org.simple.clinic.AndroidTestJUnitRunner"
 
-    val defaultProguardFile: String by project
+    val defaultProguardFile: String = project.property("defaultProguardFile") as String
     proguardFiles(
         getDefaultProguardFile(defaultProguardFile),
         "proguard-rules.pro"
@@ -81,11 +81,11 @@ android {
 
     vectorDrawables.useSupportLibrary = true
 
-    val sentryDsn: String by project
-    val sentryEnvironment: String by project
-    val manifestEndpoint: String by project
-    val disableScreenshot: String by project
-    val allowRootedDevice: String by project
+    val sentryDsn: String = project.property("sentryDsn") as String
+    val sentryEnvironment: String = project.property("sentryEnvironment") as String
+    val manifestEndpoint: String = project.property("manifestEndpoint") as String
+    val disableScreenshot: String = project.property("disableScreenshot") as String
+    val allowRootedDevice: String = project.property("allowRootedDevice") as String
 
     buildConfigField("String", "SENTRY_DSN", "\"$sentryDsn\"")
     buildConfigField("String", "SENTRY_ENVIRONMENT", "\"$sentryEnvironment\"")
@@ -103,9 +103,9 @@ android {
   signingConfigs {
     create("release") {
       storeFile = file("$rootDir/release/simple.store")
-      storePassword = "${project.properties["KEYSTORE_PASSWORD"]}"
-      keyAlias = "${project.properties["KEY_ALIAS"]}"
-      keyPassword = "${project.properties["KEY_PASSWORD"]}"
+      storePassword = "${project.findProperty("KEYSTORE_PASSWORD")}"
+      keyAlias = "${project.findProperty("KEY_ALIAS")}"
+      keyPassword = "${project.findProperty("KEY_PASSWORD")}"
     }
   }
 
@@ -115,8 +115,8 @@ android {
       isMinifyEnabled = false
     }
 
-    val runProguard: String by project
-    val maestroTests: String by project
+    val runProguard: String = project.property("runProguard") as String
+    val maestroTests: String = project.property("maestroTests") as String
 
     getByName("release") {
       isDebuggable = false

--- a/common-ui/build.gradle.kts
+++ b/common-ui/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 }
 
 android {
-  val compileSdkVersion: Int by rootProject.extra
-  val minSdkVersion: Int by rootProject.extra
+  val compileSdkVersion: Int = rootProject.extra["compileSdkVersion"] as Int
+  val minSdkVersion: Int = rootProject.extra["minSdkVersion"] as Int
 
   namespace = "org.simple.clinic.common"
   compileSdk = compileSdkVersion

--- a/mobius-base/build.gradle.kts
+++ b/mobius-base/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
 android {
   namespace = "org.simple.clinic.mobius"
 
-  val compileSdkVersion: Int by rootProject.extra
-  val minSdkVersion: Int by rootProject.extra
+  val compileSdkVersion: Int = rootProject.extra["compileSdkVersion"] as Int
+  val minSdkVersion: Int = rootProject.extra["minSdkVersion"] as Int
 
   compileSdk = compileSdkVersion
 

--- a/simple-platform/build.gradle.kts
+++ b/simple-platform/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 android {
   namespace = "org.simple.clinic.platform"
 
-  val compileSdkVersion: Int by rootProject.extra
-  val minSdkVersion: Int by rootProject.extra
+  val compileSdkVersion: Int = rootProject.extra["compileSdkVersion"] as Int
+  val minSdkVersion: Int = rootProject.extra["minSdkVersion"] as Int
 
   compileSdk = compileSdkVersion
 

--- a/simple-visuals/build.gradle.kts
+++ b/simple-visuals/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 android {
   namespace = "org.simple.clinic.visuals"
 
-  val compileSdkVersion: Int by rootProject.extra
-  val minSdkVersion: Int by rootProject.extra
+  val compileSdkVersion: Int = rootProject.extra["compileSdkVersion"] as Int
+  val minSdkVersion: Int = rootProject.extra["minSdkVersion"] as Int
 
   compileSdk = compileSdkVersion
 


### PR DESCRIPTION
## Jira

[[SIMPLEMOB-51](https://rtsl.atlassian.net/browse/SIMPLEMOB-51)](https://rtsl.atlassian.net/browse/SIMPLEMOB-51)

## Summary

Replace deprecated Kotlin DSL `by project` property delegate usage with explicit `project.property(...)` access.

## Changes

* Replaced `val ...: String by project` declarations with explicit `project.property(...)` access.
* Preserved the existing property names and types.
* No changes to build behavior or configuration values.

## Validation

* Ran `./gradlew assembleQaDebug --warning-mode all --no-configuration-cache`
* QA debug build succeeds.