### PR TITLE
Expand CDSS nudge and BP threshold support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 - Update GH Actions `setup-jdk` to v6
 - Replaced deprecated Gradle Kotlin DSL by project property delegates with explicit project.property(...) access to improve Gradle 10 compatibility.
 
+
+### Changes
+
+- Enabled CDSS nudges for all countries, previously limited to Sri Lanka and Ethiopia.
+- Applied the lower blood pressure threshold of 130/80 for diabetic patients in Sri Lanka.
+
 ## 2026.08.31
 
 ### Internal

--- a/app/src/androidTest/java/org/simple/clinic/bp/BloodPressureRepositoryAndroidTest.kt
+++ b/app/src/androidTest/java/org/simple/clinic/bp/BloodPressureRepositoryAndroidTest.kt
@@ -6,6 +6,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.simple.clinic.TestClinicApp
+import org.simple.clinic.TestData
+import org.simple.clinic.appconfig.Country
 import org.simple.clinic.facility.Facility
 import org.simple.clinic.patient.PatientRepository
 import org.simple.clinic.patient.PatientStatus
@@ -13,11 +15,10 @@ import org.simple.clinic.patient.SyncStatus
 import org.simple.clinic.rules.LocalAuthenticationRule
 import org.simple.clinic.rules.SaveDatabaseRule
 import org.simple.clinic.user.User
-import org.simple.clinic.util.toUtcInstant
-import org.simple.clinic.TestData
 import org.simple.clinic.util.Rules
 import org.simple.clinic.util.TestUserClock
 import org.simple.clinic.util.TestUtcClock
+import org.simple.clinic.util.toUtcInstant
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
@@ -475,9 +476,9 @@ class BloodPressureRepositoryAndroidTest {
     ))
 
     // when
-    val isNewestBpEntryHighForPatient1 = repository.isNewestBpEntryHigh(patient1Uuid, isDiabeticPatient = false, isSriLankaEnabled = false).blockingFirst()
-    val isNewestBpEntryHighForPatient2 = repository.isNewestBpEntryHigh(patient2Uuid, isDiabeticPatient = true, isSriLankaEnabled = false).blockingFirst()
-    val isNewestBpEntryHighForPatient3 = repository.isNewestBpEntryHigh(patient3Uuid, isDiabeticPatient = true, isSriLankaEnabled = true).blockingFirst()
+    val isNewestBpEntryHighForPatient1 = repository.isNewestBpEntryHigh(patient1Uuid, isDiabeticPatient = false, country = TestData.country()).blockingFirst()
+    val isNewestBpEntryHighForPatient2 = repository.isNewestBpEntryHigh(patient2Uuid, isDiabeticPatient = true, country = TestData.country(Country.ETHIOPIA)).blockingFirst()
+    val isNewestBpEntryHighForPatient3 = repository.isNewestBpEntryHigh(patient3Uuid, isDiabeticPatient = true, country = TestData.country(Country.BANGLADESH)).blockingFirst()
 
     // then
     assertThat(isNewestBpEntryHighForPatient1).isTrue()

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureLevel.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureLevel.kt
@@ -18,13 +18,6 @@ enum class BloodPressureLevel(private val urgency: Int, val displayTextRes: Opti
 
   LOW(-1, Optional.of(R.string.bloodpressure_level_low));
 
-  val isHigh: Boolean
-    get() = when (this) {
-      LOW, NORMAL, MILDLY_HIGH -> false
-      MODERATELY_HIGH, VERY_HIGH, EXTREMELY_HIGH -> true
-    }
-
-
   companion object {
 
     fun isHigh(

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureLevel.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureLevel.kt
@@ -27,7 +27,7 @@ enum class BloodPressureLevel(private val urgency: Int, val displayTextRes: Opti
     ): Boolean {
       return when (compute(measurement)) {
         LOW, NORMAL -> false
-        MILDLY_HIGH -> country.isoCountryCode == Country.BANGLADESH && hasDiabetes
+        MILDLY_HIGH -> usesLowerThreshold(country, hasDiabetes)
         MODERATELY_HIGH, VERY_HIGH, EXTREMELY_HIGH -> true
       }
     }
@@ -69,6 +69,15 @@ enum class BloodPressureLevel(private val urgency: Int, val displayTextRes: Opti
           else -> throw AssertionError("Shouldn't reach here: $measurement")
         }
       }
+    }
+
+    fun usesLowerThreshold(
+        country: Country,
+        hasDiabetes: Boolean
+    ): Boolean {
+      return hasDiabetes &&
+          (country.isoCountryCode == Country.BANGLADESH ||
+              country.isoCountryCode == Country.SRI_LANKA)
     }
   }
 }

--- a/app/src/main/java/org/simple/clinic/bp/BloodPressureRepository.kt
+++ b/app/src/main/java/org/simple/clinic/bp/BloodPressureRepository.kt
@@ -3,6 +3,7 @@ package org.simple.clinic.bp
 import androidx.paging.PagingSource
 import io.reactivex.Completable
 import io.reactivex.Observable
+import org.simple.clinic.appconfig.Country
 import org.simple.clinic.bp.sync.BloodPressureMeasurementPayload
 import org.simple.clinic.di.AppScope
 import org.simple.clinic.facility.Facility
@@ -169,16 +170,19 @@ class BloodPressureRepository @Inject constructor(
   fun isNewestBpEntryHigh(
       patientUuid: UUID,
       isDiabeticPatient: Boolean,
-      isSriLankaEnabled: Boolean
+      country: Country,
   ): Observable<Boolean> {
 
     val currentDate = LocalDate.now(utcClock)
 
-    val systolicThreshold =
-        if (isSriLankaEnabled && isDiabeticPatient) 130 else 140
+    val useLowerThreshold =
+        BloodPressureLevel.usesLowerThreshold(
+            country = country,
+            hasDiabetes = isDiabeticPatient
+        )
 
-    val diastolicThreshold =
-        if (isSriLankaEnabled && isDiabeticPatient) 80 else 90
+    val systolicThreshold = if (useLowerThreshold) 130 else 140
+    val diastolicThreshold = if (useLowerThreshold) 80 else 90
 
     return dao.isNewestBpEntryHigh(
         patientUuid = patientUuid,

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffect.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffect.kt
@@ -48,8 +48,6 @@ data class LoadPatientRegistrationData(val patientUuid: UUID) : PatientSummaryEf
 
 data class LoadClinicalDecisionSupportInfo(val patientUuid: UUID) : PatientSummaryEffect()
 
-data object CheckIfCDSSPilotIsEnabled : PatientSummaryEffect()
-
 data class LoadLatestScheduledAppointment(val patientUuid: UUID) : PatientSummaryEffect()
 
 data class UpdatePatientReassignmentStatus(val patientUuid: UUID, val status: Answer) : PatientSummaryEffect()

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
@@ -72,7 +72,6 @@ class PatientSummaryEffectHandler @AssistedInject constructor(
     private val facilityRepository: FacilityRepository,
     private val teleconsultationFacilityRepository: TeleconsultationFacilityRepository,
     private val prescriptionRepository: PrescriptionRepository,
-    private val cdssPilotFacilities: Lazy<List<UUID>>,
     private val diagnosisWarningPrescriptions: Provider<DiagnosisWarningPrescriptions>,
     private val nonLabBasedCVDRiskCalculator: NonLabBasedCVDRiskCalculator,
     private val labBasedCVDRiskCalculator: LabBasedCVDRiskCalculator,
@@ -103,7 +102,6 @@ class PatientSummaryEffectHandler @AssistedInject constructor(
         .addTransformer(LoadClinicalDecisionSupportInfo::class.java, loadClinicalDecisionSupport())
         .addConsumer(PatientSummaryViewEffect::class.java, viewEffectsConsumer::accept)
         .addTransformer(LoadPatientRegistrationData::class.java, checkPatientRegistrationData())
-        .addTransformer(CheckIfCDSSPilotIsEnabled::class.java, checkIfCDSSPilotIsEnabled())
         .addTransformer(LoadBMIFeature::class.java, loadBMIFeature())
         .addTransformer(LoadLatestScheduledAppointment::class.java, loadLatestScheduledAppointment())
         .addConsumer(UpdatePatientReassignmentStatus::class.java, { updatePatientReassignmentState(it.patientUuid, it.status) }, schedulersProvider.io())
@@ -406,21 +404,6 @@ class PatientSummaryEffectHandler @AssistedInject constructor(
           .map {
             val appointment = appointmentRepository.latestScheduledAppointmentForPatient(it.patientUuid)
             LatestScheduledAppointmentLoaded(appointment)
-          }
-    }
-  }
-
-  private fun checkIfCDSSPilotIsEnabled(): ObservableTransformer<CheckIfCDSSPilotIsEnabled, PatientSummaryEvent> {
-    return ObservableTransformer { effects ->
-      effects
-          .observeOn(schedulersProvider.io())
-          .map {
-            val currentFacilityId = currentFacility.get().uuid
-            CDSSPilotStatusChecked(isPilotEnabledForFacility =
-                country.isoCountryCode == Country.ETHIOPIA ||
-                    country.isoCountryCode == Country.SRI_LANKA ||
-                    cdssPilotFacilities.get().contains(currentFacilityId)
-            )
           }
     }
   }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEffectHandler.kt
@@ -434,13 +434,10 @@ class PatientSummaryEffectHandler @AssistedInject constructor(
                     patientUuid = patientUuid
                 ).diagnosedWithDiabetes == MedicalHistoryAnswer.Yes
 
-            val isSriLanka =
-                country.isoCountryCode == Country.SRI_LANKA
-
             bloodPressureRepository.isNewestBpEntryHigh(
                 patientUuid = patientUuid,
                 isDiabeticPatient = hasDiabetes,
-                isSriLankaEnabled = isSriLanka
+                country = country
             ).map { isNewestBpEntryHigh ->
               Pair(patientUuid, isNewestBpEntryHigh)
             }

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryEvent.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryEvent.kt
@@ -122,8 +122,6 @@ data object AssignedFacilityChanged : PatientSummaryEvent()
 
 data class ClinicalDecisionSupportInfoLoaded(val isNewestBpEntryHigh: Boolean, val hasPrescribedDrugsChangedToday: Boolean) : PatientSummaryEvent()
 
-data class CDSSPilotStatusChecked(val isPilotEnabledForFacility: Boolean) : PatientSummaryEvent()
-
 data class LatestScheduledAppointmentLoaded(val appointment: Appointment?) : PatientSummaryEvent()
 
 data class PatientReassignmentStatusLoaded(

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryInit.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryInit.kt
@@ -9,7 +9,8 @@ class PatientSummaryInit : Init<PatientSummaryModel, PatientSummaryEffect> {
   override fun init(model: PatientSummaryModel): First<PatientSummaryModel, PatientSummaryEffect> {
     val effects = mutableSetOf(
         LoadPatientSummaryProfile(model.patientUuid),
-        CheckIfCDSSPilotIsEnabled,
+        LoadClinicalDecisionSupportInfo(model.patientUuid),
+        LoadLatestScheduledAppointment(model.patientUuid),
         LoadBMIFeature,
         LoadBMiReading(model.patientUuid),
     )

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryModule.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryModule.kt
@@ -42,24 +42,6 @@ class PatientSummaryModule {
   @Provides
   fun teleconsultationFacilityWithMedicalOfficersDao(appDatabase: AppDatabase) = appDatabase.teleconsultFacilityWithMedicalOfficersDao()
 
-  // TODO (SM): Remove once CDSS pilot is finished
-  @Provides
-  fun cdssPilotFacilitiesIds(
-      moshi: Moshi,
-      configReader: ConfigReader
-  ): List<UUID> {
-    val type = Types.newParameterizedType(List::class.java, UUID::class.java)
-    val adapter = moshi.adapter<List<UUID>>(type)
-    val json = configReader.string("cdss_pilot_facilities_ids_v0", "[]")
-
-    return try {
-      adapter.fromJson(json)!!
-    } catch (e: Exception) {
-      CrashReporter.report(e)
-      emptyList()
-    }
-  }
-
   @Provides
   @OptIn(ExperimentalStdlibApi::class)
   fun diagnosisWarningPrescriptions(moshi: Moshi, configReader: ConfigReader): DiagnosisWarningPrescriptions {

--- a/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
+++ b/app/src/main/java/org/simple/clinic/summary/PatientSummaryUpdate.kt
@@ -97,7 +97,6 @@ class PatientSummaryUpdate(
           model.clinicalDecisionSupportInfoLoaded(event.isNewestBpEntryHigh, event.hasPrescribedDrugsChangedToday)
       )
 
-      is CDSSPilotStatusChecked -> cdssPilotStatusChecked(event, model)
       is LatestScheduledAppointmentLoaded -> next(model.scheduledAppointmentLoaded(event.appointment))
       is MeasurementWarningNotNowClicked -> measurementWarningNotNowClicked(model, event)
       is PatientReassignmentStatusLoaded -> patientReassignmentStatusLoaded(model, event)
@@ -462,20 +461,6 @@ class PatientSummaryUpdate(
     }
 
     return dispatch(effect)
-  }
-
-  private fun cdssPilotStatusChecked(
-      event: CDSSPilotStatusChecked,
-      model: PatientSummaryModel
-  ): Next<PatientSummaryModel, PatientSummaryEffect> {
-    return if (event.isPilotEnabledForFacility) {
-      dispatch(
-          LoadClinicalDecisionSupportInfo(model.patientUuid),
-          LoadLatestScheduledAppointment(model.patientUuid)
-      )
-    } else {
-      noChange()
-    }
   }
 
   private fun patientRegistrationDataLoaded(

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
@@ -653,7 +653,7 @@ class PatientSummaryEffectHandlerTest {
         patientUuid = patientUuid
     )) doReturn medicalHistory
 
-    whenever(bloodPressureRepository.isNewestBpEntryHigh(patientUuid, medicalHistory.diagnosedWithDiabetes == Yes, false)).doReturn(Observable.just(true))
+    whenever(bloodPressureRepository.isNewestBpEntryHigh(patientUuid, medicalHistory.diagnosedWithDiabetes == Yes, country = TestData.country())).doReturn(Observable.just(true))
     whenever(prescriptionRepository.hasPrescriptionForPatientChangedToday(patientUuid)).doReturn(Observable.just(true))
 
     // when

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryEffectHandlerTest.kt
@@ -4,7 +4,6 @@ import io.reactivex.Completable
 import io.reactivex.Observable
 import org.junit.After
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -115,7 +114,6 @@ class PatientSummaryEffectHandlerTest {
       facilityRepository = facilityRepository,
       teleconsultationFacilityRepository = teleconsultFacilityRepository,
       prescriptionRepository = prescriptionRepository,
-      cdssPilotFacilities = { emptyList() },
       diagnosisWarningPrescriptions = { diagnosisWarningPrescriptions },
       nonLabBasedCVDRiskCalculator = nonLabBasedCVDRiskCalculator,
       labBasedCVDRiskCalculator = labBasedCVDRiskCalculator,
@@ -163,7 +161,6 @@ class PatientSummaryEffectHandlerTest {
         facilityRepository = facilityRepository,
         teleconsultationFacilityRepository = teleconsultFacilityRepository,
         prescriptionRepository = prescriptionRepository,
-        cdssPilotFacilities = { emptyList() },
         diagnosisWarningPrescriptions = { diagnosisWarningPrescriptions },
         nonLabBasedCVDRiskCalculator = nonLabBasedCVDRiskCalculator,
         labBasedCVDRiskCalculator = labBasedCVDRiskCalculator,
@@ -183,7 +180,7 @@ class PatientSummaryEffectHandlerTest {
     )
 
     val patientProfile = PatientProfile(patient, patientAddress, listOf(patientPhoneNumber), listOf(bangladeshNationId, bpPassport))
-    whenever(patientRepository.patientProfile(patientUuid)) doReturn Observable.just<Optional<PatientProfile>>(Optional.of(patientProfile))
+    whenever(patientRepository.patientProfile(patientUuid)) doReturn Observable.just(Optional.of(patientProfile))
     whenever(facilityRepository.facility(registeredFacilityUuid)) doReturn Optional.of(facility)
 
     // when
@@ -228,7 +225,6 @@ class PatientSummaryEffectHandlerTest {
         facilityRepository = facilityRepository,
         teleconsultationFacilityRepository = teleconsultFacilityRepository,
         prescriptionRepository = prescriptionRepository,
-        cdssPilotFacilities = { emptyList() },
         diagnosisWarningPrescriptions = { diagnosisWarningPrescriptions },
         nonLabBasedCVDRiskCalculator = nonLabBasedCVDRiskCalculator,
         labBasedCVDRiskCalculator = labBasedCVDRiskCalculator,
@@ -243,7 +239,7 @@ class PatientSummaryEffectHandlerTest {
     val bangladeshNationId = TestData.businessId(patientUuid = patientUuid, identifier = Identifier("123456789012", BangladeshNationalId))
 
     val patientProfile = PatientProfile(patient, patientAddress, listOf(patientPhoneNumber), listOf(bangladeshNationId, bpPassport))
-    whenever(patientRepository.patientProfile(patientUuid)) doReturn Observable.just<Optional<PatientProfile>>(Optional.of(patientProfile))
+    whenever(patientRepository.patientProfile(patientUuid)) doReturn Observable.just(Optional.of(patientProfile))
 
     // when
     testCase.dispatch(LoadPatientSummaryProfile(patientUuid))
@@ -615,10 +611,6 @@ class PatientSummaryEffectHandlerTest {
   fun `when load patient registration data effect is received, then load patient registration data`() {
     // given
     val patientUuid = UUID.fromString("31b34900-52aa-4892-8bed-2c720951880e")
-    val medicalHistory = TestData.medicalHistory(
-        uuid = UUID.fromString("333a13f9-4a5b-4fd9-84f3-e169d26331ba"),
-        patientUuid = patientUuid
-    )
 
     whenever(prescriptionRepository.prescriptionCountImmediate(patientUuid)) doReturn 2
     whenever(bloodPressureRepository.bloodPressureCountImmediate(patientUuid)) doReturn 2
@@ -674,53 +666,6 @@ class PatientSummaryEffectHandlerTest {
             hasPrescribedDrugsChangedToday = true
         ))
     verifyNoInteractions(uiActions)
-  }
-
-  @Test
-  fun `when check if cdss pilot is enabled effect is received, then check the cdss enabled status`() {
-    // given
-    val cdssPilotFacilities = listOf(UUID.fromString("635bf319-d6bb-426e-b5f0-6003614ad4fe"))
-    val facility = TestData.facility(
-        uuid = UUID.fromString("635bf319-d6bb-426e-b5f0-6003614ad4fe"),
-        name = "CHC Obvious"
-    )
-    val effectHandler = PatientSummaryEffectHandler(
-        clock = clock,
-        userClock = userClock,
-        schedulersProvider = TestSchedulersProvider.trampoline(),
-        patientRepository = patientRepository,
-        bloodPressureRepository = bloodPressureRepository,
-        appointmentRepository = appointmentRepository,
-        missingPhoneReminderRepository = missingPhoneReminderRepository,
-        bloodSugarRepository = bloodSugarRepository,
-        dataSync = dataSync,
-        medicalHistoryRepository = medicalHistoryRepository,
-        cvdRiskRepository = cvdRiskRepository,
-        patientAttributeRepository = patientAttributeRepository,
-        country = TestData.country(),
-        currentUser = { user },
-        currentFacility = { facility },
-        uuidGenerator = uuidGenerator,
-        facilityRepository = facilityRepository,
-        teleconsultationFacilityRepository = teleconsultFacilityRepository,
-        prescriptionRepository = prescriptionRepository,
-        cdssPilotFacilities = { cdssPilotFacilities },
-        diagnosisWarningPrescriptions = { diagnosisWarningPrescriptions },
-        nonLabBasedCVDRiskCalculator = nonLabBasedCVDRiskCalculator,
-        labBasedCVDRiskCalculator = labBasedCVDRiskCalculator,
-        viewEffectsConsumer = viewEffectHandler::handle,
-        feature = features
-    )
-    val testCase = EffectHandlerTestCase(effectHandler = effectHandler.build())
-
-    // when
-    testCase.dispatch(CheckIfCDSSPilotIsEnabled)
-
-    // then
-    verifyNoInteractions(uiActions)
-
-    testCase.assertOutgoingEvents(CDSSPilotStatusChecked(isPilotEnabledForFacility = true))
-    testCase.dispose()
   }
 
   @Test

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryInitTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryInitTest.kt
@@ -30,7 +30,8 @@ class PatientSummaryInitTest {
                     CheckForInvalidPhone(patientUuid),
                     LoadMedicalOfficers,
                     LoadPatientRegistrationData(patientUuid),
-                    CheckIfCDSSPilotIsEnabled,
+                    LoadClinicalDecisionSupportInfo(patientUuid),
+                    LoadLatestScheduledAppointment(patientUuid),
                     LoadBMIFeature,
                     LoadBMiReading(patientUuid)
                 )
@@ -65,8 +66,9 @@ class PatientSummaryInitTest {
                 hasModel(model),
                 hasEffects(
                     LoadPatientSummaryProfile(patientUuid) as PatientSummaryEffect,
-                    CheckIfCDSSPilotIsEnabled,
                     LoadBMIFeature,
+                    LoadClinicalDecisionSupportInfo(patientUuid),
+                    LoadLatestScheduledAppointment(patientUuid),
                     LoadBMiReading(patientUuid)
                 )
             )

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenLogicTest.kt
@@ -233,10 +233,9 @@ class PatientSummaryScreenLogicTest {
         facilityRepository = facilityRepository,
         teleconsultationFacilityRepository = mock(),
         prescriptionRepository = prescriptionRepository,
-        cdssPilotFacilities = { emptyList() },
         diagnosisWarningPrescriptions = { diagnosisWarningPrescriptions },
         nonLabBasedCVDRiskCalculator = NonLabBasedCVDRiskCalculator { TestData.nonLabBasedCVDRiskCalculationSheet() },
-        labBasedCVDRiskCalculator = LabBasedCVDRiskCalculator() { TestData.labBasedCVDRiskCalculationSheet() },
+        labBasedCVDRiskCalculator = LabBasedCVDRiskCalculator { TestData.labBasedCVDRiskCalculationSheet() },
         viewEffectsConsumer = viewEffectHandler::handle,
         feature = mock()
     )

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenLogicTest.kt
@@ -113,6 +113,9 @@ class PatientSummaryScreenLogicTest {
     whenever(bpRepository.hasBPRecordedToday(patientUuid, today)) doReturn Observable.just(true)
     whenever(facilityRepository.facility(assignedFacilityUuid)) doReturn Optional.of(TestData.facility())
     whenever(prescriptionRepository.newestPrescriptionsForPatientImmediate(patientUuid)) doReturn emptyList()
+    whenever(
+        prescriptionRepository.hasPrescriptionForPatientChangedToday(patientUuid)
+    ) doReturn Observable.just(false)
   }
 
   @After

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenLogicTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryScreenLogicTest.kt
@@ -106,7 +106,7 @@ class PatientSummaryScreenLogicTest {
         defaultHistoryUuid = uuidGenerator.v4(),
         patientUuid = patientUuid
     )) doReturn medicalHistory
-    whenever(bpRepository.isNewestBpEntryHigh(patientUuid, isDiabeticPatient = medicalHistory.diagnosedWithDiabetes == Answer.Yes, isSriLankaEnabled = false)) doReturn Observable.just(true)
+    whenever(bpRepository.isNewestBpEntryHigh(patientUuid, isDiabeticPatient = medicalHistory.diagnosedWithDiabetes == Answer.Yes, country = TestData.country())) doReturn Observable.just(true)
     whenever(patientRepository.patientProfile(patientUuid)) doReturn Observable.just(Optional.of(patientProfile))
     whenever(patientRepository.latestPhoneNumberForPatient(patientUuid)) doReturn Optional.empty()
     whenever(appointmentRepository.lastCreatedAppointmentForPatient(patientUuid)) doReturn Optional.empty()

--- a/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
+++ b/app/src/test/java/org/simple/clinic/summary/PatientSummaryUpdateTest.kt
@@ -1639,31 +1639,6 @@ class PatientSummaryUpdateTest {
   }
 
   @Test
-  fun `when cdss pilot is enabled for facility, then load clinical decision support info and latest scheduled appointment`() {
-    updateSpec
-        .given(defaultModel)
-        .whenEvent(CDSSPilotStatusChecked(isPilotEnabledForFacility = true))
-        .then(assertThatNext(
-            hasNoModel(),
-            hasEffects(
-                LoadClinicalDecisionSupportInfo(patientUuid),
-                LoadLatestScheduledAppointment(patientUuid)
-            )
-        ))
-  }
-
-  @Test
-  fun `when cdss pilot is not enabled for facility, then do nothing`() {
-    updateSpec
-        .given(defaultModel)
-        .whenEvent(CDSSPilotStatusChecked(isPilotEnabledForFacility = false))
-        .then(assertThatNext(
-            hasNoModel(),
-            hasNoEffects()
-        ))
-  }
-
-  @Test
   fun `when scheduled appointment is loaded, then update the model`() {
     val appointment = TestData.appointment(
         uuid = UUID.fromString("adec28f7-0761-4514-b036-2737d9a6064b")


### PR DESCRIPTION
## Jira

[[SIMPLEBGD-70](https://rtsl.atlassian.net/browse/SIMPLEBGD-70)](https://rtsl.atlassian.net/browse/SIMPLEBGD-70)

## Summary

Expand CDSS nudge support to all countries and apply the lower blood pressure threshold for diabetic patients in Sri Lanka.

## Changes

* Enabled CDSS nudges for all countries.

  * Previously, CDSS nudges were enabled only for Sri Lanka and Ethiopia.
* Extended the lower BP threshold logic to Sri Lanka.

  * Diabetic patients in Sri Lanka now use **130/80** as the high BP threshold.
  * Existing Bangladesh behavior remains unchanged.
  * Other patients continue to use **140/90**.
* Centralized the lower BP threshold logic so it is consistently applied across BP-related flows.

## Validation

* Added/updated tests for Sri Lanka's lower BP threshold.
* Added/updated tests to verify CDSS nudges are enabled for all countries.
* Verified existing Bangladesh, Sri Lanka, and Ethiopia behavior remains correct.